### PR TITLE
Pu algorithm updates

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_ntuplizerPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_ntuplizerPbPb.py
@@ -1,0 +1,141 @@
+import FWCore.ParameterSet.Config as cms
+
+from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_HI_cff import *
+from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiBackgroundPF, voronoiBackgroundCalo
+from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
+from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
+kt4PFJets.src = cms.InputTag('particleFlowTmp')
+kt4PFJets.doAreaFastjet = True
+kt4PFJets.jetPtMin      = cms.double(0.0)
+kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs2PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs5PFJetSequence_PbPb_mc_cff import *
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop5PFJetSequence_PbPb_mc_cff import *
+
+highPurityTracks = cms.EDFilter("TrackSelector",
+                                src = cms.InputTag("hiGeneralTracks"),
+                                cut = cms.string('quality("highPurity")'))
+
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
+offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
+
+
+akPu4PFJetsNoLimits = akPu4PFJets.clone(
+    subtractorName = 'PuWithNtuple',
+    minimumTowersFraction = cms.double(0.)
+)
+
+
+akPu3PFJets.subtractorName = 'PuWithNtuple'
+akPu3PFJets.minimumTowersFraction = cms.double(0.5)
+akPu4PFJets.subtractorName = 'PuWithNtuple'
+akPu4PFJets.minimumTowersFraction = cms.double(0.5)
+akPu5PFJets.subtractorName = 'PuWithNtuple'
+akPu5PFJets.minimumTowersFraction = cms.double(0.5)
+
+akPu3CaloJets.subtractorName = 'PuWithNtuple'
+akPu3CaloJets.minimumTowersFraction = cms.double(0.)
+akPu4CaloJets.subtractorName = 'PuWithNtuple'
+akPu4CaloJets.minimumTowersFraction = cms.double(0.)
+akPu5CaloJets.subtractorName = 'PuWithNtuple'
+akPu5CaloJets.minimumTowersFraction = cms.double(0.)
+
+
+jetSequences = cms.Sequence(
+    PFTowers + 
+    #voronoiBackgroundPF+
+    #voronoiBackgroundCalo+
+    kt2PFJets +
+    kt4PFJets +
+    hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator + 
+
+
+    akPu4PFJetsNoLimits +
+
+    #akPu2CaloJets +
+    #akPu2PFJets +
+    #akVs2CaloJets +
+    #akVs2PFJets +
+    #akCs2PFJets +
+
+    akPu3CaloJets +
+    akPu3PFJets +
+    #akVs3CaloJets +
+    #akVs3PFJets +
+    akCs3PFJets +
+
+    akPu4CaloJets +
+    akPu4PFJets +
+    #akVs4CaloJets +
+    #akVs4PFJets +
+    akCs4PFJets +
+
+    #akPu5CaloJets +
+    #akPu5PFJets +
+    #akVs5CaloJets +
+    #akVs5PFJets +
+    #akCs5PFJets +
+
+    #akCsFilter4PFJets +
+    #akCsFilter5PFJets +
+    #akCsSoftDrop4PFJets +
+    #akCsSoftDrop5PFJets +
+
+    highPurityTracks +
+    offlinePrimaryVertices +
+
+    #akPu2CaloJetSequence +
+    #akVs2CaloJetSequence +
+    #akVs2PFJetSequence +
+    #akPu2PFJetSequence +
+    #akCs2PFJetSequence +
+
+    akPu3CaloJetSequence +
+    #akVs3CaloJetSequence +
+    #akVs3PFJetSequence +
+    akPu3PFJetSequence +
+    akCs3PFJetSequence +
+
+    akPu4CaloJetSequence +
+    #akVs4CaloJetSequence +
+    #akVs4PFJetSequence +
+    akPu4PFJetSequence +
+    akCs4PFJetSequence #+
+
+    #akPu5CaloJetSequence +
+    #akVs5CaloJetSequence +
+    #akVs5PFJetSequence +
+    #akPu5PFJetSequence +
+    #akCs5PFJetSequence +
+
+    #akCsFilter4PFJetSequence +
+    #akCsFilter5PFJetSequence +
+    #akCsSoftDrop4PFJetSequence #+
+    #akCsSoftDrop5PFJetSequence
+)

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_puLimitedPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_puLimitedPbPb.py
@@ -1,0 +1,134 @@
+import FWCore.ParameterSet.Config as cms
+
+from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_HI_cff import *
+from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiBackgroundPF, voronoiBackgroundCalo
+from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
+from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
+kt4PFJets.src = cms.InputTag('particleFlowTmp')
+kt4PFJets.doAreaFastjet = True
+kt4PFJets.jetPtMin      = cms.double(0.0)
+kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs2PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs5PFJetSequence_PbPb_mc_cff import *
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop5PFJetSequence_PbPb_mc_cff import *
+
+highPurityTracks = cms.EDFilter("TrackSelector",
+                                src = cms.InputTag("hiGeneralTracks"),
+                                cut = cms.string('quality("highPurity")'))
+
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
+offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
+
+
+akPu4PFJetsNoLimits = akPu4PFJets.clone(
+    minimumTowersFraction = cms.double(0.)
+)
+
+
+akPu3PFJets.minimumTowersFraction = cms.double(0.5)
+akPu4PFJets.minimumTowersFraction = cms.double(0.5)
+akPu5PFJets.minimumTowersFraction = cms.double(0.5)
+
+akPu3CaloJets.minimumTowersFraction = cms.double(0.)
+akPu4CaloJets.minimumTowersFraction = cms.double(0.)
+akPu5CaloJets.minimumTowersFraction = cms.double(0.)
+
+
+jetSequences = cms.Sequence(
+    PFTowers + 
+    #voronoiBackgroundPF+
+    #voronoiBackgroundCalo+
+    kt2PFJets +
+    kt4PFJets +
+    hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator + 
+
+
+    akPu4PFJetsNoLimits +
+
+    #akPu2CaloJets +
+    #akPu2PFJets +
+    #akVs2CaloJets +
+    #akVs2PFJets +
+    #akCs2PFJets +
+
+    akPu3CaloJets +
+    akPu3PFJets +
+    #akVs3CaloJets +
+    #akVs3PFJets +
+    akCs3PFJets +
+
+    akPu4CaloJets +
+    akPu4PFJets +
+    #akVs4CaloJets +
+    #akVs4PFJets +
+    akCs4PFJets +
+
+    #akPu5CaloJets +
+    #akPu5PFJets +
+    #akVs5CaloJets +
+    #akVs5PFJets +
+    #akCs5PFJets +
+
+    #akCsFilter4PFJets +
+    #akCsFilter5PFJets +
+    #akCsSoftDrop4PFJets +
+    #akCsSoftDrop5PFJets +
+
+    highPurityTracks +
+    offlinePrimaryVertices +
+
+    #akPu2CaloJetSequence +
+    #akVs2CaloJetSequence +
+    #akVs2PFJetSequence +
+    #akPu2PFJetSequence +
+    #akCs2PFJetSequence +
+
+    akPu3CaloJetSequence +
+    #akVs3CaloJetSequence +
+    #akVs3PFJetSequence +
+    akPu3PFJetSequence +
+    akCs3PFJetSequence +
+
+    akPu4CaloJetSequence +
+    #akVs4CaloJetSequence +
+    #akVs4PFJetSequence +
+    akPu4PFJetSequence +
+    akCs4PFJetSequence #+
+
+    #akPu5CaloJetSequence +
+    #akVs5CaloJetSequence +
+    #akVs5PFJetSequence +
+    #akPu5PFJetSequence +
+    #akCs5PFJetSequence +
+
+    #akCsFilter4PFJetSequence +
+    #akCsFilter5PFJetSequence +
+    #akCsSoftDrop4PFJetSequence #+
+    #akCsSoftDrop5PFJetSequence
+)

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_puUnlimitedPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_puUnlimitedPbPb.py
@@ -1,0 +1,134 @@
+import FWCore.ParameterSet.Config as cms
+
+from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_HI_cff import *
+from Configuration.StandardSequences.ReconstructionHeavyIons_cff import voronoiBackgroundPF, voronoiBackgroundCalo
+from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets
+from RecoHI.HiJetAlgos.hiFJRhoProducer import hiFJRhoProducer
+from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
+kt4PFJets.src = cms.InputTag('particleFlowTmp')
+kt4PFJets.doAreaFastjet = True
+kt4PFJets.jetPtMin      = cms.double(0.0)
+kt4PFJets.GhostArea     = cms.double(0.005)
+kt2PFJets = kt4PFJets.clone(rParam       = cms.double(0.2))
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu2PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs2PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs3PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4CaloJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akVs4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_PbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akCs4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5CaloJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akVs5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akPu5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCs5PFJetSequence_PbPb_mc_cff import *
+
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsFilter5PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop4PFJetSequence_PbPb_mc_cff import *
+#from HeavyIonsAnalysis.JetAnalysis.jets.akCsSoftDrop5PFJetSequence_PbPb_mc_cff import *
+
+highPurityTracks = cms.EDFilter("TrackSelector",
+                                src = cms.InputTag("hiGeneralTracks"),
+                                cut = cms.string('quality("highPurity")'))
+
+from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
+offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
+
+
+akPu4PFJetsNoLimits = akPu4PFJets.clone(
+    minimumTowersFraction = cms.double(0.)
+)
+
+
+akPu3PFJets.minimumTowersFraction = cms.double(0.)
+akPu4PFJets.minimumTowersFraction = cms.double(0.)
+akPu5PFJets.minimumTowersFraction = cms.double(0.)
+
+akPu3CaloJets.minimumTowersFraction = cms.double(0.)
+akPu4CaloJets.minimumTowersFraction = cms.double(0.)
+akPu5CaloJets.minimumTowersFraction = cms.double(0.)
+
+
+jetSequences = cms.Sequence(
+    PFTowers + 
+    #voronoiBackgroundPF+
+    #voronoiBackgroundCalo+
+    kt2PFJets +
+    kt4PFJets +
+    hiFJRhoProducer +
+    hiFJGridEmptyAreaCalculator + 
+
+
+    akPu4PFJetsNoLimits +
+
+    #akPu2CaloJets +
+    #akPu2PFJets +
+    #akVs2CaloJets +
+    #akVs2PFJets +
+    #akCs2PFJets +
+
+    akPu3CaloJets +
+    akPu3PFJets +
+    #akVs3CaloJets +
+    #akVs3PFJets +
+    akCs3PFJets +
+
+    akPu4CaloJets +
+    akPu4PFJets +
+    #akVs4CaloJets +
+    #akVs4PFJets +
+    akCs4PFJets +
+
+    #akPu5CaloJets +
+    #akPu5PFJets +
+    #akVs5CaloJets +
+    #akVs5PFJets +
+    #akCs5PFJets +
+
+    #akCsFilter4PFJets +
+    #akCsFilter5PFJets +
+    #akCsSoftDrop4PFJets +
+    #akCsSoftDrop5PFJets +
+
+    highPurityTracks +
+    offlinePrimaryVertices +
+
+    #akPu2CaloJetSequence +
+    #akVs2CaloJetSequence +
+    #akVs2PFJetSequence +
+    #akPu2PFJetSequence +
+    #akCs2PFJetSequence +
+
+    akPu3CaloJetSequence +
+    #akVs3CaloJetSequence +
+    #akVs3PFJetSequence +
+    akPu3PFJetSequence +
+    akCs3PFJetSequence +
+
+    akPu4CaloJetSequence +
+    #akVs4CaloJetSequence +
+    #akVs4PFJetSequence +
+    akPu4PFJetSequence +
+    akCs4PFJetSequence #+
+
+    #akPu5CaloJetSequence +
+    #akVs5CaloJetSequence +
+    #akVs5PFJetSequence +
+    #akPu5PFJetSequence +
+    #akCs5PFJetSequence +
+
+    #akCsFilter4PFJetSequence +
+    #akCsFilter5PFJetSequence +
+    #akCsSoftDrop4PFJetSequence #+
+    #akCsSoftDrop5PFJetSequence
+)

