### PR TITLE
Running the GenJet producers on the signal sub-event only

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MIX_75X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MIX_75X.py
@@ -27,7 +27,8 @@ process.source = cms.Source("PoolSource",
                             duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
                             fileNames = cms.untracked.vstring(
         #                                "file:/afs/cern.ch/work/r/richard/public/PbPb_RECODEBUG.root",
-        "file:step3_hi_mc.root",
+#        "file:step3_hi_mc.root",
+        "file:/data_CMS/cms/mnguyen/step3_RAW2DIGI_L1Reco_RECO_99.root"
                                 )
                             )
 

--- a/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
@@ -8,7 +8,8 @@ iterativeCone5HiGenJets = cms.EDProducer("SubEventGenJetProducer",
                                          GenJetParameters,
                                          AnomalousCellParameters,
                                          jetAlgorithm = cms.string("IterativeCone"),
-                                         rParam = cms.double(0.5)
+                                         rParam = cms.double(0.5),
+                                         signalOnly = cms.bool(True)
                                          )
 
 iterativeCone5HiGenJets.doAreaFastjet = cms.bool(True)

--- a/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiGenJets_cff.py
@@ -21,7 +21,8 @@ ak5HiGenJets = cms.EDProducer("SubEventGenJetProducer",
                               GenJetParameters,
                               AnomalousCellParameters,
                               jetAlgorithm = cms.string("AntiKt"),
-                              rParam = cms.double(0.5)
+                              rParam = cms.double(0.5),
+                              signalOnly = cms.bool(True)
                               )
 
 ak5HiGenJets.doAreaFastjet = cms.bool(True)

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -35,7 +35,10 @@ SubEventGenJetProducer::SubEventGenJetProducer(edm::ParameterSet const& conf):
   VirtualJetProducer( conf )
 {
    //   mapSrc_ = conf.getParameter<edm::InputTag>( "srcMap");
+   signalOnly_ = conf.getParameter<bool>("signalOnly");
    ignoreHydro_ = conf.getUntrackedParameter<bool>("ignoreHydro", true);
+
+   if(signalOnly_) ignoreHydro_ = 0;
    produces<reco::BasicJetCollection>();
   // the subjet collections are set through the config file in the "jetCollInstanceName" field.
 
@@ -58,6 +61,7 @@ void SubEventGenJetProducer::inputTowers( )
       edm::Ptr<reco::Candidate> p = inputs_[i - inBegin];
       const GenParticle * pref = dynamic_cast<const GenParticle *>(p.get());
       int subevent = pref->collisionId();
+      if(signalOnly_ && subevent != 0) continue;
       LogDebug("SubEventContainers")<<"SubEvent is : "<<subevent<<endl;
       LogDebug("SubEventContainers")<<"SubSize is : "<<subInputs_.size()<<endl;
 
@@ -69,7 +73,7 @@ void SubEventGenJetProducer::inputTowers( )
       }
 
       LogDebug("SubEventContainers")<<"HydroTag is : "<<hydroTag_[subevent]<<endl;
-      if(hydroTag_[subevent] != 0) hydroTag_[subevent] = (int)checkHydro(pref);
+      if(ignoreHydro_ && hydroTag_[subevent] != 0) hydroTag_[subevent] = (int)checkHydro(pref);
 
       subInputs_[subevent].push_back(fastjet::PseudoJet(input->px(),input->py(),input->pz(),
 						input->energy()));

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
@@ -30,6 +30,7 @@ namespace cms
    std::vector<reco::GenJet>* subJets_;
    std::vector<int> hydroTag_;
    std::vector<int> nSubParticles_;
+   bool signalOnly_;
    bool ignoreHydro_;
 
   protected:


### PR DESCRIPTION
A switch in the SubEventGenJetProducer is added.

Since the embedded event is our first concern, it's switched ON by default, so only the signal sub-event's gen-particles will be clustered for the genjets. No need to touch the genParticles - they will always contain all the signal + background particles, all flagged for their sub-event.

For Hydjet sub-event genjets, we need to switch-off the "signalOnly" flag for all the genjets. However, we should also either switch back on the "cleaning", or, find another solution. We should make specific genjet fragments, or a function, accordingly.
