### PR TITLE
Cs tune

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPbPb.py
@@ -5,10 +5,13 @@ from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiB
 
 from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
 kt4PFJets.src = cms.InputTag('particleFlowTmp')
 kt4PFJets.doAreaFastjet = True
 kt4PFJets.jetPtMin      = cms.double(0.0)
 kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
+
 
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu1CaloJetSequence_PbPb_jec_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akVs1CaloJetSequence_PbPb_jec_cff import *
@@ -140,8 +143,10 @@ ak6CaloJetAnalyzer.doSubEvent = True
 jetSequences = cms.Sequence(
     voronoiBackgroundPF+
     voronoiBackgroundCalo+
+    kt2PFJets +
     kt4PFJets +
     hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator +
 
     hiReRecoCaloJets +
     hiReRecoPFJets +

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_cleanedPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_cleanedPbPb.py
@@ -4,10 +4,13 @@ from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_HI_cff import *
 from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiBackgroundPF, voronoiBackgroundCalo
 from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
 kt4PFJets.src = cms.InputTag('particleFlowTmp')
 kt4PFJets.doAreaFastjet = True
 kt4PFJets.jetPtMin      = cms.double(0.0)
 kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
+
 
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu2CaloJetSequence_PbPb_mb_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akVs2CaloJetSequence_PbPb_mb_cff import *
@@ -47,8 +50,10 @@ offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
 jetSequences = cms.Sequence(
     voronoiBackgroundPF+
     voronoiBackgroundCalo+
+    kt2PFJets +
     kt4PFJets +
     hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator +
 
     akPu2CaloJets +
     akPu2PFJets +

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_nominalPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_nominalPbPb.py
@@ -4,10 +4,12 @@ from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_HI_cff import *
 from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiBackgroundPF, voronoiBackgroundCalo
 from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
 from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
 kt4PFJets.src = cms.InputTag('particleFlowTmp')
 kt4PFJets.doAreaFastjet = True
 kt4PFJets.jetPtMin      = cms.double(0.0)
 kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
 
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu2CaloJetSequence_PbPb_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akVs2CaloJetSequence_PbPb_mc_cff import *
@@ -45,8 +47,10 @@ offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
 jetSequences = cms.Sequence(
     voronoiBackgroundPF+
     voronoiBackgroundCalo+
+    kt2PFJets +
     kt4PFJets +
     hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator +
 
     akPu2CaloJets +
     akPu2PFJets +

--- a/HeavyIonsAnalysis/JetAnalysis/python/hiFJRhoAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/hiFJRhoAnalyzer_cff.py
@@ -1,8 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
 hiFJRhoAnalyzer = cms.EDAnalyzer('HiFJRhoAnalyzer',
-                                 etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges','HiForest'),
-                                 rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
-                                 rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+                                 etaMap             = cms.InputTag('hiFJRhoProducer','mapEtaEdges','HiForest'),
+                                 rho                = cms.InputTag('hiFJRhoProducer','mapToRho'),
+                                 rhom               = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+                                 rhoCorr            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoCorr'),
+                                 rhomCorr           = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoMCorr'),
+                                 rhoCorr1Bin            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoCorr1Bin'),
+                                 rhomCorr1Bin           = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoMCorr1Bin'),
+                                 rhoGrid            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapRhoVsEtaGrid'),
+                                 meanRhoGrid            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapMeanRhoVsEtaGrid'),
+                                 etaMaxRhoGrid            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapEtaMaxGrid'),
+                                 etaMinRhoGrid            = cms.InputTag('hiFJGridEmptyAreaCalculator','mapEtaMinGrid'),
+                                 ptJets            = cms.InputTag('hiFJRhoProducer','ptJets'),
+                                 etaJets            = cms.InputTag('hiFJRhoProducer','etaJets'),
+                                 areaJets            = cms.InputTag('hiFJRhoProducer','areaJets'),
 )
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/HiReRecoJets_HI_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/HiReRecoJets_HI_cff.py
@@ -1,25 +1,30 @@
 import FWCore.ParameterSet.Config as cms
 from RecoHI.HiJetAlgos.HiRecoJets_cff import *
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import *
-from RecoJets.JetProducers.ak8PFJetsCS_cfi import ak8PFJetsCS
+# from RecoJets.JetProducers.ak8PFJetsCS_cfi import ak8PFJetsCS
+from RecoJets.JetProducers.akCs4PFJets_cfi import akCs4PFJets
 
-akCs4PFJets = ak8PFJetsCS.clone( 
-    src    = cms.InputTag('particleFlowTmp'),
-    rParam = cms.double(0.4),
-    jetPtMin = cms.double(0.0),
-    doAreaFastjet = cms.bool(True),
-    GhostArea = cms.double(0.005),
-    useConstituentSubtraction = cms.bool(False),
-    useConstituentSubtractionHi = cms.bool(True),
-    etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
-    rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
-    rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
-    csAlpha   = cms.double(1.),
-    writeJetsWithConst = cms.bool(True),
-    verbosity = cms.int32(0),
-    jetCollInstanceName = cms.string("pfParticlesCs")
-    #writeCompound = cms.bool(True)
-    )
+# akCs4PFJets = ak8PFJetsCS.clone( 
+    # src    = cms.InputTag('particleFlowTmp'),
+    # rParam = cms.double(0.4),
+    # jetPtMin = cms.double(0.0),
+    # doAreaFastjet = cms.bool(True),
+    # GhostArea = cms.double(0.005),
+    # useConstituentSubtraction = cms.bool(False),
+    # useConstituentSubtractionHi = cms.bool(True),
+    # etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+    # rho       = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoCorr'),
+    # rhom      = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoMCorr'),
+    # csAlpha   = cms.double(1.),
+    # writeJetsWithConst = cms.bool(True),
+    # verbosity = cms.int32(0),
+    # jetCollInstanceName = cms.string("pfParticlesCs")
+    
+	##writeCompound = cms.bool(True)
+    # )
+	
+akCs4PFJets.rho      = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoCorr1Bin')
+akCs4PFJets.rhom      = cms.InputTag('hiFJGridEmptyAreaCalculator','mapToRhoMCorr1Bin')
 akCs1PFJets = akCs4PFJets.clone(rParam       = cms.double(0.1))
 akCs2PFJets = akCs4PFJets.clone(rParam       = cms.double(0.2))
 akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_DATA_75X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_DATA_75X.py
@@ -82,6 +82,8 @@ process.kt4PFJets.src = cms.InputTag('particleFlowTmp')
 process.kt4PFJets.doAreaFastjet = True
 process.kt4PFJets.jetPtMin      = cms.double(0.0)
 process.kt4PFJets.GhostArea     = cms.double(0.005)
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
+process.hiFJGridEmptyAreaCalculator = hiFJGridEmptyAreaCalculator
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 
@@ -130,6 +132,7 @@ process.jetSequences = cms.Sequence(
     voronoiBackgroundCalo+
     process.kt4PFJets +
     process.hiFJRhoProducer +
+	process.hiFJGridEmptyAreaCalculator +
     process.hiFJRhoAnalyzer +
     process.akPu2CaloJets +
     process.akPu2PFJets +

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -1,0 +1,458 @@
+// -*- C++ -*-
+//
+// Package:    HiJetBackground/HiFJGridEmptyAreaCalculator
+// Class:      HiFJGridEmptyAreaCalculator
+// Based on:   fastjet/tools/GridMedianBackgroundEstimator 
+//
+// Original Author:  Doga Gulhan
+//         Created:  Wed Mar 16 14:00:04 CET 2016
+//
+//
+
+#include "RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h"
+using namespace std;
+using namespace edm;
+
+
+HiFJGridEmptyAreaCalculator::HiFJGridEmptyAreaCalculator(const edm::ParameterSet& iConfig):
+  gridWidth_(iConfig.getUntrackedParameter<double>("gridWidth",0.005)),
+  band_(iConfig.getUntrackedParameter<double>("bandWidth",0.2)),
+  hiBinCut_(iConfig.getUntrackedParameter<int>("hiBinCut",60)),
+  doCentrality_(iConfig.getUntrackedParameter<bool>("doCentrality",true))
+{
+  pfCandsToken_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfCandSource" ));
+  mapEtaToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapEtaEdges" ));
+  mapRhoToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapToRho" ));
+  mapRhoMToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapToRhoM" ));
+  jetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>( "jetSource" ));
+  centralityBinToken_ = consumes<int>(iConfig.getParameter<edm::InputTag>("CentralityBinSrc"));
+
+  //register your products
+  produces<std::vector<double > >("mapEmptyCorrFac"); 
+  produces<std::vector<double > >("mapToRhoCorr");
+  produces<std::vector<double > >("mapToRhoMCorr");
+  produces<std::vector<double > >("mapToRhoCorr1Bin");
+  produces<std::vector<double > >("mapToRhoMCorr1Bin");
+  //rho calculation on a grid using median
+  produces<std::vector<double > >("mapRhoVsEtaGrid");
+  produces<std::vector<double > >("mapMeanRhoVsEtaGrid");
+  produces<std::vector<double > >("mapEtaMaxGrid");
+  produces<std::vector<double > >("mapEtaMinGrid");
+  
+}
+
+
+HiFJGridEmptyAreaCalculator::~HiFJGridEmptyAreaCalculator()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+// ------------ method called to produce the data  ------------
+void
+HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  //Values from rho calculator  
+  edm::Handle<std::vector<double>> mapEtaRanges;
+  iEvent.getByToken(mapEtaToken_, mapEtaRanges);
+  
+  edm::Handle<std::vector<double>> mapRho;
+  iEvent.getByToken(mapRhoToken_, mapRho);
+
+  edm::Handle<std::vector<double>> mapRhoM;  
+  iEvent.getByToken(mapRhoMToken_, mapRhoM);
+
+  // if doCentrality is set to true calculate empty area correction
+  // for only events with hiBin > hiBinCut  
+  int hiBin = -1;
+  bool doEmptyArea = true; 
+  if(doCentrality_){
+   edm::Handle<int> cbin_;
+   iEvent.getByToken(centralityBinToken_,cbin_);
+   hiBin = *cbin_;
+   
+   if(hiBin < hiBinCut_) doEmptyArea = false;
+  }
+  
+  //Define output vectors
+  int neta = (int)mapEtaRanges->size();
+   
+  std::auto_ptr<std::vector<double>> mapToRhoCorrOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoMCorrOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+  std::auto_ptr<std::vector<double>> mapToRhoMCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+
+  setup_grid(mapEtaRanges->at(0), mapEtaRanges->at(neta-1));
+  
+  //calculate empty area correction over full acceptance leaving eta bands on the sides
+  double all_acceptance_corr = 1;
+  if(doEmptyArea){
+   _eta_min_jet = mapEtaRanges->at(0) - band_;
+   _eta_max_jet = mapEtaRanges->at(neta-1) + band_;
+  
+   calculate_area_fraction_of_jets(iEvent, iSetup);
+  
+   all_acceptance_corr =  _total_inbound_area;
+  }
+  
+  //calculate empty area correction in each eta range
+  for(int ieta = 0; ieta<(neta-1); ieta++) {
+   
+   double correction_kt = 1;   
+   double rho = mapRho->at(ieta);
+   double rhoM = mapRhoM->at(ieta);
+    
+   if(doEmptyArea){
+    double eta_min = mapEtaRanges->at(ieta);
+    double eta_max = mapEtaRanges->at(ieta+1);
+      
+    _eta_min_jet = eta_min + band_;  
+    _eta_max_jet = eta_max - band_;  
+   
+    calculate_area_fraction_of_jets(iEvent, iSetup);
+    correction_kt = _total_inbound_area;
+   }
+   
+   mapToRhoCorrOut->at(ieta) = correction_kt*rho;
+   mapToRhoMCorrOut->at(ieta) = correction_kt*rhoM;
+   
+   mapToRhoCorr1BinOut->at(ieta) = all_acceptance_corr*rho;
+   mapToRhoMCorr1BinOut->at(ieta) = all_acceptance_corr*rhoM;
+  }
+
+  iEvent.put(mapToRhoCorrOut,"mapToRhoCorr");
+  iEvent.put(mapToRhoMCorrOut,"mapToRhoMCorr");
+  iEvent.put(mapToRhoCorr1BinOut,"mapToRhoCorr1Bin");
+  iEvent.put(mapToRhoMCorr1BinOut,"mapToRhoMCorr1Bin");
+  
+  //calculate rho from grid as a function of eta over full range using PF candidates
+  calculate_grid_rho(iEvent, iSetup);
+
+  std::auto_ptr<std::vector<double>> mapRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapMeanRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapEtaMaxGridOut ( new std::vector<double>(_ny,0.));
+  std::auto_ptr<std::vector<double>> mapEtaMinGridOut ( new std::vector<double>(_ny,0.));
+  for(int ieta = 0; ieta < _ny; ieta++) {
+   mapRhoVsEtaGridOut->at(ieta) = _rho_vs_eta[ieta];
+   mapMeanRhoVsEtaGridOut->at(ieta) = _mean_rho_vs_eta[ieta];
+   mapEtaMaxGridOut->at(ieta) = _eta_max_grid[ieta];
+   mapEtaMinGridOut->at(ieta) = _eta_min_grid[ieta];
+  }
+
+  iEvent.put(mapRhoVsEtaGridOut,"mapRhoVsEtaGrid");
+  iEvent.put(mapMeanRhoVsEtaGridOut,"mapMeanRhoVsEtaGrid");
+  iEvent.put(mapEtaMaxGridOut,"mapEtaMaxGrid");
+  iEvent.put(mapEtaMinGridOut,"mapEtaMinGrid");
+}
+
+//----------------------------------------------------------------------
+// setting a new event
+//----------------------------------------------------------------------
+// tell the background estimator that it has a new event, composed
+// of the specified particles.
+void
+HiFJGridEmptyAreaCalculator::calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  vector<vector<double>> scalar_pt(_ny, vector<double>(_nphi, 0.0));
+  
+  edm::Handle<reco::PFCandidateCollection> pfCands;
+  iEvent.getByToken(pfCandsToken_, pfCands);
+  const reco::PFCandidateCollection *pfCandidateColl = pfCands.product();
+  for(unsigned icand = 0; icand < pfCandidateColl->size(); icand++) {
+   const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
+   //use ony the particles within the eta range
+   if (pfCandidate.eta() < _ymin || pfCandidate.eta() > _ymax ) continue;
+   int jeta = tile_index_eta(&pfCandidate);
+   int jphi = tile_index_phi(&pfCandidate);
+   scalar_pt[jeta][jphi] += pfCandidate.pt();
+  }
+  
+ _rho_vs_eta.resize(_ny);
+ _mean_rho_vs_eta.resize(_ny);
+  for(int jeta = 0; jeta < _ny; jeta++){
+  
+ 	 _rho_vs_eta[jeta] = 0;
+ 	 _mean_rho_vs_eta[jeta] = 0;
+	 vector<double> rho_vs_phi;
+	 int n_empty = 0;
+	
+	for(int jphi = 0; jphi < _nphi; jphi++){
+	  double binpt = scalar_pt[jeta][jphi];
+	  _mean_rho_vs_eta[jeta] += binpt;
+      //fill in the vector for median calculation
+	  if(binpt > 0) rho_vs_phi.push_back(binpt);
+	  else n_empty++;
+	 } 
+	 _mean_rho_vs_eta[jeta] /= ((double)_nphi);
+     _mean_rho_vs_eta[jeta] /= _tile_area;
+
+	 //median calculation
+	 sort(rho_vs_phi.begin(), rho_vs_phi.end());
+	 //use only the nonzero grid cells for median calculation;
+	 int n_full = _nphi - n_empty;
+	 if(n_full == 0){
+ 	  _rho_vs_eta[jeta] = 0;
+ 	  continue;
+	 }
+	 if (n_full  % 2 == 0)
+     {
+       _rho_vs_eta[jeta] = (rho_vs_phi[(int)(n_full / 2 - 1)] + rho_vs_phi[(int)(n_full / 2)]) / 2;
+     }
+     else 
+     {
+       _rho_vs_eta[jeta] = rho_vs_phi[(int)(n_full / 2)];
+     }
+     //correct for empty cells 
+	 _rho_vs_eta[jeta] *= (((double) n_full)/((double) _nphi));
+	 //normalize to area
+     _rho_vs_eta[jeta] /= _tile_area;
+  }
+}
+
+void
+HiFJGridEmptyAreaCalculator::calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+  edm::Handle<edm::View<reco::Jet> > jets;
+  iEvent.getByToken(jetsToken_, jets);
+  
+  //calculate jet kt area fraction inside boundary by grid
+  _total_inbound_area = 0;
+  
+  for(auto jet = jets->begin(); jet != jets->end(); ++jet) {
+   if (jet->eta() < _eta_min_jet || jet->eta() > _eta_max_jet) continue;
+   
+   double area_kt = jet->jetArea(); 
+   setup_grid_jet(&*jet);
+   std::vector<std::pair<int, int> > pf_indices_jet;
+   std::vector<std::pair<int, int> > pf_indices_jet_inbound;
+   int n_constit_jet = 0;
+   int n_constit_jet_inbound = 0;
+   for(auto daughter : jet->getJetConstituentsQuick()){
+   	auto pfCandidate = static_cast<const reco::PFCandidate*>(daughter);
+
+	int jeta = tile_index_eta_jet(&*pfCandidate);
+	int jphi = tile_index_phi(&*pfCandidate);
+	pf_indices_jet.push_back(std::make_pair(jphi, jeta));
+	n_constit_jet++;
+	if (pfCandidate->eta() < _eta_min_jet && pfCandidate->eta() > _eta_max_jet) continue;
+	pf_indices_jet_inbound.push_back(std::make_pair(jphi, jeta));
+	n_constit_jet_inbound++;
+   }   
+   
+   //if the jet is well within the eta range just add the area
+   if(n_constit_jet == n_constit_jet_inbound){
+	_total_inbound_area += area_kt;
+    continue;
+   }
+   
+   //for jets that fall outside of eta range calculate fraction of area
+   //inside the range with a grid
+   int nthis = 0;
+   if (n_constit_jet > 0) nthis = num_jet_grid_cells(pf_indices_jet);
+
+   int nthis_inbound = 0;
+   if (n_constit_jet_inbound > 0) nthis_inbound = num_jet_grid_cells(pf_indices_jet_inbound);
+   
+  
+   double fraction_area = ((double)nthis_inbound)/((double)nthis);
+   _total_inbound_area += area_kt*fraction_area;    
+  } 
+  
+  //divide by the total area in that range
+  _total_inbound_area /= ((_eta_max_jet - _eta_min_jet)*twopi);
+  
+  //the fraction can still be greater than 1 because kt area fraction inside 
+  //the range can differ from what we calculated with the grid
+  if (_total_inbound_area > 1) _total_inbound_area = 1;
+}
+
+
+// #ifndef FASTJET_GMBGE_USEFJGRID
+//----------------------------------------------------------------------
+// protected material
+//----------------------------------------------------------------------
+// configure the grid
+void
+HiFJGridEmptyAreaCalculator::setup_grid(double eta_min, double eta_max) {
+
+  // since we've exchanged the arguments of the grid constructor,
+  // there's a danger of calls with exchanged ymax,spacing arguments -- 
+  // the following check should catch most such situations.
+  _ymin = eta_min;
+  _ymax = eta_max;
+  
+  assert(_ymax - _ymin >= gridWidth_);
+
+  // this grid-definition code is becoming repetitive -- it should
+  // probably be moved somewhere central...
+  double ny_double = (_ymax-_ymin) / gridWidth_;
+  _ny = int(ny_double+0.5);
+  _dy = (_ymax-_ymin) / _ny;
+  
+  _nphi = int (twopi / gridWidth_ + 0.5);
+  _dphi = twopi / _nphi;
+
+  // some sanity checking (could throw a fastjet::Error)
+  assert(_ny >= 1 && _nphi >= 1);
+
+  _ntotal = _nphi * _ny;
+  //_scalar_pt.resize(_ntotal);
+  _tile_area = _dy * _dphi;
+  
+  
+  _eta_max_grid.resize(_ny);
+  _eta_min_grid.resize(_ny);
+  for(int jeta = 0; jeta < _ny; jeta++){
+   _eta_min_grid[jeta] = eta_min + _dy*((double)jeta);
+   _eta_max_grid[jeta] = eta_min + _dy*((double)jeta + 1.);
+  }
+}
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_phi(const reco::PFCandidate *pfCand)  {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+ 
+  int iphi = int( (pfCand->phi() + (twopi/2.))/_dphi );
+  assert(iphi >= 0 && iphi <= _nphi);
+  if (iphi == _nphi) iphi = 0; // just in case of rounding errors
+
+  return iphi;
+}
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_eta(const reco::PFCandidate *pfCand)  {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+  int iy = int(floor( (pfCand->eta() - _ymin) / _dy ));
+  if (iy < 0 || iy >= _ny) return -1;
+  
+  assert (iy < _ny && iy >= 0);
+
+  return iy;
+}
+
+// #ifndef FASTJET_GMBGE_USEFJGRID
+//----------------------------------------------------------------------
+// protected material
+//----------------------------------------------------------------------
+// configure the grid
+void
+HiFJGridEmptyAreaCalculator::setup_grid_jet(const reco::Jet *jet) {
+
+  // since we've exchanged the arguments of the grid constructor,
+  // there's a danger of calls with exchanged ymax,spacing arguments -- 
+  // the following check should catch most such situations.
+  _yminjet = jet->eta()-0.6;
+  _ymaxjet = jet->eta()+0.6;
+  
+  assert(_ymaxjet - _yminjet >= gridWidth_);
+
+  // this grid-definition code is becoming repetitive -- it should
+  // probably be moved somewhere central...
+  double ny_double = (_ymaxjet-_yminjet) / gridWidth_;
+  _nyjet = int(ny_double+0.5);
+  _dyjet = (_ymaxjet-_yminjet) / _nyjet;
+  
+  assert(_nyjet >= 1);
+
+  _ntotaljet = _nphi * _nyjet;
+  //_scalar_pt.resize(_ntotal);
+}
+
+
+//----------------------------------------------------------------------
+// retrieve the grid tile index for a given PseudoJet
+int
+HiFJGridEmptyAreaCalculator::tile_index_eta_jet(const reco::PFCandidate *pfCand) {
+  // directly taking int does not work for values between -1 and 0
+  // so use floor instead
+  // double iy_double = (p.rap() - _ymin) / _dy;
+  // if (iy_double < 0.0) return -1;
+  // int iy = int(iy_double);
+  // if (iy >= _ny) return -1;
+
+  // writing it as below gives a huge speed gain (factor two!). Even
+  // though answers are identical and the routine here is not the
+  // speed-critical step. It's not at all clear why.
+  int iyjet = int(floor( (pfCand->eta() - _yminjet) / _dy ));
+  if (iyjet < 0 || iyjet >= _nyjet) return -1;
+  
+  assert (iyjet < _nyjet && iyjet >= 0);
+
+  return iyjet;
+}
+
+int 
+HiFJGridEmptyAreaCalculator::num_jet_grid_cells( std::vector<std::pair<int, int> >& indices )
+{
+  int ngrid = 0;
+  //sort phi eta grid indices in phi
+  std::sort(indices.begin(),indices.end());
+  int lowest_jphi = indices[0].first;
+  int lowest_jeta = indices[0].second;
+  int highest_jeta = lowest_jeta;
+    
+  //for each fixed phi value calculate the number of grids in eta
+  for(unsigned int iconst = 1; iconst < indices.size(); iconst++){
+   int jphi = indices[iconst].first;
+   int jeta = indices[iconst].second;
+   if (jphi == lowest_jphi){
+	if (jeta < lowest_jeta) lowest_jeta = jeta;
+	if (jeta > highest_jeta) highest_jeta = jeta;
+   }else{
+	lowest_jphi = jphi;
+	ngrid += highest_jeta - lowest_jeta + 1;
+    lowest_jeta = jeta;
+    highest_jeta = jeta;
+   }
+  }
+  ngrid += highest_jeta - lowest_jeta + 1;
+  return ngrid;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+HiFJGridEmptyAreaCalculator::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+HiFJGridEmptyAreaCalculator::endJob() {
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HiFJGridEmptyAreaCalculator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(HiFJGridEmptyAreaCalculator);
+

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
@@ -1,0 +1,98 @@
+#ifndef HiJetBackground_HiFJGridEmptyAreaCalculator_h
+#define HiJetBackground_HiFJGridEmptyAreaCalculator_h
+
+
+// system include files
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "TMath.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
+   public:
+      explicit HiFJGridEmptyAreaCalculator(const edm::ParameterSet&);
+      ~HiFJGridEmptyAreaCalculator();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() override;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+      
+  /// @name setting a new event
+  //\{
+  //----------------------------------------------------------------
+
+  /// tell the background estimator that it has a new event, composed
+  /// of the specified particles.
+
+
+private:
+
+  /// configure the grid
+  void setup_grid(double eta_min, double eta_max);
+  void setup_grid_jet(const reco::Jet *jet);
+
+  /// retrieve the grid cell index for a given PseudoJet
+  int tile_index_jet(const reco::PFCandidate *pfCand);
+  int tile_index_eta(const reco::PFCandidate *pfCand);
+  int tile_index_eta_jet(const reco::PFCandidate *pfCand);
+  int tile_index_phi(const reco::PFCandidate *pfCand);
+  
+  ///number of grid cells that overlap with jet constituents filling in the in between area
+  int num_jet_grid_cells( std::vector<std::pair<int, int> >& indices );
+  
+  /// calculates the area of jets that fall within the eta 
+  /// range by scaling kt areas using grid areas
+  void calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  
+  /// information about the grid
+  const double twopi = 2*TMath::Pi(); 
+  
+  ///internal parameters for grid 
+  double _ymin, _ymax, _dy, _dphi, _tile_area, //parameters of grid covering the full acceptance
+  _dyjet, _yminjet, _ymaxjet, _total_inbound_area, //parameters of grid around jets
+  _eta_min_jet, _eta_max_jet; //leave bands at boundaries
+  int _ny, _nphi, _ntotal, //for the grid calculation covering the full acceptance
+  _ntotaljet, _nyjet; //for the grid calculation around each jet
+  
+  ///input parameters
+  double gridWidth_, band_;
+  int hiBinCut_;
+  bool doCentrality_;
+  
+  std::vector<double> _rho_vs_eta;
+  std::vector<double> _mean_rho_vs_eta;
+  std::vector<double> _eta_max_grid;
+  std::vector<double> _eta_min_grid;
+  
+  int n_tiles()  {return _ntotal;}
+  
+  /// input tokens
+  edm::EDGetTokenT<edm::View<reco::Jet>>                 jetsToken_;
+  edm::EDGetTokenT<reco::PFCandidateCollection>          pfCandsToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapEtaToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapRhoToken_;
+  edm::EDGetTokenT<std::vector<double>>                  mapRhoMToken_;
+
+  edm::EDGetTokenT<int> centralityBinToken_;
+  
+};
+
+#endif
+

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoProducer.h
@@ -43,6 +43,7 @@ class HiFJRhoProducer : public edm::EDProducer {
       unsigned int   nExcl2_;             //Number of leading jets to exclude in 2nd eta region
       double         etaMaxExcl2_;        //max eta for jets to exclude in 2nd eta region
       double         ptMinExcl2_;         //min pt for excluded jets in 2nd eta region
+      std::vector<double>         etaRanges;         //eta boundaries for rho calculation regions
       bool           checkJetCand, usingPackedCand;
 };
 

--- a/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+hiFJGridEmptyAreaCalculator = cms.EDProducer('HiFJGridEmptyAreaCalculator',
+                                 gridWidth = cms.untracked.double(0.05),
+                                 bandWidth = cms.untracked.double(0.2),
+                                 mapEtaEdges = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+                                 mapToRho = cms.InputTag('hiFJRhoProducer','mapToRho'),
+                                 mapToRhoM = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+                                 pfCandSource = cms.InputTag('particleFlowTmp'),
+                                 jetSource = cms.InputTag('kt4PFJets'),
+								 doCentrality = cms.untracked.bool(True),
+								 hiBinCut = cms.untracked.int32(100),    
+								 CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
+)
+

--- a/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoProducer.py
@@ -7,6 +7,7 @@ hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
                                  ptMinExcl = cms.untracked.double(20.),
                                  nExcl2 = cms.untracked.uint32(1),
                                  etaMaxExcl2 = cms.untracked.double(3.),
-                                 ptMinExcl2 = cms.untracked.double(20.)
+                                 ptMinExcl2 = cms.untracked.double(20.),
+     					         etaRanges = cms.untracked.vdouble(-5., -3., -2., -1.5, -1., 1., 1.5, 2., 3., 5.)
+                                 # etaRanges = cms.untracked.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
 )