--- a/RecoHI/HiJetAlgos/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/BuildFile.xml
@@ -1,7 +1,9 @@
 <use   name="boost"/>
+<use   name="root"/>
 <use   name="FWCore/Framework"/>
 <use   name="RecoJets/JetProducers"/>
 <use   name="DataFormats/HeavyIonEvent"/>
+<use   name="CommonTools/UtilAlgos"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoHI/HiJetAlgos/interface/MultipleAlgoIterator.h
+++ b/RecoHI/HiJetAlgos/interface/MultipleAlgoIterator.h
@@ -5,16 +5,16 @@
 
 class MultipleAlgoIterator : public PileUpSubtractor {
  public:
- MultipleAlgoIterator(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) : PileUpSubtractor(iConfig, std::move(iC)),
-     sumRecHits_(iConfig.getParameter<bool>("sumRecHits")),
-     dropZeroTowers_(iConfig.getUntrackedParameter<bool>("dropZeroTowers",true))
-       {;}
+    MultipleAlgoIterator(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC);
     virtual void offsetCorrectJets();
     void rescaleRMS(double s);
     double getEt(const reco::CandidatePtr & in) const;
     double getEta(const reco::CandidatePtr & in) const;
     virtual void calculatePedestal(std::vector<fastjet::PseudoJet> const & coll);
     virtual void subtractPedestal(std::vector<fastjet::PseudoJet> & coll);
+    virtual void calculateOrphanInput(std::vector<fastjet::PseudoJet> & orphanInput);
+
+    double minimumTowersFraction_;
 
     bool sumRecHits_;
     bool dropZeroTowers_;

--- a/RecoHI/HiJetAlgos/interface/PuWithNtuple.h
+++ b/RecoHI/HiJetAlgos/interface/PuWithNtuple.h
@@ -1,0 +1,45 @@
+#ifndef __PuWithNtuple_h_
+#define __PuWithNtuple_h_
+
+#include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include <TTree.h>
+
+class PuWithNtuple : public PileUpSubtractor {
+ public:
+  PuWithNtuple(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC);
+    virtual void offsetCorrectJets();
+    void rescaleRMS(double s);
+    double getEt(const reco::CandidatePtr & in) const;
+    double getEta(const reco::CandidatePtr & in) const;
+    virtual void calculatePedestal(std::vector<fastjet::PseudoJet> const & coll);
+    virtual void subtractPedestal(std::vector<fastjet::PseudoJet> & coll);
+    virtual void calculateOrphanInput(std::vector<fastjet::PseudoJet> & orphanInput);
+
+    bool sumRecHits_;
+    bool dropZeroTowers_;
+
+    double minimumTowersFraction_;
+
+    ~PuWithNtuple(){;}
+
+    edm::Service<TFileService> fs_;
+    TTree* tree_;
+
+    int Neta_;
+
+    int nref;
+    float jteta[200],jtphi[200],jtpt[200],jtpu[200],jtexpt[200];
+    int jtexngeom[200], jtexntow[200];
+
+    int vngeom[82],vntow[82],vieta[82];
+    float veta[82],vmean0[82],vrms0[82],vmean1[82],vrms1[82];
+
+    double etaedge[42];
+    
+};
+
+
+#endif

--- a/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.cc
@@ -20,7 +20,6 @@
 // system include files
 #include <memory>
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -46,7 +45,6 @@
 
 #include "TMath.h"
 #include "TRandom.h"
-
 
 
 
@@ -108,7 +106,6 @@ ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
    resetTowers(iEvent, iSetup);
 
-
    edm::Handle<reco::PFCandidateCollection> inputsHandle;
    iEvent.getByToken(src_, inputsHandle);
    
@@ -121,64 +118,40 @@ ParticleTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     
     double eta = particle.eta();
 
-    if(!useHF_ && fabs(eta) > 3. ) continue;
-
     int ieta = eta2ieta(eta);
-    if(ieta==-1) continue;
-    if(eta<0) ieta  *= -1;
-
     int iphi = phi2iphi(particle.phi(),ieta);
        
-    HcalSubdetector sd;
-    if(abs(ieta)<=16) sd = HcalBarrel;
-    else if(fabs(eta)< 3.) sd = HcalEndcap;  // Use the endcap until eta =3
-    else sd = HcalForward;
-    
-    HcalDetId hid = HcalDetId(sd,ieta,iphi,1); // assume depth=1
+    if(!useHF_ && abs(ieta) > 29 ) continue;
 
-    // check against the old method (boundaries slightly shifted in the endcaps
-    /*
-    HcalDetId hid_orig = getNearestTower(particle);
-    
-    if(hid != hid_orig)
-      {	
-	if(abs((hid).ieta()-(hid_orig).ieta())>1 || abs((hid).iphi()-(hid_orig).iphi()) >1 ){
+    EtaPhi ep(ieta,iphi);
+    towers_[ep] += particle.et();
 
-	  int phi_diff = 1;
-	  if(abs((hid).ieta())>39 || abs((hid_orig).ieta())>39) phi_diff = 4;
-	  else if(abs((hid).ieta())>20 || abs((hid_orig).ieta())>20) phi_diff = 2;
-
-	  if(abs((hid).ieta()-(hid_orig).ieta()) > 1 || abs((hid).iphi()-(hid_orig).iphi()) > phi_diff ){
-	      std::cout<<" eta "<<eta<<std::endl;
-	      std::cout<<" hid "<<hid<<std::endl;
-	      std::cout<<" old method "<<hid_orig<<std::endl;
-	  }
-	}
-      }
-    */
-    towers_[hid] += particle.et();      
    }
    
    
    std::auto_ptr<CaloTowerCollection> prod(new CaloTowerCollection());
 
