### PR TITLE
remove seldigis and interestingEcalRecHits from photon path

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_DATA_53X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_DATA_53X.py
@@ -182,6 +182,17 @@ process.skimanalysis.superFilters = cms.vstring("ana_step")
 process.photonStep = cms.Sequence(process.hiGoodTracks * process.photon_extra_reco * process.makeHeavyIonPhotons * process.selectedPatPhotons)
 process.photonStep.remove(process.interestingTrackEcalDetIds)
 process.photonStep.remove(process.photonMatch)
+process.photonStep.remove(process.seldigis)
+process.reducedEcalRecHitsEB = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEB"), cms.InputTag("interestingEcalDetIdEBU")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+    reducedHitsCollection = cms.string('')
+)
+process.reducedEcalRecHitsEE = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEE")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+    reducedHitsCollection = cms.string('')
+)
 
 process.pcollisionEventSelection = cms.Path(process.collisionEventSelection)
 process.pHBHENoiseFilter = cms.Path( process.HBHENoiseFilter )

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_MC_53X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_MC_53X.py
@@ -160,6 +160,17 @@ process.load("edwenger.HiTrkEffAnalyzer.TrackSelections_cff")
 process.hiGoodTracks.src = cms.InputTag("hiGeneralTracks")
 process.photonStep = cms.Path(process.hiGoodTracks * process.photon_extra_reco * process.makeHeavyIonPhotons)
 process.photonStep.remove(process.interestingTrackEcalDetIds)
+process.photonStep.remove(process.seldigis)
+process.reducedEcalRecHitsEB = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEB"), cms.InputTag("interestingEcalDetIdEBU")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+    reducedHitsCollection = cms.string('')
+)
+process.reducedEcalRecHitsEE = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEE")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+    reducedHitsCollection = cms.string('')
+)
 process.photonMatch.matched = cms.InputTag("hiGenParticles")
 process.patPhotons.addPhotonID = cms.bool(False)
 process.extrapatstep = cms.Path(process.selectedPatPhotons)

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_MIX_53X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_MIX_53X.py
@@ -164,6 +164,17 @@ process.load("edwenger.HiTrkEffAnalyzer.TrackSelections_cff")
 process.hiGoodTracks.src = cms.InputTag("hiGeneralTracks")
 process.photonStep = cms.Path(process.hiGoodTracks * process.photon_extra_reco * process.makeHeavyIonPhotons)
 process.photonStep.remove(process.interestingTrackEcalDetIds)
+process.photonStep.remove(process.seldigis)
+process.reducedEcalRecHitsEB = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEB"), cms.InputTag("interestingEcalDetIdEBU")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+    reducedHitsCollection = cms.string('')
+)
+process.reducedEcalRecHitsEE = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEE")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+    reducedHitsCollection = cms.string('')
+)
 process.photonMatch.matched = cms.InputTag("hiGenParticles")
 process.patPhotons.addPhotonID = cms.bool(False)
 process.extrapatstep = cms.Path(process.selectedPatPhotons)

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_ppMC_53X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForest_PbPb_ppMC_53X.py
@@ -162,6 +162,17 @@ process.load("edwenger.HiTrkEffAnalyzer.TrackSelections_cff")
 process.hiGoodTracks.src = cms.InputTag("hiGeneralTracks")
 process.photonStep = cms.Path(process.hiGoodTracks * process.photon_extra_reco * process.makeHeavyIonPhotons)
 process.photonStep.remove(process.interestingTrackEcalDetIds)
+process.photonStep.remove(process.seldigis)
+process.reducedEcalRecHitsEB = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEB"), cms.InputTag("interestingEcalDetIdEBU")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+    reducedHitsCollection = cms.string('')
+)
+process.reducedEcalRecHitsEE = cms.EDProducer("ReducedRecHitCollectionProducer",
+    interestingDetIdCollections = cms.VInputTag(cms.InputTag("interestingEcalDetIdEE")),
+    recHitsLabel = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+    reducedHitsCollection = cms.string('')
+)
 process.photonMatch.matched = cms.InputTag("hiGenParticles")
 process.patPhotons.addPhotonID = cms.bool(False)
 process.extrapatstep = cms.Path(process.selectedPatPhotons)


### PR DESCRIPTION
HI does not use those modules. 

This silences ~13 warnings+errors when foresting. It has been tested on a small sample of both Data and Minbias Hydjet and confirmed 0 changes to photons.

Sorry this wasn't done sooner.
