### PR TITLE
Added Initial L1 Decisions to HLTStage2Info

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/HLTBitAnalyzer.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTBitAnalyzer.h
@@ -100,5 +100,6 @@ private:
   TFile* m_file; // pointer to Histogram file
   bool _UseTFileService;
   bool _UseL1Stage2;
+  bool _getL1InfoFromEventSetup;
 
 };

--- a/HLTrigger/HLTanalyzers/interface/HLTStage2Info.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTStage2Info.h
@@ -91,11 +91,12 @@ private:
   int   *l1stage2egbx, *l1stage2mubx, *l1stage2jtbx, *l1stage2taubx, *l1stage2etsbx, *l1stage2ctbx;
   int   L1TEvtCnt,HltEvtCnt,nl1stage2eg,nl1stage2mu,nl1stage2dimu,nl1stage2jet,nl1stage2tau,nl1stage2ets;
 
-  int   *trigflag, *l1TFinalFlag, *trigPrescl, *l1TPrescl;
+  int   *trigflag, *l1TFinalFlag, *l1TInitialFlag, *trigPrescl, *l1TPrescl;
 
   std::map<int,TString> algoBitToName;
   std::vector<std::string> dummyBranches_;
   bool getPrescales_;
+  bool getL1InfoFromEventSetup_;
 
   std::unique_ptr<HLTConfigProvider>  hltConfigProvider_;
   std::unique_ptr<l1t::L1TGlobalUtil> l1tGlobalUtil_;

--- a/HLTrigger/HLTanalyzers/interface/HLTStage2Info.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTStage2Info.h
@@ -85,7 +85,8 @@ private:
   int   *l1stage2dimuchg, *l1stage2dimuidx1, *l1stage2dimuidx2;
   float *l1stage2jtet, *l1stage2jte, *l1stage2jteta, *l1stage2jtphi;
   float *l1stage2tauet, *l1stage2taue, *l1stage2taueta, *l1stage2tauphi;
-  int   *l1stage2etset, *l1stage2etsphi;
+  int   *l1stage2etshwet, *l1stage2etshwphi;
+  float *l1stage2etset, *l1stage2etsphi;
   int   *l1stage2ctetem, *l1stage2cteth, *l1stage2ctetc, *l1stage2cteta, *l1stage2ctphi;
   int   *l1stage2etstype;
   int   *l1stage2egbx, *l1stage2mubx, *l1stage2jtbx, *l1stage2taubx, *l1stage2etsbx, *l1stage2ctbx;