-   for ( std::map< DetId, double >::const_iterator iter = towers_.begin();
+   for ( EtaPhiMap::const_iterator iter = towers_.begin();
 	 iter != towers_.end(); ++iter ){
      
-     CaloTowerDetId newTowerId(iter->first.rawId());
+     EtaPhi ep = iter->first;
      double et = iter->second;
+
+     int ieta = ep.first;
+     int iphi = ep.second;
+
+     CaloTowerDetId newTowerId(ieta,iphi); // totally dummy id
 
      if(et>0){
 
-       GlobalPoint pos =geo_->getGeometry(newTowerId)->getPosition();
-       
-       if(!useHF_ && fabs(pos.eta()) > 3. ) continue;
+       if(!useHF_ && abs(ieta) > 29) continue;
 
        // currently sets et =  pt, mass to zero
        // pt, eta , phi, mass
-       reco::Particle::PolarLorentzVector p4(et,pos.eta(),pos.phi(),0.);
-       
-       CaloTower newTower(newTowerId,et,0,0,0,0,p4,pos,pos);
+       reco::Particle::PolarLorentzVector p4(et,ieta2eta(ieta),iphi2phi(iphi,ieta),0.);
+
+       GlobalPoint dummypoint(p4.x(),p4.y(),p4.z());
+       CaloTower newTower(newTowerId,et,0,0,0,0,p4,dummypoint,dummypoint);
        prod->push_back(newTower);     
      }
    }
@@ -213,63 +186,10 @@ ParticleTowerProducer::beginJob()
   // tower edges from fast sim, used starting at index 30 for the HF
   const double etatow[42] = {0.000, 0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609, 0.696, 0.783, 0.870, 0.957, 1.044, 1.131, 1.218, 1.305, 1.392, 1.479, 1.566, 1.653, 1.740, 1.830, 1.930, 2.043, 2.172, 2.322, 2.500, 2.650, 2.853, 3.000, 3.139, 3.314, 3.489, 3.664, 3.839, 4.013, 4.191, 4.363, 4.538, 4.716, 4.889, 5.191};
   
-  // tower centers derived directly from by looping over HCAL towers and printing out the values, used up until eta = 3 where the HF/Endcap interface becomes problematic
-  const double etacent[40] = {
-    0.0435, // 1
-    0.1305, // 2
-    0.2175, // 3
-    0.3045, // 4
-    0.3915, // 5
-    0.4785, // 6
-    0.5655, // 7
-    0.6525, // 8
-    0.7395, // 9
-    0.8265, // 10
-    0.9135, // 11
-    1.0005, // 12
-    1.0875, // 13
-    1.1745, // 14
-    1.2615, // 15
-    1.3485, // 16
-    1.4355, // 17
-    1.5225, // 18
-    1.6095, // 19
-    1.6965, // 20
-    1.785 , // 21
-    1.88  , // 22
-    1.9865, // 23
-    2.1075, // 24
-    2.247 , // 25
-    2.411 , // 26
-    2.575 , // 27
-    2.759 , // 28
-    2.934 , // 29
-    2.90138,// 29
-    3.04448,// 30 
-    3.21932,// 31
-    3.39462,// 32
-    3.56966,// 33 
-    3.74485,// 34 
-    3.91956,// 35 
-    4.09497,// 36 
-    4.27007,// 37 
-    4.44417,// 38 
-    4.62046 // 39 
-      };
+  for(int i=0;i<42;i++){
+    etaedge[i]=etatow[i];
+  }
 
-  // Use the real towers centrers for the barrel and endcap up to eta=3
-  etaedge[0] = 0.;
-  for(int i=1;i<30;i++){
-    etaedge[i] = (etacent[i-1]-etaedge[i-1])*2.0 + etaedge[i-1];
-    //std::cout<<" i "<<i<<" etaedge "<<etaedge[i]<<std::endl;  
-  }
-  // beyond eta = 3 just use the fast sim values
-  if(useHF_){
-    for(int i=30;i<42;i++){
-      etaedge[i]=etatow[i];
-      //std::cout<<" i "<<i<<" etaedge "<<etaedge[i]<<std::endl;  
-    }
-  }
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
@@ -280,185 +200,10 @@ ParticleTowerProducer::endJob() {
 
 void ParticleTowerProducer::resetTowers(edm::Event& iEvent,const edm::EventSetup& iSetup)
 {
-  
-  std::vector<DetId> alldid =  geo_->getValidDetIds();
 
-  for(std::vector<DetId>::const_iterator did=alldid.begin(); did != alldid.end(); did++){
-    if( (*did).det() == DetId::Hcal ){
-       HcalDetId hid = HcalDetId(*did);
-       if( hid.depth() == 1 ) {
-	 
-	 if(!useHF_){
-	   GlobalPoint pos =geo_->getGeometry(hid)->getPosition();	 
-	   //if((hid).iphi()==1)std::cout<<" ieta "<<(hid).ieta()<<" eta "<<pos.eta()<<" iphi "<<(hid).iphi()<<" phi "<<pos.phi()<<std::endl;
-	   if(fabs(pos.eta())>3.) continue;
-	 }
-	  towers_[(*did)] = 0.;
-       }
-       
-    }
-  }
-
-
-
-
-  //print out tower eta boundaries
-  /*
-  int current_ieta=0;
-  float testphi =0.;
-  for(double testeta=1.7; testeta<=5.4;testeta+=0.00001){
-    HcalDetId hid = getNearestTower(testeta,testphi);
-    if((hid).ieta()!=current_ieta) {
-      std::cout<<" new ieta "<<current_ieta<<" testeta "<<testeta<<std::endl;
-      current_ieta = (hid).ieta();
-    }
-  }
-  */
+  towers_.clear();
 
 }
-
-
-
-
-DetId ParticleTowerProducer::getNearestTower(const reco::PFCandidate & in) const {
-
-  double eta = in.eta();
-  double phi  = in.phi();
-
-  double minDeltaR = 9999;
-
-  std::vector<DetId> alldid =  geo_->getValidDetIds();
-
-  DetId returnId;
-  
-  //int nclosetowers=0;
-
-  for(std::vector<DetId>::const_iterator did=alldid.begin(); did != alldid.end(); did++){
-    if( (*did).det() == DetId::Hcal ){
-
-      HcalDetId hid(*did);
-      
-      // which layer is irrelevant for an eta-phi map, no?
-
-      if( hid.depth() != 1 ) continue;
-
-      GlobalPoint pos =geo_->getGeometry(hid)->getPosition();
-      
-      double hcalEta = pos.eta();
-      double hcalPhi = pos.phi();
-
-      //std::cout<<" transverse distance = "<<sqrt(pos.x()*pos.x()+pos.y()*pos.y())<<std::endl;
-
-      //std::cout<<" ieta "<<(hid).ieta()<<" iphi "<<(hid).iphi()<<" hcalEta "<<hcalEta<<" hcalPhi "<<hcalPhi<<std::endl;
-
-      double deltaR = reco::deltaR(eta,phi,hcalEta,hcalPhi);
-      
-      // need to factor in the size of the tower
-      double towersize = 0.087;
-     
-      int ieta  = (hid).ieta();
-      
-      if(abs(ieta)>21){
-	if(abs(ieta)>29) towersize=0.175;
-	else{
-	  if(abs(ieta)==22) towersize=0.1;
-	  else if(abs(ieta)==23) towersize=0.113;
-	  else if(abs(ieta)==24) towersize=0.129;
-	  else if(abs(ieta)==25) towersize=0.16;
-	  else if(abs(ieta)==26) towersize=0.168;
-	  else if(abs(ieta)==27) towersize=0.15;
-	  else if(abs(ieta)==28) towersize=0.218;
-	  else if(abs(ieta)==29) towersize=0.132;
-	}
-      }
-
-      deltaR /= towersize;
-      //if(deltaR<1/3.) nclosetowers++;
-
-      if(deltaR<minDeltaR){
-	 returnId = DetId(*did);
-	 minDeltaR = deltaR;
-      }
-      
-      //if(abs(eta-hcalEta)<towersize/2. && abs(phi-hcalPhi)<towersize/2.) break;
-    }
-  }
-  //if(nclosetowers>1)std::cout<<"eta "<<eta<<" phi "<<phi<<" minDeltaR "<<minDeltaR<<" nclosetowers "<<nclosetowers<<std::endl;
-  return returnId;
-
-
-}
-
-
-DetId ParticleTowerProducer::getNearestTower(double eta, double phi) const {
-
-  // get closest tower by delta R matching
-  // Now obsolute, instead use faster premade eta-phi grid
-
-  double minDeltaR = 9999;
-
-  std::vector<DetId> alldid =  geo_->getValidDetIds();
-
-  DetId returnId;
-  
-  //int nclosetowers=0;
-
-  for(std::vector<DetId>::const_iterator did=alldid.begin(); did != alldid.end(); did++){
-    if( (*did).det() == DetId::Hcal ){
-
-      HcalDetId hid(*did);
-      
-      // which layer is irrelevant for an eta-phi map, no?
-
-      if( hid.depth() != 1 ) continue;
-
-      GlobalPoint pos =geo_->getGeometry(hid)->getPosition();
-      
-      double hcalEta = pos.eta();
-      double hcalPhi = pos.phi();
-
-      //std::cout<<" transverse distance = "<<sqrt(pos.x()*pos.x()+pos.y()*pos.y())<<std::endl;
-
-      //std::cout<<" ieta "<<(hid).ieta()<<" iphi "<<(hid).iphi()<<" hcalEta "<<hcalEta<<" hcalPhi "<<hcalPhi<<std::endl;
-
-      double deltaR = reco::deltaR(eta,phi,hcalEta,hcalPhi);
-      
-      // need to factor in the size of the tower
-      double towersize = 0.087;
-     
-      int ieta  = (hid).ieta();
-      
-      if(abs(ieta)>21){
-	if(abs(ieta)>29) towersize=0.175;
-	else{
-	  if(abs(ieta)==22) towersize=0.1;
-	  else if(abs(ieta)==23) towersize=0.113;
-	  else if(abs(ieta)==24) towersize=0.129;
-	  else if(abs(ieta)==25) towersize=0.16;
-	  else if(abs(ieta)==26) towersize=0.168;
-	  else if(abs(ieta)==27) towersize=0.15;
-	  else if(abs(ieta)==28) towersize=0.218;
-	  else if(abs(ieta)==29) towersize=0.132;
-	}
-      }
-
-      deltaR /= towersize;
-      //if(deltaR<1/3.) nclosetowers++;
-
-      if(deltaR<minDeltaR){
-	 returnId = DetId(*did);
-	 minDeltaR = deltaR;
-      }
-      
-      //if(abs(eta-hcalEta)<towersize/2. && abs(phi-hcalPhi)<towersize/2.) break;
-    }
-  }
-  //if(nclosetowers>1)std::cout<<"eta "<<eta<<" phi "<<phi<<" minDeltaR "<<minDeltaR<<" nclosetowers "<<nclosetowers<<std::endl;
-  return returnId;
-
-
-}
-
 
 
 
@@ -467,68 +212,70 @@ DetId ParticleTowerProducer::getNearestTower(double eta, double phi) const {
 int ParticleTowerProducer::eta2ieta(double eta) const {
   // binary search in the array of towers eta edges
 
-  int size = 42;
-  if(!useHF_) size = 30;
+  int ieta = 0;
 
-  if(fabs(eta)>etaedge[size-1]) return -1;
-
-  double x = fabs(eta);
-  int curr = size / 2;
-  int step = size / 4;
-  int iter;
-  int prevdir = 0; 
-  int actudir = 0; 
-
-  for (iter = 0; iter < size ; iter++) {
-
-    if( curr >= size || curr < 1 )
-      std::cout <<  " ParticleTowerProducer::eta2ieta - wrong current index = "
-		<< curr << " !!!" << std::endl;
-
-    if ((x <= etaedge[curr]) && (x > etaedge[curr-1])) break;
-    prevdir = actudir;
-    if(x > etaedge[curr]) {actudir =  1;}
-    else {actudir = -1;}
-    if(prevdir * actudir < 0) { if(step > 1) step /= 2;}
-    curr += actudir * step;
-    if(curr > size) curr = size;
-    else { if(curr < 1) {curr = 1;}}
-
-    /*
-    std::cout << " HCALProperties::eta2ieta  end of iter." << iter 
-          << " curr, etaedge[curr-1], etaedge[curr] = "
-	        << curr << " " << etaedge[curr-1] << " " << etaedge[curr] << std::endl;
-    */
-    
+  while(fabs(eta) > etaedge[ieta]){
+    ++ieta;  
   }
 
-  /*
-  std::cout << " HCALProperties::eta2ieta  for input x = " << x 
-      << "  found index = " << curr-1
-          << std::endl;
-  */
-  
-  return curr;
+  if(eta < 0) ieta = -ieta;
+  return ieta;
+
 }
 
 int ParticleTowerProducer::phi2iphi(double phi, int ieta) const {
   
   if(phi<0) phi += 2.*PI;
   else if(phi> 2.*PI) phi -= 2.*PI;
-  
-  int iphi = (int) TMath::Ceil(phi/2.0/PI*72.);
-  // take into account larger granularity in endcap (x2) and at the end of the HF (x4)
-  if(abs(ieta)>20){
-    if(abs(ieta)<40) iphi -= (iphi+1)%2;
-    else {
-      iphi -= (iphi+1)%4;
-      if(iphi==-1) iphi=71;
-      }
-  }
-  
+
+  int Nphi = 72;
+  int n = 1;
+  if(abs(ieta)>20) n = 2;
+  if(abs(ieta)>=40) n = 4;
+
+  int iphi = (int) TMath::Ceil(phi/2.0/PI*Nphi/n);
+
+  iphi = n * (iphi - 1) + 1;
+
   return iphi;
 
 }
+
+double ParticleTowerProducer::iphi2phi(int iphi, int ieta) const {
+
+
+  double phi = 0;
+  int Nphi = 72;
+
+  int n = 1;
+  if(abs(ieta)>20) n = 2;
+  if(abs(ieta)>=40) n = 4;
+
+  int myphi = (iphi - 1)/n + 1;
+
+  phi = 2.*PI*(myphi-0.5)/Nphi*n;
+  while(phi > PI) phi -= 2.*PI;
+
+  return phi;
+
+}
+
+
+
+double ParticleTowerProducer::ieta2eta(int ieta) const {
+
+  int sign = 1;
+  if(ieta < 0){
+    sign = -1;
+    ieta = -ieta;
+  }
+
+  double eta = sign*(etaedge[ieta] + etaedge[ieta-1])/2.;
+  return eta;
+}
+
+
+
 
     //define this as a plug-in
 DEFINE_FWK_MODULE(ParticleTowerProducer);

--- a/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/ParticleTowerProducer.h
@@ -42,15 +42,17 @@ class ParticleTowerProducer : public edm::EDProducer {
   //  uint32_t denseIndex(int ieta, int iphi, double eta) const;
   int eta2ieta(double eta) const;
   int phi2iphi(double phi, int ieta) const;
-  
+  double ieta2eta(int ieta) const;
+  double iphi2phi(int iphi, int ieta) const;  
   // ----------member data ---------------------------
 
   edm::EDGetTokenT<reco::PFCandidateCollection> src_;
   bool useHF_;
   
-  std::map<DetId,double> towers_;
-  
-  
+  typedef std::pair<int,int> EtaPhi;
+  typedef std::map<EtaPhi,double> EtaPhiMap;
+  EtaPhiMap towers_;
+   
   double PI;
   TRandom* random_;
   

--- a/RecoHI/HiJetAlgos/src/PuWithNtuple.cc
+++ b/RecoHI/HiJetAlgos/src/PuWithNtuple.cc
@@ -1,0 +1,409 @@
+#include "RecoHI/HiJetAlgos/interface/PuWithNtuple.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+using namespace std;
+
+PuWithNtuple::PuWithNtuple(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) : 
+  PileUpSubtractor(iConfig, std::move(iC)),
+  sumRecHits_(iConfig.getParameter<bool>("sumRecHits")),
+  dropZeroTowers_(iConfig.getUntrackedParameter<bool>("dropZeroTowers",true))
+{
+  
+  if(iConfig.exists("minimumTowersFraction")){
+    minimumTowersFraction_ = iConfig.getParameter<double>("minimumTowersFraction");
+    cout<<"LIMITING THE MINIMUM TOWERS FRACTION TO : "<<minimumTowersFraction_<<endl;
+  }else{
+    minimumTowersFraction_ = 0;
+    cout<<"ATTENTION - NOT LIMITING THE MINIMUM TOWERS FRACTION"<<endl;
+  }
+
+  Neta_ = 82;
+
+  tree_ = fs_->make<TTree>("puTree","");
+
+  tree_->Branch("nref",&nref,"nref/I");
+  tree_->Branch("jteta",jteta,"jteta[nref]/F");
+  tree_->Branch("jtphi",jtphi,"jtphi[nref]/F");
+  tree_->Branch("jtpt",jtpt,"jtpt[nref]/F");
+  tree_->Branch("jtexngeom",jtexngeom,"jtexngeom[nref]/I");
+  tree_->Branch("jtexntow",jtexntow,"jtexntow[nref]/I");
+
+  tree_->Branch("jtexpt",jtexpt,"jtexpt[nref]/F");
+  tree_->Branch("jtpu",jtpu,"jtpu[nref]/F");
+
+  tree_->Branch("ngeom",vngeom,"ngeom[82]/I");
+  tree_->Branch("ntow",vntow,"ntow[82]/I");
+
+  tree_->Branch("eta",veta,"eta[82]/F");
+  tree_->Branch("ieta",vieta,"ieta[82]/I");
+
+  tree_->Branch("mean0",vmean0,"mean0[82]/F");
+  tree_->Branch("rms0",vrms0,"rms0[82]/F");
+
+  tree_->Branch("mean1",vmean1,"mean1[82]/F");
+  tree_->Branch("rms1",vrms1,"rms1[82]/F");
+
+  const double etatow[42] = {0.000, 0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609, 0.696, 0.783, 0.870, 0.957, 1.044, 1.131, 1.218, 1.305, 1.392, 1.479, 1.566, 1.653, 1.740, 1.830, 1.930, 2.043, 2.172, 2.322, 2.500, 2.650, 2.853, 3.000, 3.139, 3.314, 3.489, 3.664, 3.839, 4.013, 4.191, 4.363, 4.538, 4.716, 4.889, 5.191};
+
+  for(int i=0;i<42;i++){
+    etaedge[i]=etatow[i];
+  }
+
+}
+
+
+void PuWithNtuple::rescaleRMS(double s){
+   for ( std::map<int, double>::iterator iter = esigma_.begin();
+	 iter != esigma_.end(); ++iter ){
+      iter->second = s*(iter->second);
+   }
+}
+
+
+void PuWithNtuple::offsetCorrectJets()
+{
+
+  LogDebug("PileUpSubtractor")<<"The subtractor correcting jets...\n";
+  jetOffset_.clear();
+
+  using namespace reco;
+  
+  (*fjInputs_) = fjOriginalInputs_;
+  rescaleRMS(nSigmaPU_);
+  subtractPedestal(*fjInputs_);
+  const fastjet::JetDefinition& def = *fjJetDefinition_;
+  if ( !doAreaFastjet_ && !doRhoFastjet_) {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequence( *fjInputs_, def ) );
+  } else {
+    fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceArea( *fjInputs_, def, *fjActiveArea_ ) );
+  }
+  
+  (*fjJets_) = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
+  
+  jetOffset_.reserve(fjJets_->size());
+  
+  vector<fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin (),
+    jetsEnd = fjJets_->end();
+  for (; pseudojetTMP != jetsEnd; ++pseudojetTMP) {
+    
+    int ijet = pseudojetTMP - fjJets_->begin();
+    jetOffset_[ijet] = 0;
+    
+    std::vector<fastjet::PseudoJet> towers =
+      sorted_by_pt(pseudojetTMP->constituents());
+    
+    double newjetet = 0.;
+    for(vector<fastjet::PseudoJet>::const_iterator ito = towers.begin(),
+	  towEnd = towers.end();
+	ito != towEnd;
+	++ito)
+      {
+	const reco::CandidatePtr& originalTower = (*inputs_)[ito->user_index()];
+	int it = ieta( originalTower );
+	double Original_Et = originalTower->et();
+	double etnew = Original_Et - (*emean_.find(it)).second - (*esigma_.find(it)).second;
+	if(etnew < 0.) etnew = 0;
+	newjetet = newjetet + etnew;
+	jetOffset_[ijet] += Original_Et - etnew;
+      }
+  }
+}
+
+void PuWithNtuple::subtractPedestal(vector<fastjet::PseudoJet> & coll)
+{
+
+   LogDebug("PileUpSubtractor")<<"The subtractor subtracting pedestals...\n";
+
+   int it = -100;
+
+   vector<fastjet::PseudoJet> newcoll;
+
+   for (vector<fastjet::PseudoJet>::iterator input_object = coll.begin (),
+	   fjInputsEnd = coll.end(); 
+	input_object != fjInputsEnd; ++input_object) {
+    
+      reco::CandidatePtr const & itow =  (*inputs_)[ input_object->user_index() ];
+    
+      it = ieta( itow );
+      iphi( itow );
+    
+      double Original_Et = itow->et();
+      if(sumRecHits_){
+         Original_Et = getEt(itow);
+      }
+
+      double etnew = Original_Et - (*(emean_.find(it))).second - (*(esigma_.find(it))).second;
+      float mScale = etnew/input_object->Et(); 
+      if(etnew < 0.) mScale = 0.;
+    
+      math::XYZTLorentzVectorD towP4(input_object->px()*mScale, input_object->py()*mScale,
+				     input_object->pz()*mScale, input_object->e()*mScale);
+    
+      int index = input_object->user_index();
+      input_object->reset_momentum ( towP4.px(),
+				     towP4.py(),
+				     towP4.pz(),
+				     towP4.energy() );
+      input_object->set_user_index(index);
+
+      if(etnew > 0. && dropZeroTowers_) newcoll.push_back(*input_object);
+   }
+
+   if(dropZeroTowers_) coll = newcoll;
+
+}
+
+void PuWithNtuple::calculatePedestal( vector<fastjet::PseudoJet> const & coll )
+{
+   LogDebug("PileUpSubtractor")<<"The subtractor calculating pedestals...\n";
+
+   map<int,double> emean2;
+   map<int,int> ntowers;
+    
+   int ietaold = -10000;
+   int ieta0 = -100;
+   
+   // Initial values for emean_, emean2, esigma_, ntowers
+
+
+   for(int vi = 0; vi < Neta_; ++vi){
+     int it = vi+1;
+     if(it > Neta_/2) it = vi - Neta_;
+
+     int sign = 1;
+     if(it < 0){
+       sign = -1;
+     }
+     
+     vieta[vi] = it;
+     veta[vi] = sign*(etaedge[abs(it)] + etaedge[abs(it)-1])/2.;
+
+     vngeom[vi] = -99;
+     vntow[vi] = -99;
+
+     vmean1[vi] = -99;
+     vrms1[vi] = -99;
+
+     if((*(ntowersWithJets_.find(it))).second == 0){
+       vmean0[vi] = -99;
+       vrms0[vi] = -99;
+     }
+
+   }
+
+
+   for(int i = ietamin_; i < ietamax_+1; i++)
+      {
+	 emean_[i] = 0.;
+	 emean2[i] = 0.;
+	 esigma_[i] = 0.;
+	 ntowers[i] = 0;
+      }
+    
+   for (vector<fastjet::PseudoJet>::const_iterator input_object = coll.begin (),
+	   fjInputsEnd = coll.end();  
+	input_object != fjInputsEnd; ++input_object) {
+
+      const reco::CandidatePtr & originalTower=(*inputs_)[ input_object->user_index()];
+      ieta0 = ieta( originalTower );
+      double Original_Et = originalTower->et();
+      if(sumRecHits_){
+         Original_Et = getEt(originalTower);
+      }
+
+      if( ieta0-ietaold != 0 )
+	 {
+	    emean_[ieta0] = emean_[ieta0]+Original_Et;
+	    emean2[ieta0] = emean2[ieta0]+Original_Et*Original_Et;
+	    ntowers[ieta0] = 1;
+	    ietaold = ieta0;
+	 }
+      else
+	 {
+	    emean_[ieta0] = emean_[ieta0]+Original_Et;
+	    emean2[ieta0] = emean2[ieta0]+Original_Et*Original_Et;
+	    ntowers[ieta0]++;
+	 }
+
+   }
+
+   for(map<int,int>::const_iterator gt = geomtowers_.begin(); gt != geomtowers_.end(); gt++)    
+      {
+
+	 int it = (*gt).first;
+	 int vi = it-1;
+	 if(it < 0) vi = Neta_ + it;
+       
+	 double e1 = (*(emean_.find(it))).second;
+	 double e2 = (*emean2.find(it)).second;
+	 int nt = (*gt).second - (*(ntowersWithJets_.find(it))).second;
+
+	 if(vi < Neta_){
+	   vngeom[vi] = (*gt).second;
+	   vntow[vi] = nt;
+	 }
+
+	 LogDebug("PileUpSubtractor")<<" ieta : "<<it<<" number of towers : "<<nt<<" e1 : "<<e1<<" e2 : "<<e2<<"\n";
+        
+	 if(nt > 0) {
+	    emean_[it] = e1/nt;
+	    double eee = e2/nt - e1*e1/(nt*nt);    
+	    if(eee<0.) eee = 0.;
+	    esigma_[it] = nSigmaPU_*sqrt(eee);
+
+	    if(vi < Neta_){
+	      vmean1[vi] = emean_[it];
+	      vrms1[vi] = esigma_[it];
+	      if(vngeom[vi] == vntow[vi]){
+		vmean0[vi] = emean_[it];
+		vrms0[vi] = esigma_[it];
+	      }
+	    }
+	 }
+	 else
+	    {
+	       emean_[it] = 0.;
+	       esigma_[it] = 0.;
+	    }
+	 LogDebug("PileUpSubtractor")<<" ieta : "<<it<<" Pedestals : "<<emean_[it]<<"  "<<esigma_[it]<<"\n";
+      }
+}
+
+
+void PuWithNtuple::calculateOrphanInput(vector<fastjet::PseudoJet> & orphanInput)
+{
+
+  LogDebug("PileUpSubtractor")<<"The subtractor calculating orphan input...\n";
+
+  (*fjInputs_) = fjOriginalInputs_;
+
+  vector<int> jettowers; // vector of towers indexed by "user_index"
+  vector<pair<int,int> >  excludedTowers; // vector of excluded ieta, iphi values
+
+  vector <fastjet::PseudoJet>::iterator pseudojetTMP = fjJets_->begin (),
+    fjJetsEnd = fjJets_->end();
+
+  //  cout<<"First iteration found N jets : "<<fjJets_->size()<<endl;
+
+  nref = 0;
+
+  for (; pseudojetTMP != fjJetsEnd ; ++pseudojetTMP) {
+
+    //    cout<<"Jet with pt "<<pseudojetTMP->perp()<<" to be excluded"<<endl;
+
+
+    if(nref < 200){
+      jtexngeom[nref] = 0;
+      jtexntow[nref] = 0;      
+      jtexpt[nref] = 0;
+      jtpt[nref] = pseudojetTMP->perp();
+      jteta[nref] = pseudojetTMP->eta();
+      jtphi[nref] = pseudojetTMP->phi();
+    }
+
+    if(pseudojetTMP->perp() < puPtMin_) continue;
+
+    //    cout<<"Looping over towers..."<<endl;
+
+    // find towers within radiusPU_ of this jet
+    for(vector<HcalDetId>::const_iterator im = allgeomid_.begin(); im != allgeomid_.end(); im++)
+      {
+	double dr = reco::deltaR(geo_->getPosition((DetId)(*im)),(*pseudojetTMP));
+        vector<pair<int,int> >::const_iterator exclude = find(excludedTowers.begin(),excludedTowers.end(),pair<int,int>(im->ieta(),im->iphi()));
+        if( dr < radiusPU_
+            &&
+            exclude == excludedTowers.end()
+            &&
+            (geomtowers_[(*im).ieta()] - ntowersWithJets_[(*im).ieta()]) > minimumTowersFraction_*(geomtowers_[(*im).ieta()])) {
+          ntowersWithJets_[(*im).ieta()]++;
+
+	  //          cout<<"At ieta : "<<(*im).ieta()<<" -  excluded so far : "<<ntowersWithJets_[(*im).ieta()]<<" out of max "<<geomtowers_[(*im).ieta()]<<endl;
+          excludedTowers.push_back(pair<int,int>(im->ieta(),im->iphi()));
+
+	  if(nref < 200) jtexngeom[nref]++;  
+        }
+      }
+
+    vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(),
+      fjInputsEnd = fjInputs_->end();
+
+    for (; it != fjInputsEnd; ++it ) {
+      int index = it->user_index();
+      int ie = ieta((*inputs_)[index]);
+      int ip = iphi((*inputs_)[index]);
+      vector<pair<int,int> >::const_iterator exclude = find(excludedTowers.begin(),excludedTowers.end(),pair<int,int>(ie,ip));
+      if(exclude != excludedTowers.end()) {
+        jettowers.push_back(index);
+	//        cout<<"tower with index "<<index<<" excluded."<<endl;
+	//        cout<<"jettowers now : "<<jettowers.size()<<endl;
+      }
+    } // initial input collection
+
+
+    for (it = fjInputs_->begin(); it != fjInputsEnd; ++it ) {
+      int index = it->user_index();
+      const reco::CandidatePtr& originalTower = (*inputs_)[index];
+      double dr = reco::deltaR((*it),(*pseudojetTMP));
+
+      if(dr < radiusPU_){
+	if(nref < 200){
+	  jtexntow[nref]++;
+	  jtexpt[nref] += originalTower->pt();
+	}
+      }
+
+    }
+
+
+
+    if(nref < 200) nref++;
+  } // pseudojets
+
+  //
+  // Create a new collections from the towers not included in jets
+  //
+
+  for(vector<fastjet::PseudoJet>::const_iterator it = fjInputs_->begin(),
+        fjInputsEnd = fjInputs_->end(); it != fjInputsEnd; ++it ) {
+    int index = it->user_index();
+    vector<int>::const_iterator itjet = find(jettowers.begin(),jettowers.end(),index);
+    if( itjet == jettowers.end() ){
+      const reco::CandidatePtr& originalTower = (*inputs_)[index];
+      fastjet::PseudoJet orphan(originalTower->px(),originalTower->py(),originalTower->pz(),originalTower->energy());
+      orphan.set_user_index(index);
+
+      orphanInput.push_back(orphan);
+    }
+  }
+
+  //  cout<<"Number of jets : "<<nref<<endl;
+
+  tree_->Fill();
+
+}
+
+
+
+
+
+
+
+
+
+double PuWithNtuple::getEt(const reco::CandidatePtr & in) const {
+   const CaloTower* ctc = dynamic_cast<const CaloTower*>(in.get());
+   const GlobalPoint& pos=geo_->getPosition(ctc->id());
+   double energy = ctc->emEnergy() + ctc->hadEnergy();
+   double et = energy*sin(pos.theta());
+   return et;
+}
+
+double PuWithNtuple::getEta(const reco::CandidatePtr & in) const {
+   const CaloTower* ctc = dynamic_cast<const CaloTower*>(in.get());
+   const GlobalPoint& pos=geo_->getPosition(ctc->id());
+   double eta = pos.eta();
+   return eta;
+}


### PR DESCRIPTION
Describe the Pull-Request:
- PF-towering changed to use fixed grid instead of geometry.
- Pu algorithm possibility of limiting the fraction of excluded towers (off by default, switch to 0.5 suggested)
- Pu-plugin which is exact copy of standard Pu but also generates an ntuple of the jet and tower info in first iteration

Slides in : https://twiki.cern.ch/twiki/pub/CMS/HiJetReco2015/algo_pu_yetkin_20160428.pdf

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
