### PR TITLE
Enable ClusterCompatibility Filter for AOD

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/collisionEventSelection_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/collisionEventSelection_cff.py
@@ -15,6 +15,10 @@ from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from HLTrigger.special.hltPixelClusterShapeFilter_cfi import *
 hltPixelClusterShapeFilter.inputTag = "siPixelRecHits"
 
+# Cluster-shape filter re-run offline from ClusterCompatibility object
+from HeavyIonsAnalysis.EventAnalysis.HIClusterCompatibilityFilter_cfi import *
+
+
 # Reject BSC beam halo L1 technical bits
 from L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff import *
 from HLTrigger.HLTfilters.hltLevel1GTSeed_cfi import hltLevel1GTSeed
@@ -28,3 +32,8 @@ collisionEventSelection = cms.Sequence(noBSChalo *
                                        primaryVertexFilter *
                                        siPixelRecHits *
                                        hltPixelClusterShapeFilter)
+
+collisionEventSelectionAOD = cms.Sequence(noBSChalo *
+                                          hfCoincFilter3 *
+                                          primaryVertexFilter *
+                                          clusterCompatibilityFilter)

--- a/HeavyIonsAnalysis/EventAnalysis/interface/HIClusterCompatibilityFilter.h
+++ b/HeavyIonsAnalysis/EventAnalysis/interface/HIClusterCompatibilityFilter.h
@@ -10,8 +10,6 @@
 //
 //
 
-// Don't compile until CMSSW_7_5_0_pre5 or later
-#ifdef CMSSW_7_5_0_pre5_OR_LATER
 
 #include <iostream>
 
@@ -54,5 +52,4 @@ class HIClusterCompatibilityFilter : public edm::EDFilter {
     double              clusterTrunc_;  //maximum vertex compatibility value for event rejection
 };
 
-#endif
 #endif

--- a/HeavyIonsAnalysis/EventAnalysis/src/HIClusterCompatibilityFilter.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/src/HIClusterCompatibilityFilter.cc
@@ -7,9 +7,6 @@
 //
 //
 
-// Don't compile until CMSSW_7_5_0_pre5 or later
-#ifdef CMSSW_7_5_0_pre5_OR_LATER
-
 #include "HeavyIonsAnalysis/EventAnalysis/interface/HIClusterCompatibilityFilter.h"
 
 HIClusterCompatibilityFilter::HIClusterCompatibilityFilter(const edm::ParameterSet& iConfig):
@@ -136,4 +133,3 @@ HIClusterCompatibilityFilter::fillDescriptions(edm::ConfigurationDescriptions& d
 }
 
 DEFINE_FWK_MODULE(HIClusterCompatibilityFilter);
-#endif


### PR DESCRIPTION
Enable the ClusterCompatibility Filter which will compile in 750pre5 and later, also create sequence in event selection to use the filter.
