### PR TITLE
use pp jec for pPb

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
@@ -748,6 +748,27 @@ def overrideJEC_MC_Pbp5020(process):
         ])
     return process
 
+####
+####
+
+def overrideJEC_pPb8TeV(process):
+    process.GlobalTag.toGet.extend([
+## no PU
+       cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                 tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4Calo"),
+                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+                 label = cms.untracked.string("AK4Calo")
+             ),
+        cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                 tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4PF"),
+                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+                 label = cms.untracked.string("AK4PF")
+             ),
+    ])
+    return process
+
+####
+####
 
 def overrideJEC_pp5020(process):
     process.load("CondCore.DBCommon.CondDBCommon_cfi")

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPPb.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_pp_cff import *
+
+from HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pPb_jec_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.ak4CaloJetSequence_pPb_jec_cff import *
+
+ak4PFJetAnalyzer.doSubEvent = True
+ak4CaloJetAnalyzer.doSubEvent = True
+
+from RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets
+ak5GenJets = ak5GenJets
+ak4GenJets = ak5GenJets.clone(rParam = 0.4)
+from RecoJets.Configuration.GenJetParticles_cff import *
+
+akGenJets = cms.Sequence(
+    genParticlesForJets +
+    ak4GenJets
+)
+
+from HeavyIonsAnalysis.JetAnalysis.makePartons_cff import *
+highPurityTracks = cms.EDFilter("TrackSelector",
+                                src = cms.InputTag("generalTracks"),
+                                cut = cms.string('quality("highPurity")')
+)
+
+jetSequences = cms.Sequence(
+    akGenJets +
+#    ppReRecoPFJets +
+#    ppReRecoCaloJets +
+    makePartons +
+    highPurityTracks +
+    ak4CaloJets +
+    ak4PFJetSequence +
+    ak4CaloJetSequence 
+    )

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for system in PbPb pp
+for system in PbPb pp pPb
 do
     for sample in data jec mc mb
     do
@@ -18,7 +18,11 @@ do
                         for object in PF Calo
                         do
 			    # no Cs Calo or pp jets
-			    if ( [ $object == "Calo" ] || [ $system == "pp" ] ) && ( [ $sub == "Cs" ] ) ; then
+			    
+                            if( [ $system == "pPb" ] ) && ( [ $radius -ne 4 ] || [ $sample != "jec" ] || [ $sub != "NONE" ] || [ $groom != "NONE" ] ) ; then 
+                                continue
+                            fi
+                            if ( [ $object == "Calo" ] || [ $system == "pp" ] ) && ( [ $sub == "Cs" ] ) ; then
 			        continue
 			    fi
                             subt=$sub
@@ -57,7 +61,7 @@ do
 			    jetcorrectionlevels="\'L2Relative\',\'L3Absolute\'"
                             #echo "" > $algo$subt$radius${object}JetSequence_${system}_${sample}_cff.py
                             
-                            if [ $system == "pp" ]; then
+                            if [ $system == "pp" ] || [ $system == "pPb" ]; then
                                 #corrlabel="_generalTracks"
                                 tracks="generalTracks"
 			        vertex="offlinePrimaryVertices"
@@ -74,11 +78,13 @@ do
                                 ismc="True"
                             fi
 
-                            if [ $system == "pp" ]; then
+                            if [ $system == "pp" ] || [ $system == "pPb" ]; then
                                 genjets="GenJets"
                                 matchGenjets="GenJets"
                             fi
-
+                            if [ $system == "pPb" ]; then 
+                                corrlabel=""
+                            fi
 			    if [ $sub == "Pu" ]; then
 			        corrname=`echo ${algo} | sed 's/\(.*\)/\U\1/'`${sub}${radius}${object}${corrlabel}
 			    else 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
