### PR TITLE
consumes migration for RecHitTreeProducer

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
@@ -27,7 +27,7 @@ process.HiForest.HiForestVersion = cms.string(version)
 process.source = cms.Source("PoolSource",
                             duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
                             fileNames = cms.untracked.vstring(
-                                "file:step3_MinBias_pPb_RAW2DIGI_L1Reco_RECO_1.root"
+				"root://cms-xrd-global.cern.ch//store/himc/pPb816Summer16DR/ReggeGribovPartonMC_EposLHC_pPb_4080_4080/AODSIM/80X_mcRun2_asymptotic_v15-v1/100000/003E9BF0-7979-E611-B43E-000E1EB004E0.root"
                             )
 )
 
@@ -146,6 +146,16 @@ my_id_modules = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElect
 for idmod in my_id_modules:
     setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 #####################################################################################
+#####################
+# Rechit analyzer
+#####################
+process.load('HeavyIonsAnalysis.JetAnalysis.rechitanalyzer_pp_cfi')
+process.rechitanalyzer.doVS = cms.untracked.bool(False)
+process.rechitanalyzer.doEcal = cms.untracked.bool(False)
+process.rechitanalyzer.doHcal = cms.untracked.bool(False)
+process.rechitanalyzer.doHF = cms.untracked.bool(False)
+process.rechitanalyzer.JetSrc = cms.untracked.InputTag("ak4CaloJets")
+process.pfTowers.JetSrc = cms.untracked.InputTag("ak4CaloJets")
 
 #########################
 # Main analysis list
@@ -160,7 +170,8 @@ process.ana_step = cms.Path(process.hltanalysis *
                             process.pfcandAnalyzer +
                             process.HiForest +
 			    process.trackSequencesPP +
-                            process.runAnalyzer
+                            process.runAnalyzer +
+                            process.rechitanalyzer
 )
 
 #####################################################################################


### PR DESCRIPTION
Describe the Pull-Request:
switch
from edm::InputTag to edm::EDGetTokenT
from getByLabel to getByToken
use "consumes" when getting parameters

Some edm::InputTag instances used to get multiple objects. Make sure one edm::EDGetTokenT instance reads one object, eg.
-  srcVor_ = iConfig.getParameteredm::InputTag("bkg");
-  srcVor_backgrounds_ = consumesreco::VoronoiMap (iConfig.getParameteredm::InputTag("bkg"));
-  srcVor_vn_ = consumesstd::vector<float> (iConfig.getParameteredm::InputTag("bkg"));

Details :
https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMGetDataFromEvent#Registering_for_data_access

the reason for the switch is the error below which shows up starting from CMSSW_8

----- Begin Fatal Exception 20-Oct-2016 14:53:04 CEST-----------------------
An exception of category 'GetByLabelWithoutRegistration' occurred while
  [0] Processing run: 1 lumi: 1 event: 1
  [1] Running path 'ana_step'
  [2] Calling event method for module RecHitTreeProducer/'rechitanalyzer'
Exception Message:
::getByLabel without corresponding call to consumes or mayConsumes for this module.
 type: std::vectorreco::Vertex
 module label: offlinePrimaryVerticesWithBS
 product instance name: ''
 process name: ''
----- End Fatal Exception -------------------------------------------------

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@mverwe @dgulhan @kurtejung @mandrenguyen @cfmcginn 