-

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -1,0 +1,190 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "RecoJets/JetProducers/plugins/CSJetProducer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "RecoJets/JetProducers/interface/JetSpecific.h"
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+using namespace cms;
+
+CSJetProducer::CSJetProducer(edm::ParameterSet const& conf):
+  VirtualJetProducer( conf ),
+  csRho_EtaMax_(-1.0),
+  csRParam_(-1.0),
+  csAlpha_(0.)
+{
+  //get eta range, rho and rhom map
+  etaToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "etaMap" ));
+  rhoToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rho" ));
+  rhomToken_ = consumes<std::vector<double>>(conf.getParameter<edm::InputTag>( "rhom" ));
+  csAlpha_ = conf.getParameter<double>("csAlpha");
+}
+
+void CSJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & iSetup )
+{
+  // use the default production from one collection
+  VirtualJetProducer::produce( iEvent, iSetup );
+  //use runAlgorithm of this class
+
+
+  // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
+  // depending on the exact configuration; and there are 24 FastjetJetProducers in the
+  // sequence so this adds up to about 60 Mb. It's allocated every time runAlgorithm
+  // is called, so safe to delete here.
+  fjClusterSeq_.reset();
+}
+
+//______________________________________________________________________________
+void CSJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup const& iSetup)
+{
+  // run algorithm
+  if ( !doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs_, *fjJetDefinition_ ) );
+  } else if (voronoiRfact_ <= 0) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( fjInputs_, *fjJetDefinition_ , *fjAreaDefinition_ ) );
+  } else {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
+  }
+
+  //fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
+  fjJets_.clear();
+  std::vector<fastjet::PseudoJet> tempJets = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
+
+  //Get local rho and rhomo map
+  edm::Handle<std::vector<double>> etaRanges;
+  edm::Handle<std::vector<double>> rhoRanges;
+  edm::Handle<std::vector<double>> rhomRanges;
+  
+  iEvent.getByToken(etaToken_, etaRanges);
+  iEvent.getByToken(rhoToken_, rhoRanges);
+  iEvent.getByToken(rhomToken_, rhomRanges);
+
+  //Starting from here re-implementation of constituent subtraction
+  //source: http://fastjet.hepforge.org/svn/contrib/contribs/ConstituentSubtractor/tags/1.0.0/ConstituentSubtractor.cc
+  //some minor modifications with respect to original
+  //main change: eta-dependent rho within the jet
+  for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(), ijetEnd = tempJets.end(); ijet != ijetEnd; ++ijet ) {
+  
+    //----------------------------------------------------------------------
+    // sift ghosts and particles in the input jet
+    std::vector<fastjet::PseudoJet> particles, ghosts;
+    fastjet::SelectorIsPureGhost().sift(ijet->constituents(), ghosts, particles);
+    unsigned long nGhosts=ghosts.size();
+    unsigned long nParticles=particles.size();
+    if(nParticles==0) continue; //don't subtract ghost jets
+    
+    //assign rho and rhom to ghosts according to local eta-dependent map
+    std::vector<double> rho;
+    std::vector<double> rhom;
+    for (unsigned int j=0;j<nGhosts; j++) {
+
+      if(ghosts[j].eta()<=etaRanges->at(0)) {
+        rho.push_back(rhoRanges->at(0));
+        rhom.push_back(rhomRanges->at(0));
+      } else if(ghosts[j].eta()>=etaRanges->at(etaRanges->size()-1)) {
+        rho.push_back(rhoRanges->at(rhoRanges->size()-1));
+        rhom.push_back(rhomRanges->at(rhomRanges->size()-1));
+      } else {
+        for(int ie = 0; ie<(int)(etaRanges->size()-1); ie++) {
+          if(ghosts[j].eta()>=etaRanges->at(ie) && ghosts[j].eta()<etaRanges->at(ie+1)) {
+            rho.push_back(rhoRanges->at(ie));
+            rhom.push_back(rhomRanges->at(ie));
+            break;
+          }
+        }
+      }
+      
+    }
+
+    //----------------------------------------------------------------------
+    // computing and sorting the distances, deltaR
+    bool useMaxDeltaR = false;
+    if (csRParam_>0) useMaxDeltaR = true;
+    double maxDeltaR_squared=pow(csRParam_,2); 
+    double alpha_times_two= csAlpha_*2.;
+    std::vector<std::pair<double,int> > deltaRs;  // the first element is deltaR, the second element is only the index in the vector used for sorting
+    std::vector<int> particle_indices_unsorted;
+    std::vector<int> ghost_indices_unsorted;
+    for (unsigned int i=0;i<nParticles; i++){
+      double pt_factor=1.;
+      if (fabs(alpha_times_two)>1e-5) pt_factor=pow(particles[i].pt(),alpha_times_two);
+      for (unsigned int j=0;j<nGhosts; j++){
+	double deltaR_squared = ghosts[j].squared_distance(particles[i])*pt_factor;
+	if (!useMaxDeltaR || deltaR_squared<=maxDeltaR_squared){
+	  particle_indices_unsorted.push_back(i);
+	  ghost_indices_unsorted.push_back(j);
+	  int deltaRs_size=deltaRs.size();  // current position
+	  deltaRs.push_back(std::make_pair(deltaR_squared,deltaRs_size));
+	}
+      }
+    }
+    std::sort(deltaRs.begin(),deltaRs.end(),CSJetProducer::function_used_for_sorting);
+    unsigned long nStoredPairs=deltaRs.size();
+
+    //----------------------------------------------------------------------
+    // the iterative process. Here, only finding the fractions of pt or deltaM to be corrected. The actual correction of particles is done later.
+    std::vector<double> ghosts_fraction_of_pt(nGhosts,1.);
+    std::vector<double> particles_fraction_of_pt(nParticles,1.);
+    std::vector<double> ghosts_fraction_of_mtMinusPt(nGhosts,1.);
+    std::vector<double> particles_fraction_of_mtMinusPt(nParticles,1.);
+    for (unsigned long iindices=0;iindices<nStoredPairs;++iindices){
+      int particle_index=particle_indices_unsorted[deltaRs[iindices].second];
+      int ghost_index=ghost_indices_unsorted[deltaRs[iindices].second];
+      if (ghosts_fraction_of_pt[ghost_index]>0 && particles_fraction_of_pt[particle_index]>0){
+	double ratio_pt=particles[particle_index].pt()*particles_fraction_of_pt[particle_index]/rho[ghost_index]/ghosts[ghost_index].area()/ghosts_fraction_of_pt[ghost_index];
+	if (ratio_pt>1){
+	  particles_fraction_of_pt[particle_index]*=1-1./ratio_pt;
+	  ghosts_fraction_of_pt[ghost_index]=-1;
+	}
+	else {
+	  ghosts_fraction_of_pt[ghost_index]*=1-ratio_pt;
+	  particles_fraction_of_pt[particle_index]=-1;
+	}
+      }
+      if (ghosts_fraction_of_mtMinusPt[ghost_index]>0 && particles_fraction_of_mtMinusPt[particle_index]>0){
+	double ratio_mtMinusPt=(particles[particle_index].mt()-particles[particle_index].pt())*particles_fraction_of_mtMinusPt[particle_index]/rhom[ghost_index]/ghosts[ghost_index].area()/ghosts_fraction_of_mtMinusPt[ghost_index];
+	if (ratio_mtMinusPt>1){
+	  particles_fraction_of_mtMinusPt[particle_index]*=1-1./ratio_mtMinusPt;
+	  ghosts_fraction_of_mtMinusPt[ghost_index]=-1;
+	}
+	else{
+	  ghosts_fraction_of_mtMinusPt[ghost_index]*=1-ratio_mtMinusPt;
+	  particles_fraction_of_mtMinusPt[particle_index]=-1;
+	}
+      }
+    }
+
+    //----------------------------------------------------------------------
+    // do the actual correction for particles:
+    std::vector<fastjet::PseudoJet> subtracted_particles;
+    for (unsigned int i=0;i<particles_fraction_of_pt.size(); i++){
+      if (particles_fraction_of_pt[i]<=0) continue;  // particles with zero pt are not used (but particles with zero mtMinusPt are used)
+      double rapidity=particles[i].rap();
+      double azimuth=particles[i].phi();
+      double subtracted_pt=0;
+      if (particles_fraction_of_pt[i]>0) subtracted_pt=particles[i].pt()*particles_fraction_of_pt[i];
+      double subtracted_mtMinusPt=0;
+      if (particles_fraction_of_mtMinusPt[i]>0) subtracted_mtMinusPt=(particles[i].mt()-particles[i].pt())*particles_fraction_of_mtMinusPt[i];
+      fastjet::PseudoJet subtracted_const(subtracted_pt*cos(azimuth),subtracted_pt*sin(azimuth),(subtracted_pt+subtracted_mtMinusPt)*sinh(rapidity),(subtracted_pt+subtracted_mtMinusPt)*cosh(rapidity));
+      subtracted_const.set_user_index(i);
+      subtracted_particles.push_back(subtracted_const);
+    }
+    fastjet::PseudoJet subtracted_jet=join(subtracted_particles);
+    //std::cout << "orig jet pt: " << ijet->perp() << " sub pt: " << subtracted_jet.perp() << std::endl;
+    if(subtracted_jet.perp()>0.)
+      fjJets_.push_back( subtracted_jet );
+    
+  }//jet loop
+  fjJets_ = fastjet::sorted_by_pt(fjJets_); 
+}
+
+bool  CSJetProducer::function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j){
+    return (i.first < j.first);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// define as cmssw plugin
+////////////////////////////////////////////////////////////////////////////////
+
+DEFINE_FWK_MODULE(CSJetProducer);

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -1,0 +1,54 @@
+#ifndef RecoJets_JetProducers_CSJetProducer_h
+#define RecoJets_JetProducers_CSJetProducer_h
+
+/* *********************************************************
+  \class CSJetProducer
+
+  \brief Jet producer to produce CMS-style constituent subtracted jets
+
+  \author   Marta Verweij
+  \version  
+
+         Notes on implementation:
+
+         Reimplementation of constituent subtraction from fastjet contrib package
+         to allow the use of eta-dependent rho and rho_m for the constituents 
+         inside a jet
+
+ ************************************************************/
+
+
+#include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
+
+namespace cms
+{
+  class CSJetProducer : public VirtualJetProducer
+  {
+  public:
+
+    CSJetProducer(const edm::ParameterSet& ps);
+
+    virtual ~CSJetProducer() {}
+
+    virtual void produce( edm::Event & iEvent, const edm::EventSetup & iSetup );
+    
+  protected:
+
+    virtual void runAlgorithm( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+    static bool function_used_for_sorting(std::pair<double,int> i,std::pair<double, int> j);
+    
+     // calls VirtualJetProducer::inputTowers
+    //virtual void inputTowers();
+
+    double csRho_EtaMax_;       /// for constituent subtraction : maximum rapidity for ghosts
+    double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
+    double csAlpha_;            /// for HI constituent subtraction : alpha (power of pt in metric)
+
+    //input rho and rho_m + eta map
+    edm::EDGetTokenT<std::vector<double>>                       etaToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhoToken_;
+    edm::EDGetTokenT<std::vector<double>>                       rhomToken_;
+  };
+}
+#endif

--- a/RecoJets/JetProducers/python/akCs4PFJets_cfi.py
+++ b/RecoJets/JetProducers/python/akCs4PFJets_cfi.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoJets.JetProducers.PFJetParameters_cfi import *
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+
+akCs4PFJets = cms.EDProducer(
+    "CSJetProducer",
+    PFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm  = cms.string("AntiKt"),
+    rParam        = cms.double(0.4),
+    etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+    rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
+    rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+    csAlpha   = cms.double(1.),
+    writeJetsWithConst = cms.bool(True),
+    jetCollInstanceName = cms.string("pfParticlesCs")
+)
+akCs4PFJets.src           = cms.InputTag('particleFlowTmp')
+akCs4PFJets.doAreaFastjet = cms.bool(True)
+akCs4PFJets.jetPtMin      = cms.double(0.0)
+akCs4PFJets.useExplicitGhosts = cms.bool(True)


### PR DESCRIPTION
Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.

Tune of Cs jets which include:
- Empty area calculation: Jet kt areas from fast jet are summed and compared to total acceptance. Jets are checked on whether or not the go outside of the acceptance. When they fall out the kt area is scaled by the fraction of "grid-jets" that is inside the eta boundaries. There is a possibility to calculate empty areas in eta bins but because eta slices are narrow it is better to use it over the full acceptance which is the current default mode. This correction is only ran in 50-100% events.
- Local eta branch from here:
  https://github.com/CmsHI/cmssw/tree/csLocalEta/RecoHI/HiJetAlgos
- Eta boundaries for rho calculator was tuned to reduce the eta dependence
  Performance is documented in:
  https://github.com/CmsHI/cmssw/tree/csLocalEta/RecoHI/HiJetAlgos

@richard-cms could we merge this into forest, @mverwe might want to comment and take a look.
