### PR TITLE
adding pPb 80X hlt object implementation

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/python/hltobject_pPb_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hltobject_pPb_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+hltobject = cms.EDAnalyzer("TriggerObjectAnalyzer",
+                           processName = cms.string("HLT"),
+                           treeName = cms.string("JetTriggers"),
+                           loadTriggersFromHLT = cms.untracked.bool(True),
+			   triggerNames = cms.vstring(),
+                           triggerResults = cms.InputTag("TriggerResults","","HLT"),
+                           triggerEvent   = cms.InputTag("hltTriggerSummaryAOD","","HLT")
+)


### PR DESCRIPTION
Describe the Pull-Request:
Adding pPb hlt object implementation - code now pulls all triggers for hltobject tree from HLTInfo object, unless user specifies specific desired triggers in the cfi file.

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No
(passes pPb and pp tests - PbPb tests fail for other reasons)

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@mverwe 