@@ -1,0 +1,207 @@
+### HiForest Configuration
+# Collisions: pp
+# Type: MC
+# Input: AOD
+
+import FWCore.ParameterSet.Config as cms
+process = cms.Process('HiForest')
+process.options = cms.untracked.PSet()
+
+#####################################################################################
+# HiForest labelling info
+#####################################################################################
+
+process.load("HeavyIonsAnalysis.JetAnalysis.HiForest_cff")
+process.HiForest.inputLines = cms.vstring("HiForest V3",)
+import subprocess
+version = subprocess.Popen(["(cd $CMSSW_BASE/src && git describe --tags)"], stdout=subprocess.PIPE, shell=True).stdout.read()
+
+if version == '':
+    version = 'no git info'
+process.HiForest.HiForestVersion = cms.string(version)
+
+#####################################################################################
+# Input source
+#####################################################################################
+
+process.source = cms.Source("PoolSource",
+                            duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
+                            fileNames = cms.untracked.vstring(
+                                "file:step3_MinBias_pPb_RAW2DIGI_L1Reco_RECO_1.root"
+                            )
+)
+
+# Number of events we want to process, -1 = all events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10))
+
+
+#####################################################################################
+# Load Global Tag, Geometry, etc.
+#####################################################################################
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.Geometry.GeometryDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load("CondCore.DBCommon.CondDBCommon_cfi")
+ 
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_miniAODv2_v1', '')
+process.HiForest.GlobalTagLabel = process.GlobalTag.globaltag
+
+
+# Customization
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_pPb8TeV
+process = overrideJEC_pPb8TeV(process)
+
+#####################################################################################
+# Define tree output
+#####################################################################################
+
+process.TFileService = cms.Service("TFileService",
+                                   fileName=cms.string("HiForestAOD.root"))
+
+#####################################################################################
+# Additional Reconstruction and Analysis: Main Body
+#####################################################################################
+
+####################################################################################
+
+#############################
+# Jets
+#############################
+
+process.load("HeavyIonsAnalysis.JetAnalysis.FullJetSequence_JECPPb")
+# Use this version for JEC
+#process.load("HeavyIonsAnalysis.JetAnalysis.FullJetSequence_JECPP")
+
+#####################################################################################
+
+############################
+# Event Analysis
+############################
+process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cff')
+process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi') #use data version to avoid PbPb MC
+process.hiEvtAnalyzer.Vertex = cms.InputTag("offlinePrimaryVertices")
+process.hiEvtAnalyzer.doCentrality = cms.bool(False)
+process.hiEvtAnalyzer.doEvtPlane = cms.bool(False)
+process.hiEvtAnalyzer.doMC = cms.bool(True) #general MC info
+process.hiEvtAnalyzer.doHiMC = cms.bool(False) #HI specific MC info
+
+process.load('HeavyIonsAnalysis.JetAnalysis.HiGenAnalyzer_cfi')
+process.HiGenParticleAna.genParticleSrc = cms.untracked.InputTag("genParticles")
+process.HiGenParticleAna.doHI = False
+process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cff')
+process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_pp_cfi")
+process.pfcandAnalyzer.skipCharged = False
+process.pfcandAnalyzer.pfPtMin = 0
+process.pfcandAnalyzer.pfCandidateLabel = cms.InputTag("particleFlow")
+process.pfcandAnalyzer.doVS = cms.untracked.bool(False)
+process.pfcandAnalyzer.doUEraw_ = cms.untracked.bool(False)
+process.pfcandAnalyzer.genLabel = cms.InputTag("genParticles")
+
+#####################################################################################
+
+#########################
+# Track Analyzer
+#########################
+process.load('HeavyIonsAnalysis.JetAnalysis.ExtraTrackReco_cff')
+process.load('HeavyIonsAnalysis.JetAnalysis.TrkAnalyzers_cff')
+
+# Use this instead for track corrections
+## process.load('HeavyIonsAnalysis.JetAnalysis.TrkAnalyzers_Corr_cff')
+
+#####################################################################################
+
+#####################
+# photons
+######################
+process.load('HeavyIonsAnalysis.PhotonAnalysis.ggHiNtuplizer_cfi')
+process.ggHiNtuplizer.gsfElectronLabel   = cms.InputTag("gedGsfElectrons")
+process.ggHiNtuplizer.recoPhotonHiIsolationMap = cms.InputTag('photonIsolationHIProducerpp')
+process.ggHiNtuplizer.VtxLabel           = cms.InputTag("offlinePrimaryVertices")
+process.ggHiNtuplizer.particleFlowCollection = cms.InputTag("particleFlow")
+process.ggHiNtuplizer.doVsIso            = cms.bool(False)
+process.ggHiNtuplizer.doElectronVID      = cms.bool(True)
+process.ggHiNtuplizerGED = process.ggHiNtuplizer.clone(recoPhotonSrc = cms.InputTag('gedPhotons'),
+                                                       recoPhotonHiIsolationMap = cms.InputTag('photonIsolationHIProducerppGED'))
+
+####################################################################################
+#####################
+# Electron ID
+#####################
+
+from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
+# turn on VID producer, indicate data format to be processed
+# DataFormat.AOD or DataFormat.MiniAOD
+dataFormat = DataFormat.AOD
+switchOnVIDElectronIdProducer(process, dataFormat)
+
+# define which IDs we want to produce. Check here https://twiki.cern.ch/twiki/bin/viewauth/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_for_7_4
+my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff']
+
+#add them to the VID producer
+for idmod in my_id_modules:
+    setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
+#####################################################################################
+
+#########################
+# Main analysis list
+#########################
+process.ana_step = cms.Path(process.hltanalysis *
+                            process.hiEvtAnalyzer *
+                            process.HiGenParticleAna*
+                            process.jetSequences +
+                            process.egmGsfElectronIDSequence + #Should be added in the path for VID module
+                            process.ggHiNtuplizer +
+                            process.ggHiNtuplizerGED +
+                            process.pfcandAnalyzer +
+                            process.HiForest +
+			    process.trackSequencesPP +
+                            process.runAnalyzer
+)
+
+#####################################################################################
+
+#########################
+# Event Selection
+#########################
+
+process.load('HeavyIonsAnalysis.JetAnalysis.EventSelection_cff')
+process.pHBHENoiseFilterResultProducer = cms.Path( process.HBHENoiseFilterResultProducer )
+process.HBHENoiseFilterResult = cms.Path(process.fHBHENoiseFilterResult)
+process.HBHENoiseFilterResultRun1 = cms.Path(process.fHBHENoiseFilterResultRun1)
+process.HBHENoiseFilterResultRun2Loose = cms.Path(process.fHBHENoiseFilterResultRun2Loose)
+process.HBHENoiseFilterResultRun2Tight = cms.Path(process.fHBHENoiseFilterResultRun2Tight)
+process.HBHEIsoNoiseFilterResult = cms.Path(process.fHBHEIsoNoiseFilterResult)
+
+process.PAprimaryVertexFilter = cms.EDFilter("VertexSelector",
+    src = cms.InputTag("offlinePrimaryVertices"),
+    cut = cms.string("!isFake && abs(z) <= 25 && position.Rho <= 2 && tracksSize >= 2"),
+    filter = cms.bool(True), # otherwise it won't filter the events
+)
+
+process.NoScraping = cms.EDFilter("FilterOutScraping",
+ applyfilter = cms.untracked.bool(True),
+ debugOn = cms.untracked.bool(False),
+ numtrack = cms.untracked.uint32(10),
+ thresh = cms.untracked.double(0.25)
+)
+
+process.pPAprimaryVertexFilter = cms.Path(process.PAprimaryVertexFilter)
+process.pBeamScrapingFilter=cms.Path(process.NoScraping)
+
+process.load("HeavyIonsAnalysis.VertexAnalysis.PAPileUpVertexFilter_cff")
+
+process.pVertexFilterCutG = cms.Path(process.pileupVertexFilterCutG)
+process.pVertexFilterCutGloose = cms.Path(process.pileupVertexFilterCutGloose)
+process.pVertexFilterCutGtight = cms.Path(process.pileupVertexFilterCutGtight)
+process.pVertexFilterCutGplus = cms.Path(process.pileupVertexFilterCutGplus)
+process.pVertexFilterCutE = cms.Path(process.pileupVertexFilterCutE)
+process.pVertexFilterCutEandG = cms.Path(process.pileupVertexFilterCutEandG)
+
+process.pAna = cms.EndPath(process.skimanalysis)
+
+# Customization


### PR DESCRIPTION
Describe the Pull-Request:
Made a forest config for pPb using using pp JEC, requires GT and a new override JEC. For the moment only ak4Calo and ak4PF are available. The makeJetSequences.sh is changed it makes two new python files, ak4CaloJetSequence_pPb_jec_cff.py and ak4PFJetSequence_pPb_jec_cff.py. I didn't add those python files hoping they will be generated automatically. 

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.

@luck @mverwe 
