### PR TITLE
Resolve genJet matching ambiguities by distance, rather than relying on pT ordering

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak1PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak2PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak3PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak5PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak6PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ak6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("ak6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCs6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsFilter6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsFilter6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsFilter6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akCsSoftDrop6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akCsSoftDrop6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akCsSoftDrop6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu1PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu2PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu3PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu5PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu6PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akPu6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akPu6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(False),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1CaloJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs1PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs1PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs1PFJets"),
     matched = cms.InputTag("ak1GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.1
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2CaloJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs2PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs2PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs2PFJets"),
     matched = cms.InputTag("ak2GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.2
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3CaloJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs3PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs3PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs3PFJets"),
     matched = cms.InputTag("ak3GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.3
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4CaloJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs4PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs4PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs4PFJets"),
     matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.4
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5CaloJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs5PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs5PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs5PFJets"),
     matched = cms.InputTag("ak5GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.5
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6CaloJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6Calomatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6CaloJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_mb_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6HiCleanedGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_PbPb_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6HiSignalGenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_data_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_jec_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akVs6PFJetSequence_pp_mc_cff.py
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 akVs6PFmatch = patJetGenJetMatch.clone(
     src = cms.InputTag("akVs6PFJets"),
     matched = cms.InputTag("ak6GenJets"),
+    resolveByMatchQuality = cms.bool(True),
     maxDeltaR = 0.6
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -30,6 +30,11 @@ do
 			    matchGenjets="HiSignalGenJets"
 			    partons="hiSignalGenParticles"
 			fi
+			if ( [ $sub == "Vs" ] || [ $sub == "Cs" ] || [ $sub == "CsSoftDrop" ] || [ $sub == "CsFilter" ] ) ; then
+			    resolveByDist="True"
+			else 
+			    resolveByDist="False"
+			fi
 			genjets="HiGenJets"
                         ismc="False"
                         corrlabel="_offline"
@@ -98,6 +103,7 @@ do
 			    -e "s/JETCORRECTIONLEVELS/$jetcorrectionlevels/g" \
 			    -e "s/DOTOWERS_/$doTower/g" \
 			    -e "s/DOSUBJETS_/$doSubJets/g" \
+			    -e "s/RESOLVEBYDIST_/$resolveByDist/g" \
 				  > $algo$subt$radius${object}JetSequence_${system}_${sample}_cff.py
 
 			# skip no sub

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
@@ -10,6 +10,7 @@ from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
 ALGO_SUB_RADIUS_OBJECT_match = patJetGenJetMatch.clone(
     src = cms.InputTag("ALGO_SUB_RADIUS_OBJECT_Jets"),
     matched = cms.InputTag("ALGO_RADIUS_MATCHGENJETS"),
+    resolveByMatchQuality = cms.bool(RESOLVEBYDIST_),
     maxDeltaR = 0.RADIUS_
     )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_cff.py.txt
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_cff.py.txt
@@ -6,6 +6,7 @@ from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
 ALGO_SUB_RADIUS_OBJECT_match = patJetGenJetMatch.clone(
     src = cms.InputTag("ALGO_SUB_RADIUS_OBJECT_Jets"),
     matched = cms.InputTag("ALGO_RADIUS_GENJETS"),
+    resolveByMatchQuality = cms.bool(RESOLVEBYDIST_),
     maxDeltaR = 0.RADIUS_
     )
 


### PR DESCRIPTION
Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.

@mverwe @dgulhan @cfmcginn 
