### PR TITLE
put cs jets pt-ordered in event

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -570,6 +570,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       }
       if(subtractor) { delete subtractor; subtractor = 0;} 
     }
+    fjJets_ = fastjet::sorted_by_pt(fjJets_);
   }
   
 


### PR DESCRIPTION
As agreed on slack: putting cs jets pt-ordered based on subtracted pt in the event.

Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@mandrenguyen @dgulhan @cfmcginn 