--- a/HLTrigger/HLTanalyzers/python/HLTBitAnalyser_cfi.py
+++ b/HLTrigger/HLTanalyzers/python/HLTBitAnalyser_cfi.py
@@ -10,6 +10,7 @@ hltbitanalysis = cms.EDAnalyzer("HLTBitAnalyzer",
 
     ### L1 Stage 2 objects
     l1tAlgBlkInputTag               = cms.InputTag("gtStage2Digis"),  # Needed, fix bug of GlobalAlgBlk uninitialized token
+    l1tExtBlkInputTag               = cms.InputTag("gtStage2Digis"),
     gObjectMapRecord                = cms.InputTag("hltGtStage2ObjectMap"),
     gmtStage2Digis                  = cms.string("gmtStage2Digis"),
     caloStage2Digis                 = cms.string("caloStage2Digis"),

--- a/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
@@ -35,6 +35,7 @@ HLTBitAnalyzer::HLTBitAnalyzer(edm::ParameterSet const& conf)  :
   // variables. Example as follows:
 
   _UseL1Stage2 = conf.getUntrackedParameter<bool>("UseL1Stage2",true);
+  _getL1InfoFromEventSetup = conf.getUntrackedParameter<bool>("getL1InfoFromEventSetup", true);
 
   if (_UseL1Stage2) {
     std::cout << " Starting Stage2 HLTBitAnalyzer Analysis " << std::endl;
@@ -154,7 +155,7 @@ void HLTBitAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& iS
 
   getCollection( iEvent, missing, hltresults,      hltresults_,        hltresultsToken_,      kHltresults );
   if (_UseL1Stage2) {
-    getCollection( iEvent, missing, l1GoMR,          gObjectMapRecord_,  gObjectMapRecordToken_,"L1 Stage2 Global Object Map Record" );
+    if(!_getL1InfoFromEventSetup) getCollection( iEvent, missing, l1GoMR,          gObjectMapRecord_,  gObjectMapRecordToken_,"L1 Stage2 Global Object Map Record" );
     getCollection( iEvent, missing, l1stage2eg,      m_l1stage2eg,       l1stage2egToken_,      "L1 Stage2 EGamma objects" );
     getCollection( iEvent, missing, l1stage2mu,      m_l1stage2mu,       l1stage2muToken_,      "L1 Stage2 Muon objects" );
     getCollection( iEvent, missing, l1stage2jet,     m_l1stage2jet,      l1stage2jetToken_,     "L1 Stage2 Jet objects" );

--- a/HLTrigger/HLTanalyzers/src/HLTStage2Info.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTStage2Info.cc
@@ -113,8 +113,10 @@ void HLTStage2Info::setup(const edm::ParameterSet& pSet, TTree* HltTree) {
   l1stage2tauphi = new float[kMaxL1Stage2Tau];
   l1stage2taubx = new int[kMaxL1Stage2Tau];
   const int kMaxL1Stage2EtS = 10000;
-  l1stage2etset = new int[kMaxL1Stage2EtS];
-  l1stage2etsphi = new int[kMaxL1Stage2EtS];
+  l1stage2etset = new float[kMaxL1Stage2EtS];
+  l1stage2etsphi = new float[kMaxL1Stage2EtS];
+  l1stage2etshwet = new int[kMaxL1Stage2EtS];
+  l1stage2etshwphi = new int[kMaxL1Stage2EtS];
   l1stage2etstype = new int[kMaxL1Stage2EtS];
   l1stage2etsbx = new int[kMaxL1Stage2EtS];
 
@@ -160,8 +162,10 @@ void HLTStage2Info::setup(const edm::ParameterSet& pSet, TTree* HltTree) {
   HltTree->Branch("L1Stage2TauPhi",l1stage2tauphi,"L1Stage2TauPhi[NL1Stage2Tau]/F");
   HltTree->Branch("L1Stage2TauBx",l1stage2taubx,"L1Stage2TauBx[NL1Stage2Tau]/I");
   HltTree->Branch("NL1Stage2EtSum",&nl1stage2ets,"NL1Stage2EtSum/I");
-  HltTree->Branch("L1Stage2EtSumEt",l1stage2etset,"L1Stage2EtSumEt[NL1Stage2EtSum]/I");
-  HltTree->Branch("L1Stage2EtSumPhi",l1stage2etsphi,"L1Stage2EtSumPhi[NL1Stage2EtSum]/I");
+  HltTree->Branch("L1Stage2EtSumEt",l1stage2etset,"L1Stage2EtSumEt[NL1Stage2EtSum]/F");
+  HltTree->Branch("L1Stage2EtSumPhi",l1stage2etsphi,"L1Stage2EtSumPhi[NL1Stage2EtSum]/F");
+  HltTree->Branch("L1Stage2EtSumHwEt",l1stage2etshwet,"L1Stage2EtSumHwEt[NL1Stage2EtSum]/I");
+  HltTree->Branch("L1Stage2EtSumHwPhi",l1stage2etshwphi,"L1Stage2EtSumHwPhi[NL1Stage2EtSum]/I");
   HltTree->Branch("L1Stage2EtSumType",l1stage2etstype,"L1Stage2EtSumType[NL1Stage2EtSum]/I");
   HltTree->Branch("L1Stage2EtSumBx",l1stage2etsbx,"L1Stage2EtSumBx[NL1Stage2EtSum]/I");
 }
@@ -357,8 +361,10 @@ void HLTStage2Info::analyze(const edm::Handle<edm::TriggerResults>              
     typedef std::vector<l1t::EtSum>::const_iterator l1cand;
     for(int iBx = L1Stage2EtSum->getFirstBX(); iBx <= L1Stage2EtSum->getLastBX(); ++iBx) { 
       for (l1cand etsItr=L1Stage2EtSum->begin(iBx); etsItr!=L1Stage2EtSum->end(iBx); ++etsItr) {
-        l1stage2etset[il1stage2ets]   = etsItr->hwPt();
-        l1stage2etsphi[il1stage2ets]  = etsItr->hwPhi();
+        l1stage2etset[il1stage2ets]   = etsItr->et();
+        l1stage2etsphi[il1stage2ets]  = etsItr->phi();
+        l1stage2etshwet[il1stage2ets]   = etsItr->hwPt();
+        l1stage2etshwphi[il1stage2ets]  = etsItr->hwPhi();
         l1stage2etstype[il1stage2ets] = etsItr->getType();
         l1stage2etsbx[il1stage2ets]   = iBx;
         il1stage2ets++;


### PR DESCRIPTION
Describe the Pull-Request:

Updated the HltBitAnalyzer to include the L1 Stage2 decisions if the L1 information is obtained from the Event Setup. To select the source of the L1 decisions (Event Setup [GT] or the AOD collection), you can use the flag "getL1InfoFromEventSetup" (by default is set to 'True' to obtain the info from the Event Setup so that the initial  L1 decisions are stored).

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@kurtejung @kkrajczar 
