### PR TITLE
Don't cluster neutrinos in gen jets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_JECPPb.py
@@ -22,11 +22,11 @@ ak4CaloJetAnalyzer.doSubEvent = True
 
 from RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets
 ak5GenJets = ak5GenJets
-ak4GenJets = ak5GenJets.clone(rParam = 0.4)
+ak4GenJets = ak5GenJets.clone(rParam = 0.4, src = cms.InputTag("genParticlesForJetsNoNu"))
 from RecoJets.Configuration.GenJetParticles_cff import *
 
 akGenJets = cms.Sequence(
-    genParticlesForJets +
+    genParticlesForJetsNoNu +
     ak4GenJets
 )
 


### PR DESCRIPTION
Changes source for gen jets to exclude neutrinos.

@cfmcginn @dgulhan @kurtejung 

Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.

