### PR TITLE
Fix jet tower content

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
@@ -778,13 +778,23 @@ def overrideJEC_pPb8TeV(process):
 	cms.PSet(record = cms.string("JetCorrectionsRecord"),
                  tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4Calo"),
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+                 label = cms.untracked.string("AKPu4Calo")
+             ),
+        cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                 tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4PF"),
+                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+                 label = cms.untracked.string("AKPu4PF")
+	     ),
+	cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                 tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4Calo"),
+                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
                  label = cms.untracked.string("AKPu4Calo_offline")
              ),
         cms.PSet(record = cms.string("JetCorrectionsRecord"),
                  tag = cms.string("JetCorrectorParametersCollection_Spring16_25nsV6_MC_AK4PF"),
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
                  label = cms.untracked.string("AKPu4PF_offline")
-	     )
+             )
     ])
     return process
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_DataPPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_DataPPb.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from HeavyIonsAnalysis.JetAnalysis.jets.HiReRecoJets_pPb_cff import *
 
-from HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pp_data_cff import *
-from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_pp_data_cff import *
-from HeavyIonsAnalysis.JetAnalysis.jets.ak4CaloJetSequence_pp_data_cff import *
-from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_pp_data_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pPb_data_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_pPb_data_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.ak4CaloJetSequence_pPb_data_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_pPb_data_cff import *
 
 ## put this back in if you need to rebuild the rho analyzer eta maps...
 #from RecoJets.JetProducers.kt4PFJets_cfi import kt4PFJets

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_data_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets")
+                                                        )
+
+ak4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("ak4CaloJets"),
+    payload = "AK4Calo"
+    )
+
+ak4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4CalobTagger = bTaggers("ak4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4Calomatch = ak4CalobTagger.match
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets"), matched = cms.InputTag("genParticles"))
+ak4CaloPatJetFlavourAssociationLegacy = ak4CalobTagger.PatJetFlavourAssociationLegacy
+ak4CaloPatJetPartons = ak4CalobTagger.PatJetPartons
+ak4CaloJetTracksAssociatorAtVertex = ak4CalobTagger.JetTracksAssociatorAtVertex
+ak4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+ak4CaloJetBProbabilityBJetTags = ak4CalobTagger.JetBProbabilityBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloTrackCountingHighEffBJetTags = ak4CalobTagger.TrackCountingHighEffBJetTags
+ak4CaloTrackCountingHighPurBJetTags = ak4CalobTagger.TrackCountingHighPurBJetTags
+ak4CaloPatJetPartonAssociationLegacy = ak4CalobTagger.PatJetPartonAssociationLegacy
+
+ak4CaloImpactParameterTagInfos = ak4CalobTagger.ImpactParameterTagInfos
+ak4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloJetProbabilityBJetTags = ak4CalobTagger.JetProbabilityBJetTags
+
+ak4CaloSecondaryVertexTagInfos = ak4CalobTagger.SecondaryVertexTagInfos
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4CaloSecondaryVertexNegativeTagInfos = ak4CalobTagger.SecondaryVertexNegativeTagInfos
+ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4CaloNegativeCombinedSecondaryVertexBJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4CaloPositiveCombinedSecondaryVertexBJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4CaloNegativeCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4CaloPositiveCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4CaloSoftPFMuonsTagInfos = ak4CalobTagger.SoftPFMuonsTagInfos
+ak4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloSoftPFMuonBJetTags = ak4CalobTagger.SoftPFMuonBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloNegativeSoftPFMuonByPtBJetTags = ak4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+ak4CaloPositiveSoftPFMuonByPtBJetTags = ak4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+ak4CaloPatJetFlavourIdLegacy = cms.Sequence(ak4CaloPatJetPartonAssociationLegacy*ak4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4CaloPatJetFlavourAssociation = ak4CalobTagger.PatJetFlavourAssociation
+#ak4CaloPatJetFlavourId = cms.Sequence(ak4CaloPatJetPartons*ak4CaloPatJetFlavourAssociation)
+
+ak4CaloJetBtaggingIP       = cms.Sequence(ak4CaloImpactParameterTagInfos *
+            (ak4CaloTrackCountingHighEffBJetTags +
+             ak4CaloTrackCountingHighPurBJetTags +
+             ak4CaloJetProbabilityBJetTags +
+             ak4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+ak4CaloJetBtaggingSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexTagInfos
+            * (ak4CaloSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloCombinedSecondaryVertexBJetTags+
+                ak4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingNegSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexNegativeTagInfos
+            * (ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexBJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingMu = cms.Sequence(ak4CaloSoftPFMuonsTagInfos * (ak4CaloSoftPFMuonBJetTags
+                +
+                ak4CaloSoftPFMuonByIP3dBJetTags
+                +
+                ak4CaloSoftPFMuonByPtBJetTags
+                +
+                ak4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4CaloJetBtagging = cms.Sequence(ak4CaloJetBtaggingIP
+            *ak4CaloJetBtaggingSV
+            *ak4CaloJetBtaggingNegSV
+#            *ak4CaloJetBtaggingMu
+            )
+
+ak4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4CaloJets"),
+        genJetMatch          = cms.InputTag("ak4Calomatch"),
+        genPartonMatch       = cms.InputTag("ak4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("ak4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("ak4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = False,
+        addGenPartonMatch = False,
+        addGenJetMatch = False,
+        embedGenJetMatch = False,
+        embedGenPartonMatch = False,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4CalopatJetsWithBtagging.userData.userFloats.src += ['ak4CaloNjettiness:tau1','ak4CaloNjettiness:tau2','ak4CaloNjettiness:tau3']
+
+ak4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = False,
+                                                             isMC = False,
+							     doSubEvent = False,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4Calo"),
+                                                             jetName = cms.untracked.string("ak4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = False
+                                                             )
+
+ak4CaloJetSequence_mc = cms.Sequence(
+                                                  #ak4Caloclean
+                                                  #*
+                                                  ak4Calomatch
+                                                  #*
+                                                  #ak4CalomatchGroomed
+                                                  *
+                                                  ak4Caloparton
+                                                  *
+                                                  ak4Calocorr
+                                                  *
+                                                  #ak4CaloJetID
+                                                  #*
+                                                  ak4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4CaloJetBtagging
+                                                  *
+                                                  ak4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4CalopatJetsWithBtagging
+                                                  *
+                                                  ak4CaloJetAnalyzer
+                                                  )
+
+ak4CaloJetSequence_data = cms.Sequence(ak4Calocorr
+                                                    *
+                                                    #ak4CaloJetID
+                                                    #*
+                                                    ak4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4CaloJetBtagging
+                                                    *
+                                                    ak4CaloNjettiness 
+                                                    *
+                                                    ak4CalopatJetsWithBtagging
+                                                    *
+                                                    ak4CaloJetAnalyzer
+                                                    )
+
+ak4CaloJetSequence_jec = cms.Sequence(ak4CaloJetSequence_mc)
+ak4CaloJetSequence_mb = cms.Sequence(ak4CaloJetSequence_mc)
+
+ak4CaloJetSequence = cms.Sequence(ak4CaloJetSequence_data)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_mb_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets")
+                                                        )
+
+ak4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("ak4CaloJets"),
+    payload = "AK4Calo"
+    )
+
+ak4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4CalobTagger = bTaggers("ak4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4Calomatch = ak4CalobTagger.match
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets"), matched = cms.InputTag("genParticles"))
+ak4CaloPatJetFlavourAssociationLegacy = ak4CalobTagger.PatJetFlavourAssociationLegacy
+ak4CaloPatJetPartons = ak4CalobTagger.PatJetPartons
+ak4CaloJetTracksAssociatorAtVertex = ak4CalobTagger.JetTracksAssociatorAtVertex
+ak4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+ak4CaloJetBProbabilityBJetTags = ak4CalobTagger.JetBProbabilityBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloTrackCountingHighEffBJetTags = ak4CalobTagger.TrackCountingHighEffBJetTags
+ak4CaloTrackCountingHighPurBJetTags = ak4CalobTagger.TrackCountingHighPurBJetTags
+ak4CaloPatJetPartonAssociationLegacy = ak4CalobTagger.PatJetPartonAssociationLegacy
+
+ak4CaloImpactParameterTagInfos = ak4CalobTagger.ImpactParameterTagInfos
+ak4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloJetProbabilityBJetTags = ak4CalobTagger.JetProbabilityBJetTags
+
+ak4CaloSecondaryVertexTagInfos = ak4CalobTagger.SecondaryVertexTagInfos
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4CaloSecondaryVertexNegativeTagInfos = ak4CalobTagger.SecondaryVertexNegativeTagInfos
+ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4CaloNegativeCombinedSecondaryVertexBJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4CaloPositiveCombinedSecondaryVertexBJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4CaloNegativeCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4CaloPositiveCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4CaloSoftPFMuonsTagInfos = ak4CalobTagger.SoftPFMuonsTagInfos
+ak4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloSoftPFMuonBJetTags = ak4CalobTagger.SoftPFMuonBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloNegativeSoftPFMuonByPtBJetTags = ak4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+ak4CaloPositiveSoftPFMuonByPtBJetTags = ak4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+ak4CaloPatJetFlavourIdLegacy = cms.Sequence(ak4CaloPatJetPartonAssociationLegacy*ak4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4CaloPatJetFlavourAssociation = ak4CalobTagger.PatJetFlavourAssociation
+#ak4CaloPatJetFlavourId = cms.Sequence(ak4CaloPatJetPartons*ak4CaloPatJetFlavourAssociation)
+
+ak4CaloJetBtaggingIP       = cms.Sequence(ak4CaloImpactParameterTagInfos *
+            (ak4CaloTrackCountingHighEffBJetTags +
+             ak4CaloTrackCountingHighPurBJetTags +
+             ak4CaloJetProbabilityBJetTags +
+             ak4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+ak4CaloJetBtaggingSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexTagInfos
+            * (ak4CaloSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloCombinedSecondaryVertexBJetTags+
+                ak4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingNegSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexNegativeTagInfos
+            * (ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexBJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingMu = cms.Sequence(ak4CaloSoftPFMuonsTagInfos * (ak4CaloSoftPFMuonBJetTags
+                +
+                ak4CaloSoftPFMuonByIP3dBJetTags
+                +
+                ak4CaloSoftPFMuonByPtBJetTags
+                +
+                ak4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4CaloJetBtagging = cms.Sequence(ak4CaloJetBtaggingIP
+            *ak4CaloJetBtaggingSV
+            *ak4CaloJetBtaggingNegSV
+#            *ak4CaloJetBtaggingMu
+            )
+
+ak4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4CaloJets"),
+        genJetMatch          = cms.InputTag("ak4Calomatch"),
+        genPartonMatch       = cms.InputTag("ak4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("ak4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("ak4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4CalopatJetsWithBtagging.userData.userFloats.src += ['ak4CaloNjettiness:tau1','ak4CaloNjettiness:tau2','ak4CaloNjettiness:tau3']
+
+ak4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4Calo"),
+                                                             jetName = cms.untracked.string("ak4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+ak4CaloJetSequence_mc = cms.Sequence(
+                                                  #ak4Caloclean
+                                                  #*
+                                                  ak4Calomatch
+                                                  #*
+                                                  #ak4CalomatchGroomed
+                                                  *
+                                                  ak4Caloparton
+                                                  *
+                                                  ak4Calocorr
+                                                  *
+                                                  #ak4CaloJetID
+                                                  #*
+                                                  ak4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4CaloJetBtagging
+                                                  *
+                                                  ak4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4CalopatJetsWithBtagging
+                                                  *
+                                                  ak4CaloJetAnalyzer
+                                                  )
+
+ak4CaloJetSequence_data = cms.Sequence(ak4Calocorr
+                                                    *
+                                                    #ak4CaloJetID
+                                                    #*
+                                                    ak4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4CaloJetBtagging
+                                                    *
+                                                    ak4CaloNjettiness 
+                                                    *
+                                                    ak4CalopatJetsWithBtagging
+                                                    *
+                                                    ak4CaloJetAnalyzer
+                                                    )
+
+ak4CaloJetSequence_jec = cms.Sequence(ak4CaloJetSequence_mc)
+ak4CaloJetSequence_mb = cms.Sequence(ak4CaloJetSequence_mc)
+
+ak4CaloJetSequence = cms.Sequence(ak4CaloJetSequence_mb)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4CaloJetSequence_pPb_mc_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets")
+                                                        )
+
+ak4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("ak4CaloJets"),
+    payload = "AK4Calo"
+    )
+
+ak4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4CalobTagger = bTaggers("ak4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4Calomatch = ak4CalobTagger.match
+ak4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("ak4CaloJets"), matched = cms.InputTag("genParticles"))
+ak4CaloPatJetFlavourAssociationLegacy = ak4CalobTagger.PatJetFlavourAssociationLegacy
+ak4CaloPatJetPartons = ak4CalobTagger.PatJetPartons
+ak4CaloJetTracksAssociatorAtVertex = ak4CalobTagger.JetTracksAssociatorAtVertex
+ak4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+ak4CaloJetBProbabilityBJetTags = ak4CalobTagger.JetBProbabilityBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloTrackCountingHighEffBJetTags = ak4CalobTagger.TrackCountingHighEffBJetTags
+ak4CaloTrackCountingHighPurBJetTags = ak4CalobTagger.TrackCountingHighPurBJetTags
+ak4CaloPatJetPartonAssociationLegacy = ak4CalobTagger.PatJetPartonAssociationLegacy
+
+ak4CaloImpactParameterTagInfos = ak4CalobTagger.ImpactParameterTagInfos
+ak4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloJetProbabilityBJetTags = ak4CalobTagger.JetProbabilityBJetTags
+
+ak4CaloSecondaryVertexTagInfos = ak4CalobTagger.SecondaryVertexTagInfos
+ak4CaloSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4CaloSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4CaloCombinedSecondaryVertexBJetTags = ak4CalobTagger.CombinedSecondaryVertexBJetTags
+ak4CaloCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4CaloSecondaryVertexNegativeTagInfos = ak4CalobTagger.SecondaryVertexNegativeTagInfos
+ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = ak4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4CaloNegativeCombinedSecondaryVertexBJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4CaloPositiveCombinedSecondaryVertexBJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4CaloNegativeCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4CaloPositiveCombinedSecondaryVertexV2BJetTags = ak4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4CaloSoftPFMuonsTagInfos = ak4CalobTagger.SoftPFMuonsTagInfos
+ak4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4CaloSoftPFMuonBJetTags = ak4CalobTagger.SoftPFMuonBJetTags
+ak4CaloSoftPFMuonByIP3dBJetTags = ak4CalobTagger.SoftPFMuonByIP3dBJetTags
+ak4CaloSoftPFMuonByPtBJetTags = ak4CalobTagger.SoftPFMuonByPtBJetTags
+ak4CaloNegativeSoftPFMuonByPtBJetTags = ak4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+ak4CaloPositiveSoftPFMuonByPtBJetTags = ak4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+ak4CaloPatJetFlavourIdLegacy = cms.Sequence(ak4CaloPatJetPartonAssociationLegacy*ak4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4CaloPatJetFlavourAssociation = ak4CalobTagger.PatJetFlavourAssociation
+#ak4CaloPatJetFlavourId = cms.Sequence(ak4CaloPatJetPartons*ak4CaloPatJetFlavourAssociation)
+
+ak4CaloJetBtaggingIP       = cms.Sequence(ak4CaloImpactParameterTagInfos *
+            (ak4CaloTrackCountingHighEffBJetTags +
+             ak4CaloTrackCountingHighPurBJetTags +
+             ak4CaloJetProbabilityBJetTags +
+             ak4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+ak4CaloJetBtaggingSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexTagInfos
+            * (ak4CaloSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloCombinedSecondaryVertexBJetTags+
+                ak4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingNegSV = cms.Sequence(ak4CaloImpactParameterTagInfos
+            *
+            ak4CaloSecondaryVertexNegativeTagInfos
+            * (ak4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexBJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexBJetTags+
+                ak4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4CaloJetBtaggingMu = cms.Sequence(ak4CaloSoftPFMuonsTagInfos * (ak4CaloSoftPFMuonBJetTags
+                +
+                ak4CaloSoftPFMuonByIP3dBJetTags
+                +
+                ak4CaloSoftPFMuonByPtBJetTags
+                +
+                ak4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4CaloJetBtagging = cms.Sequence(ak4CaloJetBtaggingIP
+            *ak4CaloJetBtaggingSV
+            *ak4CaloJetBtaggingNegSV
+#            *ak4CaloJetBtaggingMu
+            )
+
+ak4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4CaloJets"),
+        genJetMatch          = cms.InputTag("ak4Calomatch"),
+        genPartonMatch       = cms.InputTag("ak4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("ak4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("ak4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4CalopatJetsWithBtagging.userData.userFloats.src += ['ak4CaloNjettiness:tau1','ak4CaloNjettiness:tau2','ak4CaloNjettiness:tau3']
+
+ak4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4Calo"),
+                                                             jetName = cms.untracked.string("ak4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+ak4CaloJetSequence_mc = cms.Sequence(
+                                                  #ak4Caloclean
+                                                  #*
+                                                  ak4Calomatch
+                                                  #*
+                                                  #ak4CalomatchGroomed
+                                                  *
+                                                  ak4Caloparton
+                                                  *
+                                                  ak4Calocorr
+                                                  *
+                                                  #ak4CaloJetID
+                                                  #*
+                                                  ak4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4CaloJetBtagging
+                                                  *
+                                                  ak4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4CalopatJetsWithBtagging
+                                                  *
+                                                  ak4CaloJetAnalyzer
+                                                  )
+
+ak4CaloJetSequence_data = cms.Sequence(ak4Calocorr
+                                                    *
+                                                    #ak4CaloJetID
+                                                    #*
+                                                    ak4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4CaloJetBtagging
+                                                    *
+                                                    ak4CaloNjettiness 
+                                                    *
+                                                    ak4CalopatJetsWithBtagging
+                                                    *
+                                                    ak4CaloJetAnalyzer
+                                                    )
+
+ak4CaloJetSequence_jec = cms.Sequence(ak4CaloJetSequence_mc)
+ak4CaloJetSequence_mb = cms.Sequence(ak4CaloJetSequence_mc)
+
+ak4CaloJetSequence = cms.Sequence(ak4CaloJetSequence_mc)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_data_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets")
+                                                        )
+
+ak4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute','L2L3Residual'),
+    src = cms.InputTag("ak4PFJets"),
+    payload = "AK4PF"
+    )
+
+ak4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4PFbTagger = bTaggers("ak4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4PFmatch = ak4PFbTagger.match
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets"), matched = cms.InputTag("genParticles"))
+ak4PFPatJetFlavourAssociationLegacy = ak4PFbTagger.PatJetFlavourAssociationLegacy
+ak4PFPatJetPartons = ak4PFbTagger.PatJetPartons
+ak4PFJetTracksAssociatorAtVertex = ak4PFbTagger.JetTracksAssociatorAtVertex
+ak4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+ak4PFJetBProbabilityBJetTags = ak4PFbTagger.JetBProbabilityBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFTrackCountingHighEffBJetTags = ak4PFbTagger.TrackCountingHighEffBJetTags
+ak4PFTrackCountingHighPurBJetTags = ak4PFbTagger.TrackCountingHighPurBJetTags
+ak4PFPatJetPartonAssociationLegacy = ak4PFbTagger.PatJetPartonAssociationLegacy
+
+ak4PFImpactParameterTagInfos = ak4PFbTagger.ImpactParameterTagInfos
+ak4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFJetProbabilityBJetTags = ak4PFbTagger.JetProbabilityBJetTags
+
+ak4PFSecondaryVertexTagInfos = ak4PFbTagger.SecondaryVertexTagInfos
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4PFSecondaryVertexNegativeTagInfos = ak4PFbTagger.SecondaryVertexNegativeTagInfos
+ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4PFNegativeCombinedSecondaryVertexBJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4PFPositiveCombinedSecondaryVertexBJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4PFNegativeCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4PFPositiveCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4PFSoftPFMuonsTagInfos = ak4PFbTagger.SoftPFMuonsTagInfos
+ak4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFSoftPFMuonBJetTags = ak4PFbTagger.SoftPFMuonBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFNegativeSoftPFMuonByPtBJetTags = ak4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+ak4PFPositiveSoftPFMuonByPtBJetTags = ak4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+ak4PFPatJetFlavourIdLegacy = cms.Sequence(ak4PFPatJetPartonAssociationLegacy*ak4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4PFPatJetFlavourAssociation = ak4PFbTagger.PatJetFlavourAssociation
+#ak4PFPatJetFlavourId = cms.Sequence(ak4PFPatJetPartons*ak4PFPatJetFlavourAssociation)
+
+ak4PFJetBtaggingIP       = cms.Sequence(ak4PFImpactParameterTagInfos *
+            (ak4PFTrackCountingHighEffBJetTags +
+             ak4PFTrackCountingHighPurBJetTags +
+             ak4PFJetProbabilityBJetTags +
+             ak4PFJetBProbabilityBJetTags 
+            )
+            )
+
+ak4PFJetBtaggingSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexTagInfos
+            * (ak4PFSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFCombinedSecondaryVertexBJetTags+
+                ak4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingNegSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexNegativeTagInfos
+            * (ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexBJetTags+
+                ak4PFPositiveCombinedSecondaryVertexBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingMu = cms.Sequence(ak4PFSoftPFMuonsTagInfos * (ak4PFSoftPFMuonBJetTags
+                +
+                ak4PFSoftPFMuonByIP3dBJetTags
+                +
+                ak4PFSoftPFMuonByPtBJetTags
+                +
+                ak4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4PFJetBtagging = cms.Sequence(ak4PFJetBtaggingIP
+            *ak4PFJetBtaggingSV
+            *ak4PFJetBtaggingNegSV
+#            *ak4PFJetBtaggingMu
+            )
+
+ak4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4PFJets"),
+        genJetMatch          = cms.InputTag("ak4PFmatch"),
+        genPartonMatch       = cms.InputTag("ak4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("ak4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4PFJetBProbabilityBJetTags"),
+            cms.InputTag("ak4PFJetProbabilityBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = False,
+        addGenPartonMatch = False,
+        addGenJetMatch = False,
+        embedGenJetMatch = False,
+        embedGenPartonMatch = False,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4PFpatJetsWithBtagging.userData.userFloats.src += ['ak4PFNjettiness:tau1','ak4PFNjettiness:tau2','ak4PFNjettiness:tau3']
+
+ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = False,
+                                                             isMC = False,
+							     doSubEvent = False,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4PF"),
+                                                             jetName = cms.untracked.string("ak4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = False
+                                                             )
+
+ak4PFJetSequence_mc = cms.Sequence(
+                                                  #ak4PFclean
+                                                  #*
+                                                  ak4PFmatch
+                                                  #*
+                                                  #ak4PFmatchGroomed
+                                                  *
+                                                  ak4PFparton
+                                                  *
+                                                  ak4PFcorr
+                                                  *
+                                                  #ak4PFJetID
+                                                  #*
+                                                  ak4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4PFJetBtagging
+                                                  *
+                                                  ak4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4PFpatJetsWithBtagging
+                                                  *
+                                                  ak4PFJetAnalyzer
+                                                  )
+
+ak4PFJetSequence_data = cms.Sequence(ak4PFcorr
+                                                    *
+                                                    #ak4PFJetID
+                                                    #*
+                                                    ak4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4PFJetBtagging
+                                                    *
+                                                    ak4PFNjettiness 
+                                                    *
+                                                    ak4PFpatJetsWithBtagging
+                                                    *
+                                                    ak4PFJetAnalyzer
+                                                    )
+
+ak4PFJetSequence_jec = cms.Sequence(ak4PFJetSequence_mc)
+ak4PFJetSequence_mb = cms.Sequence(ak4PFJetSequence_mc)
+
+ak4PFJetSequence = cms.Sequence(ak4PFJetSequence_data)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_mb_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets")
+                                                        )
+
+ak4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("ak4PFJets"),
+    payload = "AK4PF"
+    )
+
+ak4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4PFbTagger = bTaggers("ak4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4PFmatch = ak4PFbTagger.match
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets"), matched = cms.InputTag("genParticles"))
+ak4PFPatJetFlavourAssociationLegacy = ak4PFbTagger.PatJetFlavourAssociationLegacy
+ak4PFPatJetPartons = ak4PFbTagger.PatJetPartons
+ak4PFJetTracksAssociatorAtVertex = ak4PFbTagger.JetTracksAssociatorAtVertex
+ak4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+ak4PFJetBProbabilityBJetTags = ak4PFbTagger.JetBProbabilityBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFTrackCountingHighEffBJetTags = ak4PFbTagger.TrackCountingHighEffBJetTags
+ak4PFTrackCountingHighPurBJetTags = ak4PFbTagger.TrackCountingHighPurBJetTags
+ak4PFPatJetPartonAssociationLegacy = ak4PFbTagger.PatJetPartonAssociationLegacy
+
+ak4PFImpactParameterTagInfos = ak4PFbTagger.ImpactParameterTagInfos
+ak4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFJetProbabilityBJetTags = ak4PFbTagger.JetProbabilityBJetTags
+
+ak4PFSecondaryVertexTagInfos = ak4PFbTagger.SecondaryVertexTagInfos
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4PFSecondaryVertexNegativeTagInfos = ak4PFbTagger.SecondaryVertexNegativeTagInfos
+ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4PFNegativeCombinedSecondaryVertexBJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4PFPositiveCombinedSecondaryVertexBJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4PFNegativeCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4PFPositiveCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4PFSoftPFMuonsTagInfos = ak4PFbTagger.SoftPFMuonsTagInfos
+ak4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFSoftPFMuonBJetTags = ak4PFbTagger.SoftPFMuonBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFNegativeSoftPFMuonByPtBJetTags = ak4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+ak4PFPositiveSoftPFMuonByPtBJetTags = ak4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+ak4PFPatJetFlavourIdLegacy = cms.Sequence(ak4PFPatJetPartonAssociationLegacy*ak4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4PFPatJetFlavourAssociation = ak4PFbTagger.PatJetFlavourAssociation
+#ak4PFPatJetFlavourId = cms.Sequence(ak4PFPatJetPartons*ak4PFPatJetFlavourAssociation)
+
+ak4PFJetBtaggingIP       = cms.Sequence(ak4PFImpactParameterTagInfos *
+            (ak4PFTrackCountingHighEffBJetTags +
+             ak4PFTrackCountingHighPurBJetTags +
+             ak4PFJetProbabilityBJetTags +
+             ak4PFJetBProbabilityBJetTags 
+            )
+            )
+
+ak4PFJetBtaggingSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexTagInfos
+            * (ak4PFSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFCombinedSecondaryVertexBJetTags+
+                ak4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingNegSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexNegativeTagInfos
+            * (ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexBJetTags+
+                ak4PFPositiveCombinedSecondaryVertexBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingMu = cms.Sequence(ak4PFSoftPFMuonsTagInfos * (ak4PFSoftPFMuonBJetTags
+                +
+                ak4PFSoftPFMuonByIP3dBJetTags
+                +
+                ak4PFSoftPFMuonByPtBJetTags
+                +
+                ak4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4PFJetBtagging = cms.Sequence(ak4PFJetBtaggingIP
+            *ak4PFJetBtaggingSV
+            *ak4PFJetBtaggingNegSV
+#            *ak4PFJetBtaggingMu
+            )
+
+ak4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4PFJets"),
+        genJetMatch          = cms.InputTag("ak4PFmatch"),
+        genPartonMatch       = cms.InputTag("ak4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("ak4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4PFJetBProbabilityBJetTags"),
+            cms.InputTag("ak4PFJetProbabilityBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4PFpatJetsWithBtagging.userData.userFloats.src += ['ak4PFNjettiness:tau1','ak4PFNjettiness:tau2','ak4PFNjettiness:tau3']
+
+ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4PF"),
+                                                             jetName = cms.untracked.string("ak4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+ak4PFJetSequence_mc = cms.Sequence(
+                                                  #ak4PFclean
+                                                  #*
+                                                  ak4PFmatch
+                                                  #*
+                                                  #ak4PFmatchGroomed
+                                                  *
+                                                  ak4PFparton
+                                                  *
+                                                  ak4PFcorr
+                                                  *
+                                                  #ak4PFJetID
+                                                  #*
+                                                  ak4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4PFJetBtagging
+                                                  *
+                                                  ak4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4PFpatJetsWithBtagging
+                                                  *
+                                                  ak4PFJetAnalyzer
+                                                  )
+
+ak4PFJetSequence_data = cms.Sequence(ak4PFcorr
+                                                    *
+                                                    #ak4PFJetID
+                                                    #*
+                                                    ak4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4PFJetBtagging
+                                                    *
+                                                    ak4PFNjettiness 
+                                                    *
+                                                    ak4PFpatJetsWithBtagging
+                                                    *
+                                                    ak4PFJetAnalyzer
+                                                    )
+
+ak4PFJetSequence_jec = cms.Sequence(ak4PFJetSequence_mc)
+ak4PFJetSequence_mb = cms.Sequence(ak4PFJetSequence_mc)
+
+ak4PFJetSequence = cms.Sequence(ak4PFJetSequence_mb)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/ak4PFJetSequence_pPb_mc_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+ak4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets")
+                                                        )
+
+ak4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("ak4PFJets"),
+    payload = "AK4PF"
+    )
+
+ak4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('ak4CaloJets'))
+
+#ak4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+ak4PFbTagger = bTaggers("ak4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#ak4PFmatch = ak4PFbTagger.match
+ak4PFparton = patJetPartonMatch.clone(src = cms.InputTag("ak4PFJets"), matched = cms.InputTag("genParticles"))
+ak4PFPatJetFlavourAssociationLegacy = ak4PFbTagger.PatJetFlavourAssociationLegacy
+ak4PFPatJetPartons = ak4PFbTagger.PatJetPartons
+ak4PFJetTracksAssociatorAtVertex = ak4PFbTagger.JetTracksAssociatorAtVertex
+ak4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+ak4PFJetBProbabilityBJetTags = ak4PFbTagger.JetBProbabilityBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFTrackCountingHighEffBJetTags = ak4PFbTagger.TrackCountingHighEffBJetTags
+ak4PFTrackCountingHighPurBJetTags = ak4PFbTagger.TrackCountingHighPurBJetTags
+ak4PFPatJetPartonAssociationLegacy = ak4PFbTagger.PatJetPartonAssociationLegacy
+
+ak4PFImpactParameterTagInfos = ak4PFbTagger.ImpactParameterTagInfos
+ak4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFJetProbabilityBJetTags = ak4PFbTagger.JetProbabilityBJetTags
+
+ak4PFSecondaryVertexTagInfos = ak4PFbTagger.SecondaryVertexTagInfos
+ak4PFSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+ak4PFSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+ak4PFCombinedSecondaryVertexBJetTags = ak4PFbTagger.CombinedSecondaryVertexBJetTags
+ak4PFCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+ak4PFSecondaryVertexNegativeTagInfos = ak4PFbTagger.SecondaryVertexNegativeTagInfos
+ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags = ak4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+ak4PFNegativeCombinedSecondaryVertexBJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+ak4PFPositiveCombinedSecondaryVertexBJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+ak4PFNegativeCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+ak4PFPositiveCombinedSecondaryVertexV2BJetTags = ak4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+ak4PFSoftPFMuonsTagInfos = ak4PFbTagger.SoftPFMuonsTagInfos
+ak4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+ak4PFSoftPFMuonBJetTags = ak4PFbTagger.SoftPFMuonBJetTags
+ak4PFSoftPFMuonByIP3dBJetTags = ak4PFbTagger.SoftPFMuonByIP3dBJetTags
+ak4PFSoftPFMuonByPtBJetTags = ak4PFbTagger.SoftPFMuonByPtBJetTags
+ak4PFNegativeSoftPFMuonByPtBJetTags = ak4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+ak4PFPositiveSoftPFMuonByPtBJetTags = ak4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+ak4PFPatJetFlavourIdLegacy = cms.Sequence(ak4PFPatJetPartonAssociationLegacy*ak4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#ak4PFPatJetFlavourAssociation = ak4PFbTagger.PatJetFlavourAssociation
+#ak4PFPatJetFlavourId = cms.Sequence(ak4PFPatJetPartons*ak4PFPatJetFlavourAssociation)
+
+ak4PFJetBtaggingIP       = cms.Sequence(ak4PFImpactParameterTagInfos *
+            (ak4PFTrackCountingHighEffBJetTags +
+             ak4PFTrackCountingHighPurBJetTags +
+             ak4PFJetProbabilityBJetTags +
+             ak4PFJetBProbabilityBJetTags 
+            )
+            )
+
+ak4PFJetBtaggingSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexTagInfos
+            * (ak4PFSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFCombinedSecondaryVertexBJetTags+
+                ak4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingNegSV = cms.Sequence(ak4PFImpactParameterTagInfos
+            *
+            ak4PFSecondaryVertexNegativeTagInfos
+            * (ak4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                ak4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexBJetTags+
+                ak4PFPositiveCombinedSecondaryVertexBJetTags+
+                ak4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                ak4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+ak4PFJetBtaggingMu = cms.Sequence(ak4PFSoftPFMuonsTagInfos * (ak4PFSoftPFMuonBJetTags
+                +
+                ak4PFSoftPFMuonByIP3dBJetTags
+                +
+                ak4PFSoftPFMuonByPtBJetTags
+                +
+                ak4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                ak4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+ak4PFJetBtagging = cms.Sequence(ak4PFJetBtaggingIP
+            *ak4PFJetBtaggingSV
+            *ak4PFJetBtaggingNegSV
+#            *ak4PFJetBtaggingMu
+            )
+
+ak4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("ak4PFJets"),
+        genJetMatch          = cms.InputTag("ak4PFmatch"),
+        genPartonMatch       = cms.InputTag("ak4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("ak4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("ak4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("ak4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("ak4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("ak4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("ak4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("ak4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("ak4PFJetBProbabilityBJetTags"),
+            cms.InputTag("ak4PFJetProbabilityBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("ak4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("ak4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("ak4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+ak4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("ak4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+ak4PFpatJetsWithBtagging.userData.userFloats.src += ['ak4PFNjettiness:tau1','ak4PFNjettiness:tau2','ak4PFNjettiness:tau3']
+
+ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("ak4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("ak4PF"),
+                                                             jetName = cms.untracked.string("ak4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+ak4PFJetSequence_mc = cms.Sequence(
+                                                  #ak4PFclean
+                                                  #*
+                                                  ak4PFmatch
+                                                  #*
+                                                  #ak4PFmatchGroomed
+                                                  *
+                                                  ak4PFparton
+                                                  *
+                                                  ak4PFcorr
+                                                  *
+                                                  #ak4PFJetID
+                                                  #*
+                                                  ak4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #ak4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  ak4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  ak4PFJetBtagging
+                                                  *
+                                                  ak4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  ak4PFpatJetsWithBtagging
+                                                  *
+                                                  ak4PFJetAnalyzer
+                                                  )
+
+ak4PFJetSequence_data = cms.Sequence(ak4PFcorr
+                                                    *
+                                                    #ak4PFJetID
+                                                    #*
+                                                    ak4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    ak4PFJetBtagging
+                                                    *
+                                                    ak4PFNjettiness 
+                                                    *
+                                                    ak4PFpatJetsWithBtagging
+                                                    *
+                                                    ak4PFJetAnalyzer
+                                                    )
+
+ak4PFJetSequence_jec = cms.Sequence(ak4PFJetSequence_mc)
+ak4PFJetSequence_mb = cms.Sequence(ak4PFJetSequence_mc)
+
+ak4PFJetSequence = cms.Sequence(ak4PFJetSequence_mc)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_data_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets")
+                                                        )
+
+akPu4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4CaloJets"),
+    payload = "AKPu4Calo"
+    )
+
+akPu4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4CalobTagger = bTaggers("akPu4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4Calomatch = akPu4CalobTagger.match
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets"), matched = cms.InputTag("genParticles"))
+akPu4CaloPatJetFlavourAssociationLegacy = akPu4CalobTagger.PatJetFlavourAssociationLegacy
+akPu4CaloPatJetPartons = akPu4CalobTagger.PatJetPartons
+akPu4CaloJetTracksAssociatorAtVertex = akPu4CalobTagger.JetTracksAssociatorAtVertex
+akPu4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+akPu4CaloJetBProbabilityBJetTags = akPu4CalobTagger.JetBProbabilityBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloTrackCountingHighEffBJetTags = akPu4CalobTagger.TrackCountingHighEffBJetTags
+akPu4CaloTrackCountingHighPurBJetTags = akPu4CalobTagger.TrackCountingHighPurBJetTags
+akPu4CaloPatJetPartonAssociationLegacy = akPu4CalobTagger.PatJetPartonAssociationLegacy
+
+akPu4CaloImpactParameterTagInfos = akPu4CalobTagger.ImpactParameterTagInfos
+akPu4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloJetProbabilityBJetTags = akPu4CalobTagger.JetProbabilityBJetTags
+
+akPu4CaloSecondaryVertexTagInfos = akPu4CalobTagger.SecondaryVertexTagInfos
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSecondaryVertexNegativeTagInfos = akPu4CalobTagger.SecondaryVertexNegativeTagInfos
+akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexBJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4CaloPositiveCombinedSecondaryVertexBJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSoftPFMuonsTagInfos = akPu4CalobTagger.SoftPFMuonsTagInfos
+akPu4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloSoftPFMuonBJetTags = akPu4CalobTagger.SoftPFMuonBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloNegativeSoftPFMuonByPtBJetTags = akPu4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4CaloPositiveSoftPFMuonByPtBJetTags = akPu4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4CaloPatJetFlavourIdLegacy = cms.Sequence(akPu4CaloPatJetPartonAssociationLegacy*akPu4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4CaloPatJetFlavourAssociation = akPu4CalobTagger.PatJetFlavourAssociation
+#akPu4CaloPatJetFlavourId = cms.Sequence(akPu4CaloPatJetPartons*akPu4CaloPatJetFlavourAssociation)
+
+akPu4CaloJetBtaggingIP       = cms.Sequence(akPu4CaloImpactParameterTagInfos *
+            (akPu4CaloTrackCountingHighEffBJetTags +
+             akPu4CaloTrackCountingHighPurBJetTags +
+             akPu4CaloJetProbabilityBJetTags +
+             akPu4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4CaloJetBtaggingSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexTagInfos
+            * (akPu4CaloSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloCombinedSecondaryVertexBJetTags+
+                akPu4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingNegSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexNegativeTagInfos
+            * (akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexBJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingMu = cms.Sequence(akPu4CaloSoftPFMuonsTagInfos * (akPu4CaloSoftPFMuonBJetTags
+                +
+                akPu4CaloSoftPFMuonByIP3dBJetTags
+                +
+                akPu4CaloSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4CaloJetBtagging = cms.Sequence(akPu4CaloJetBtaggingIP
+            *akPu4CaloJetBtaggingSV
+            *akPu4CaloJetBtaggingNegSV
+#            *akPu4CaloJetBtaggingMu
+            )
+
+akPu4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4CaloJets"),
+        genJetMatch          = cms.InputTag("akPu4Calomatch"),
+        genPartonMatch       = cms.InputTag("akPu4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = False,
+        addGenPartonMatch = False,
+        addGenJetMatch = False,
+        embedGenJetMatch = False,
+        embedGenPartonMatch = False,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4CalopatJetsWithBtagging.userData.userFloats.src += ['akPu4CaloNjettiness:tau1','akPu4CaloNjettiness:tau2','akPu4CaloNjettiness:tau3']
+
+akPu4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = False,
+                                                             isMC = False,
+							     doSubEvent = False,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4Calo"),
+                                                             jetName = cms.untracked.string("akPu4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = False
+                                                             )
+
+akPu4CaloJetSequence_mc = cms.Sequence(
+                                                  #akPu4Caloclean
+                                                  #*
+                                                  akPu4Calomatch
+                                                  #*
+                                                  #akPu4CalomatchGroomed
+                                                  *
+                                                  akPu4Caloparton
+                                                  *
+                                                  akPu4Calocorr
+                                                  *
+                                                  #akPu4CaloJetID
+                                                  #*
+                                                  akPu4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4CaloJetBtagging
+                                                  *
+                                                  akPu4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4CalopatJetsWithBtagging
+                                                  *
+                                                  akPu4CaloJetAnalyzer
+                                                  )
+
+akPu4CaloJetSequence_data = cms.Sequence(akPu4Calocorr
+                                                    *
+                                                    #akPu4CaloJetID
+                                                    #*
+                                                    akPu4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4CaloJetBtagging
+                                                    *
+                                                    akPu4CaloNjettiness 
+                                                    *
+                                                    akPu4CalopatJetsWithBtagging
+                                                    *
+                                                    akPu4CaloJetAnalyzer
+                                                    )
+
+akPu4CaloJetSequence_jec = cms.Sequence(akPu4CaloJetSequence_mc)
+akPu4CaloJetSequence_mb = cms.Sequence(akPu4CaloJetSequence_mc)
+
+akPu4CaloJetSequence = cms.Sequence(akPu4CaloJetSequence_data)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_jec_cff.py
@@ -1,0 +1,253 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets")
+                                                        )
+
+akPu4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4CaloJets"),
+    payload = "AKPu4Calo"
+    )
+
+akPu4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4CalobTagger = bTaggers("akPu4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4Calomatch = akPu4CalobTagger.match
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets"), matched = cms.InputTag("genParticles"))
+akPu4CaloPatJetFlavourAssociationLegacy = akPu4CalobTagger.PatJetFlavourAssociationLegacy
+akPu4CaloPatJetPartons = akPu4CalobTagger.PatJetPartons
+akPu4CaloJetTracksAssociatorAtVertex = akPu4CalobTagger.JetTracksAssociatorAtVertex
+akPu4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+akPu4CaloJetBProbabilityBJetTags = akPu4CalobTagger.JetBProbabilityBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloTrackCountingHighEffBJetTags = akPu4CalobTagger.TrackCountingHighEffBJetTags
+akPu4CaloTrackCountingHighPurBJetTags = akPu4CalobTagger.TrackCountingHighPurBJetTags
+akPu4CaloPatJetPartonAssociationLegacy = akPu4CalobTagger.PatJetPartonAssociationLegacy
+
+akPu4CaloImpactParameterTagInfos = akPu4CalobTagger.ImpactParameterTagInfos
+akPu4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloJetProbabilityBJetTags = akPu4CalobTagger.JetProbabilityBJetTags
+
+akPu4CaloSecondaryVertexTagInfos = akPu4CalobTagger.SecondaryVertexTagInfos
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSecondaryVertexNegativeTagInfos = akPu4CalobTagger.SecondaryVertexNegativeTagInfos
+akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexBJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4CaloPositiveCombinedSecondaryVertexBJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSoftPFMuonsTagInfos = akPu4CalobTagger.SoftPFMuonsTagInfos
+akPu4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloSoftPFMuonBJetTags = akPu4CalobTagger.SoftPFMuonBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloNegativeSoftPFMuonByPtBJetTags = akPu4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4CaloPositiveSoftPFMuonByPtBJetTags = akPu4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4CaloPatJetFlavourIdLegacy = cms.Sequence(akPu4CaloPatJetPartonAssociationLegacy*akPu4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4CaloPatJetFlavourAssociation = akPu4CalobTagger.PatJetFlavourAssociation
+#akPu4CaloPatJetFlavourId = cms.Sequence(akPu4CaloPatJetPartons*akPu4CaloPatJetFlavourAssociation)
+
+akPu4CaloJetBtaggingIP       = cms.Sequence(akPu4CaloImpactParameterTagInfos *
+            (akPu4CaloTrackCountingHighEffBJetTags +
+             akPu4CaloTrackCountingHighPurBJetTags +
+             akPu4CaloJetProbabilityBJetTags +
+             akPu4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4CaloJetBtaggingSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexTagInfos
+            * (akPu4CaloSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloCombinedSecondaryVertexBJetTags+
+                akPu4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingNegSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexNegativeTagInfos
+            * (akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexBJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingMu = cms.Sequence(akPu4CaloSoftPFMuonsTagInfos * (akPu4CaloSoftPFMuonBJetTags
+                +
+                akPu4CaloSoftPFMuonByIP3dBJetTags
+                +
+                akPu4CaloSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4CaloJetBtagging = cms.Sequence(akPu4CaloJetBtaggingIP
+            *akPu4CaloJetBtaggingSV
+            *akPu4CaloJetBtaggingNegSV
+#            *akPu4CaloJetBtaggingMu
+            )
+
+akPu4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4CaloJets"),
+        genJetMatch          = cms.InputTag("akPu4Calomatch"),
+        genPartonMatch       = cms.InputTag("akPu4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4CalopatJetsWithBtagging.userData.userFloats.src += ['akPu4CaloNjettiness:tau1','akPu4CaloNjettiness:tau2','akPu4CaloNjettiness:tau3']
+
+akPu4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4Calo"),
+                                                             jetName = cms.untracked.string("akPu4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4CaloJetSequence_mc = cms.Sequence(
+                                                  #akPu4Caloclean
+                                                  #*
+                                                  akPu4Calomatch
+                                                  #*
+                                                  #akPu4CalomatchGroomed
+                                                  *
+                                                  akPu4Caloparton
+                                                  *
+                                                  akPu4Calocorr
+                                                  *
+                                                  #akPu4CaloJetID
+                                                  #*
+                                                  akPu4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4CaloJetBtagging
+                                                  *
+                                                  akPu4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4CalopatJetsWithBtagging
+                                                  *
+                                                  akPu4CaloJetAnalyzer
+                                                  )
+
+akPu4CaloJetSequence_data = cms.Sequence(akPu4Calocorr
+                                                    *
+                                                    #akPu4CaloJetID
+                                                    #*
+                                                    akPu4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4CaloJetBtagging
+                                                    *
+                                                    akPu4CaloNjettiness 
+                                                    *
+                                                    akPu4CalopatJetsWithBtagging
+                                                    *
+                                                    akPu4CaloJetAnalyzer
+                                                    )
+
+akPu4CaloJetSequence_jec = cms.Sequence(akPu4CaloJetSequence_mc)
+akPu4CaloJetSequence_mb = cms.Sequence(akPu4CaloJetSequence_mc)
+
+akPu4CaloJetSequence = cms.Sequence(akPu4CaloJetSequence_jec)
+akPu4CaloJetAnalyzer.genPtMin = cms.untracked.double(1)
+akPu4CaloJetAnalyzer.jetPtMin = cms.double(1)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_mb_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets")
+                                                        )
+
+akPu4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4CaloJets"),
+    payload = "AKPu4Calo"
+    )
+
+akPu4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4CalobTagger = bTaggers("akPu4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4Calomatch = akPu4CalobTagger.match
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets"), matched = cms.InputTag("genParticles"))
+akPu4CaloPatJetFlavourAssociationLegacy = akPu4CalobTagger.PatJetFlavourAssociationLegacy
+akPu4CaloPatJetPartons = akPu4CalobTagger.PatJetPartons
+akPu4CaloJetTracksAssociatorAtVertex = akPu4CalobTagger.JetTracksAssociatorAtVertex
+akPu4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+akPu4CaloJetBProbabilityBJetTags = akPu4CalobTagger.JetBProbabilityBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloTrackCountingHighEffBJetTags = akPu4CalobTagger.TrackCountingHighEffBJetTags
+akPu4CaloTrackCountingHighPurBJetTags = akPu4CalobTagger.TrackCountingHighPurBJetTags
+akPu4CaloPatJetPartonAssociationLegacy = akPu4CalobTagger.PatJetPartonAssociationLegacy
+
+akPu4CaloImpactParameterTagInfos = akPu4CalobTagger.ImpactParameterTagInfos
+akPu4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloJetProbabilityBJetTags = akPu4CalobTagger.JetProbabilityBJetTags
+
+akPu4CaloSecondaryVertexTagInfos = akPu4CalobTagger.SecondaryVertexTagInfos
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSecondaryVertexNegativeTagInfos = akPu4CalobTagger.SecondaryVertexNegativeTagInfos
+akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexBJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4CaloPositiveCombinedSecondaryVertexBJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSoftPFMuonsTagInfos = akPu4CalobTagger.SoftPFMuonsTagInfos
+akPu4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloSoftPFMuonBJetTags = akPu4CalobTagger.SoftPFMuonBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloNegativeSoftPFMuonByPtBJetTags = akPu4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4CaloPositiveSoftPFMuonByPtBJetTags = akPu4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4CaloPatJetFlavourIdLegacy = cms.Sequence(akPu4CaloPatJetPartonAssociationLegacy*akPu4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4CaloPatJetFlavourAssociation = akPu4CalobTagger.PatJetFlavourAssociation
+#akPu4CaloPatJetFlavourId = cms.Sequence(akPu4CaloPatJetPartons*akPu4CaloPatJetFlavourAssociation)
+
+akPu4CaloJetBtaggingIP       = cms.Sequence(akPu4CaloImpactParameterTagInfos *
+            (akPu4CaloTrackCountingHighEffBJetTags +
+             akPu4CaloTrackCountingHighPurBJetTags +
+             akPu4CaloJetProbabilityBJetTags +
+             akPu4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4CaloJetBtaggingSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexTagInfos
+            * (akPu4CaloSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloCombinedSecondaryVertexBJetTags+
+                akPu4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingNegSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexNegativeTagInfos
+            * (akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexBJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingMu = cms.Sequence(akPu4CaloSoftPFMuonsTagInfos * (akPu4CaloSoftPFMuonBJetTags
+                +
+                akPu4CaloSoftPFMuonByIP3dBJetTags
+                +
+                akPu4CaloSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4CaloJetBtagging = cms.Sequence(akPu4CaloJetBtaggingIP
+            *akPu4CaloJetBtaggingSV
+            *akPu4CaloJetBtaggingNegSV
+#            *akPu4CaloJetBtaggingMu
+            )
+
+akPu4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4CaloJets"),
+        genJetMatch          = cms.InputTag("akPu4Calomatch"),
+        genPartonMatch       = cms.InputTag("akPu4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4CalopatJetsWithBtagging.userData.userFloats.src += ['akPu4CaloNjettiness:tau1','akPu4CaloNjettiness:tau2','akPu4CaloNjettiness:tau3']
+
+akPu4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4Calo"),
+                                                             jetName = cms.untracked.string("akPu4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4CaloJetSequence_mc = cms.Sequence(
+                                                  #akPu4Caloclean
+                                                  #*
+                                                  akPu4Calomatch
+                                                  #*
+                                                  #akPu4CalomatchGroomed
+                                                  *
+                                                  akPu4Caloparton
+                                                  *
+                                                  akPu4Calocorr
+                                                  *
+                                                  #akPu4CaloJetID
+                                                  #*
+                                                  akPu4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4CaloJetBtagging
+                                                  *
+                                                  akPu4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4CalopatJetsWithBtagging
+                                                  *
+                                                  akPu4CaloJetAnalyzer
+                                                  )
+
+akPu4CaloJetSequence_data = cms.Sequence(akPu4Calocorr
+                                                    *
+                                                    #akPu4CaloJetID
+                                                    #*
+                                                    akPu4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4CaloJetBtagging
+                                                    *
+                                                    akPu4CaloNjettiness 
+                                                    *
+                                                    akPu4CalopatJetsWithBtagging
+                                                    *
+                                                    akPu4CaloJetAnalyzer
+                                                    )
+
+akPu4CaloJetSequence_jec = cms.Sequence(akPu4CaloJetSequence_mc)
+akPu4CaloJetSequence_mb = cms.Sequence(akPu4CaloJetSequence_mc)
+
+akPu4CaloJetSequence = cms.Sequence(akPu4CaloJetSequence_mb)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4CaloJetSequence_pPb_mc_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4Calomatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4CaloJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4CalomatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets")
+                                                        )
+
+akPu4Calocorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4CaloJets"),
+    payload = "AKPu4Calo"
+    )
+
+akPu4CaloJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4Caloclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4CalobTagger = bTaggers("akPu4Calo",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4Calomatch = akPu4CalobTagger.match
+akPu4Caloparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4CaloJets"), matched = cms.InputTag("genParticles"))
+akPu4CaloPatJetFlavourAssociationLegacy = akPu4CalobTagger.PatJetFlavourAssociationLegacy
+akPu4CaloPatJetPartons = akPu4CalobTagger.PatJetPartons
+akPu4CaloJetTracksAssociatorAtVertex = akPu4CalobTagger.JetTracksAssociatorAtVertex
+akPu4CaloJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+akPu4CaloJetBProbabilityBJetTags = akPu4CalobTagger.JetBProbabilityBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloTrackCountingHighEffBJetTags = akPu4CalobTagger.TrackCountingHighEffBJetTags
+akPu4CaloTrackCountingHighPurBJetTags = akPu4CalobTagger.TrackCountingHighPurBJetTags
+akPu4CaloPatJetPartonAssociationLegacy = akPu4CalobTagger.PatJetPartonAssociationLegacy
+
+akPu4CaloImpactParameterTagInfos = akPu4CalobTagger.ImpactParameterTagInfos
+akPu4CaloImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloJetProbabilityBJetTags = akPu4CalobTagger.JetProbabilityBJetTags
+
+akPu4CaloSecondaryVertexTagInfos = akPu4CalobTagger.SecondaryVertexTagInfos
+akPu4CaloSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4CaloSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4CaloCombinedSecondaryVertexBJetTags = akPu4CalobTagger.CombinedSecondaryVertexBJetTags
+akPu4CaloCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSecondaryVertexNegativeTagInfos = akPu4CalobTagger.SecondaryVertexNegativeTagInfos
+akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4CalobTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexBJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4CaloPositiveCombinedSecondaryVertexBJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags = akPu4CalobTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4CaloSoftPFMuonsTagInfos = akPu4CalobTagger.SoftPFMuonsTagInfos
+akPu4CaloSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4CaloSoftPFMuonBJetTags = akPu4CalobTagger.SoftPFMuonBJetTags
+akPu4CaloSoftPFMuonByIP3dBJetTags = akPu4CalobTagger.SoftPFMuonByIP3dBJetTags
+akPu4CaloSoftPFMuonByPtBJetTags = akPu4CalobTagger.SoftPFMuonByPtBJetTags
+akPu4CaloNegativeSoftPFMuonByPtBJetTags = akPu4CalobTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4CaloPositiveSoftPFMuonByPtBJetTags = akPu4CalobTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4CaloPatJetFlavourIdLegacy = cms.Sequence(akPu4CaloPatJetPartonAssociationLegacy*akPu4CaloPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4CaloPatJetFlavourAssociation = akPu4CalobTagger.PatJetFlavourAssociation
+#akPu4CaloPatJetFlavourId = cms.Sequence(akPu4CaloPatJetPartons*akPu4CaloPatJetFlavourAssociation)
+
+akPu4CaloJetBtaggingIP       = cms.Sequence(akPu4CaloImpactParameterTagInfos *
+            (akPu4CaloTrackCountingHighEffBJetTags +
+             akPu4CaloTrackCountingHighPurBJetTags +
+             akPu4CaloJetProbabilityBJetTags +
+             akPu4CaloJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4CaloJetBtaggingSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexTagInfos
+            * (akPu4CaloSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloCombinedSecondaryVertexBJetTags+
+                akPu4CaloCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingNegSV = cms.Sequence(akPu4CaloImpactParameterTagInfos
+            *
+            akPu4CaloSecondaryVertexNegativeTagInfos
+            * (akPu4CaloNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4CaloNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexBJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexBJetTags+
+                akPu4CaloNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4CaloPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4CaloJetBtaggingMu = cms.Sequence(akPu4CaloSoftPFMuonsTagInfos * (akPu4CaloSoftPFMuonBJetTags
+                +
+                akPu4CaloSoftPFMuonByIP3dBJetTags
+                +
+                akPu4CaloSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4CaloPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4CaloJetBtagging = cms.Sequence(akPu4CaloJetBtaggingIP
+            *akPu4CaloJetBtaggingSV
+            *akPu4CaloJetBtaggingNegSV
+#            *akPu4CaloJetBtaggingMu
+            )
+
+akPu4CalopatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4CaloJets"),
+        genJetMatch          = cms.InputTag("akPu4Calomatch"),
+        genPartonMatch       = cms.InputTag("akPu4Caloparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4Calocorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4CaloPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4CaloJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4CaloSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4CaloSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4CaloCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4CaloJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4CaloJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4CaloSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4CaloTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4CaloJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4CaloNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4CaloJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4CalopatJetsWithBtagging.userData.userFloats.src += ['akPu4CaloNjettiness:tau1','akPu4CaloNjettiness:tau2','akPu4CaloNjettiness:tau3']
+
+akPu4CaloJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4CalopatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4Calo"),
+                                                             jetName = cms.untracked.string("akPu4Calo"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4CaloJetSequence_mc = cms.Sequence(
+                                                  #akPu4Caloclean
+                                                  #*
+                                                  akPu4Calomatch
+                                                  #*
+                                                  #akPu4CalomatchGroomed
+                                                  *
+                                                  akPu4Caloparton
+                                                  *
+                                                  akPu4Calocorr
+                                                  *
+                                                  #akPu4CaloJetID
+                                                  #*
+                                                  akPu4CaloPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4CaloPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4CaloJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4CaloJetBtagging
+                                                  *
+                                                  akPu4CaloNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4CalopatJetsWithBtagging
+                                                  *
+                                                  akPu4CaloJetAnalyzer
+                                                  )
+
+akPu4CaloJetSequence_data = cms.Sequence(akPu4Calocorr
+                                                    *
+                                                    #akPu4CaloJetID
+                                                    #*
+                                                    akPu4CaloJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4CaloJetBtagging
+                                                    *
+                                                    akPu4CaloNjettiness 
+                                                    *
+                                                    akPu4CalopatJetsWithBtagging
+                                                    *
+                                                    akPu4CaloJetAnalyzer
+                                                    )
+
+akPu4CaloJetSequence_jec = cms.Sequence(akPu4CaloJetSequence_mc)
+akPu4CaloJetSequence_mb = cms.Sequence(akPu4CaloJetSequence_mc)
+
+akPu4CaloJetSequence = cms.Sequence(akPu4CaloJetSequence_mc)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_data_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets")
+                                                        )
+
+akPu4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4PFJets"),
+    payload = "AKPu4PF"
+    )
+
+akPu4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4PFbTagger = bTaggers("akPu4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4PFmatch = akPu4PFbTagger.match
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets"), matched = cms.InputTag("genParticles"))
+akPu4PFPatJetFlavourAssociationLegacy = akPu4PFbTagger.PatJetFlavourAssociationLegacy
+akPu4PFPatJetPartons = akPu4PFbTagger.PatJetPartons
+akPu4PFJetTracksAssociatorAtVertex = akPu4PFbTagger.JetTracksAssociatorAtVertex
+akPu4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+akPu4PFJetBProbabilityBJetTags = akPu4PFbTagger.JetBProbabilityBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFTrackCountingHighEffBJetTags = akPu4PFbTagger.TrackCountingHighEffBJetTags
+akPu4PFTrackCountingHighPurBJetTags = akPu4PFbTagger.TrackCountingHighPurBJetTags
+akPu4PFPatJetPartonAssociationLegacy = akPu4PFbTagger.PatJetPartonAssociationLegacy
+
+akPu4PFImpactParameterTagInfos = akPu4PFbTagger.ImpactParameterTagInfos
+akPu4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFJetProbabilityBJetTags = akPu4PFbTagger.JetProbabilityBJetTags
+
+akPu4PFSecondaryVertexTagInfos = akPu4PFbTagger.SecondaryVertexTagInfos
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4PFSecondaryVertexNegativeTagInfos = akPu4PFbTagger.SecondaryVertexNegativeTagInfos
+akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4PFNegativeCombinedSecondaryVertexBJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4PFPositiveCombinedSecondaryVertexBJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4PFNegativeCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4PFPositiveCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4PFSoftPFMuonsTagInfos = akPu4PFbTagger.SoftPFMuonsTagInfos
+akPu4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFSoftPFMuonBJetTags = akPu4PFbTagger.SoftPFMuonBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFNegativeSoftPFMuonByPtBJetTags = akPu4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4PFPositiveSoftPFMuonByPtBJetTags = akPu4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4PFPatJetFlavourIdLegacy = cms.Sequence(akPu4PFPatJetPartonAssociationLegacy*akPu4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4PFPatJetFlavourAssociation = akPu4PFbTagger.PatJetFlavourAssociation
+#akPu4PFPatJetFlavourId = cms.Sequence(akPu4PFPatJetPartons*akPu4PFPatJetFlavourAssociation)
+
+akPu4PFJetBtaggingIP       = cms.Sequence(akPu4PFImpactParameterTagInfos *
+            (akPu4PFTrackCountingHighEffBJetTags +
+             akPu4PFTrackCountingHighPurBJetTags +
+             akPu4PFJetProbabilityBJetTags +
+             akPu4PFJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4PFJetBtaggingSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexTagInfos
+            * (akPu4PFSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFCombinedSecondaryVertexBJetTags+
+                akPu4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingNegSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexNegativeTagInfos
+            * (akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexBJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingMu = cms.Sequence(akPu4PFSoftPFMuonsTagInfos * (akPu4PFSoftPFMuonBJetTags
+                +
+                akPu4PFSoftPFMuonByIP3dBJetTags
+                +
+                akPu4PFSoftPFMuonByPtBJetTags
+                +
+                akPu4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4PFJetBtagging = cms.Sequence(akPu4PFJetBtaggingIP
+            *akPu4PFJetBtaggingSV
+            *akPu4PFJetBtaggingNegSV
+#            *akPu4PFJetBtaggingMu
+            )
+
+akPu4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4PFJets"),
+        genJetMatch          = cms.InputTag("akPu4PFmatch"),
+        genPartonMatch       = cms.InputTag("akPu4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4PFJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4PFJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = False,
+        addGenPartonMatch = False,
+        addGenJetMatch = False,
+        embedGenJetMatch = False,
+        embedGenPartonMatch = False,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4PFpatJetsWithBtagging.userData.userFloats.src += ['akPu4PFNjettiness:tau1','akPu4PFNjettiness:tau2','akPu4PFNjettiness:tau3']
+
+akPu4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = False,
+                                                             isMC = False,
+							     doSubEvent = False,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4PF"),
+                                                             jetName = cms.untracked.string("akPu4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = False
+                                                             )
+
+akPu4PFJetSequence_mc = cms.Sequence(
+                                                  #akPu4PFclean
+                                                  #*
+                                                  akPu4PFmatch
+                                                  #*
+                                                  #akPu4PFmatchGroomed
+                                                  *
+                                                  akPu4PFparton
+                                                  *
+                                                  akPu4PFcorr
+                                                  *
+                                                  #akPu4PFJetID
+                                                  #*
+                                                  akPu4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4PFJetBtagging
+                                                  *
+                                                  akPu4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4PFpatJetsWithBtagging
+                                                  *
+                                                  akPu4PFJetAnalyzer
+                                                  )
+
+akPu4PFJetSequence_data = cms.Sequence(akPu4PFcorr
+                                                    *
+                                                    #akPu4PFJetID
+                                                    #*
+                                                    akPu4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4PFJetBtagging
+                                                    *
+                                                    akPu4PFNjettiness 
+                                                    *
+                                                    akPu4PFpatJetsWithBtagging
+                                                    *
+                                                    akPu4PFJetAnalyzer
+                                                    )
+
+akPu4PFJetSequence_jec = cms.Sequence(akPu4PFJetSequence_mc)
+akPu4PFJetSequence_mb = cms.Sequence(akPu4PFJetSequence_mc)
+
+akPu4PFJetSequence = cms.Sequence(akPu4PFJetSequence_data)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_jec_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_jec_cff.py
@@ -1,0 +1,253 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets")
+                                                        )
+
+akPu4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4PFJets"),
+    payload = "AKPu4PF"
+    )
+
+akPu4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4PFbTagger = bTaggers("akPu4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4PFmatch = akPu4PFbTagger.match
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets"), matched = cms.InputTag("genParticles"))
+akPu4PFPatJetFlavourAssociationLegacy = akPu4PFbTagger.PatJetFlavourAssociationLegacy
+akPu4PFPatJetPartons = akPu4PFbTagger.PatJetPartons
+akPu4PFJetTracksAssociatorAtVertex = akPu4PFbTagger.JetTracksAssociatorAtVertex
+akPu4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+akPu4PFJetBProbabilityBJetTags = akPu4PFbTagger.JetBProbabilityBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFTrackCountingHighEffBJetTags = akPu4PFbTagger.TrackCountingHighEffBJetTags
+akPu4PFTrackCountingHighPurBJetTags = akPu4PFbTagger.TrackCountingHighPurBJetTags
+akPu4PFPatJetPartonAssociationLegacy = akPu4PFbTagger.PatJetPartonAssociationLegacy
+
+akPu4PFImpactParameterTagInfos = akPu4PFbTagger.ImpactParameterTagInfos
+akPu4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFJetProbabilityBJetTags = akPu4PFbTagger.JetProbabilityBJetTags
+
+akPu4PFSecondaryVertexTagInfos = akPu4PFbTagger.SecondaryVertexTagInfos
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4PFSecondaryVertexNegativeTagInfos = akPu4PFbTagger.SecondaryVertexNegativeTagInfos
+akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4PFNegativeCombinedSecondaryVertexBJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4PFPositiveCombinedSecondaryVertexBJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4PFNegativeCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4PFPositiveCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4PFSoftPFMuonsTagInfos = akPu4PFbTagger.SoftPFMuonsTagInfos
+akPu4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFSoftPFMuonBJetTags = akPu4PFbTagger.SoftPFMuonBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFNegativeSoftPFMuonByPtBJetTags = akPu4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4PFPositiveSoftPFMuonByPtBJetTags = akPu4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4PFPatJetFlavourIdLegacy = cms.Sequence(akPu4PFPatJetPartonAssociationLegacy*akPu4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4PFPatJetFlavourAssociation = akPu4PFbTagger.PatJetFlavourAssociation
+#akPu4PFPatJetFlavourId = cms.Sequence(akPu4PFPatJetPartons*akPu4PFPatJetFlavourAssociation)
+
+akPu4PFJetBtaggingIP       = cms.Sequence(akPu4PFImpactParameterTagInfos *
+            (akPu4PFTrackCountingHighEffBJetTags +
+             akPu4PFTrackCountingHighPurBJetTags +
+             akPu4PFJetProbabilityBJetTags +
+             akPu4PFJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4PFJetBtaggingSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexTagInfos
+            * (akPu4PFSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFCombinedSecondaryVertexBJetTags+
+                akPu4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingNegSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexNegativeTagInfos
+            * (akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexBJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingMu = cms.Sequence(akPu4PFSoftPFMuonsTagInfos * (akPu4PFSoftPFMuonBJetTags
+                +
+                akPu4PFSoftPFMuonByIP3dBJetTags
+                +
+                akPu4PFSoftPFMuonByPtBJetTags
+                +
+                akPu4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4PFJetBtagging = cms.Sequence(akPu4PFJetBtaggingIP
+            *akPu4PFJetBtaggingSV
+            *akPu4PFJetBtaggingNegSV
+#            *akPu4PFJetBtaggingMu
+            )
+
+akPu4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4PFJets"),
+        genJetMatch          = cms.InputTag("akPu4PFmatch"),
+        genPartonMatch       = cms.InputTag("akPu4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4PFJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4PFJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4PFpatJetsWithBtagging.userData.userFloats.src += ['akPu4PFNjettiness:tau1','akPu4PFNjettiness:tau2','akPu4PFNjettiness:tau3']
+
+akPu4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4PF"),
+                                                             jetName = cms.untracked.string("akPu4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4PFJetSequence_mc = cms.Sequence(
+                                                  #akPu4PFclean
+                                                  #*
+                                                  akPu4PFmatch
+                                                  #*
+                                                  #akPu4PFmatchGroomed
+                                                  *
+                                                  akPu4PFparton
+                                                  *
+                                                  akPu4PFcorr
+                                                  *
+                                                  #akPu4PFJetID
+                                                  #*
+                                                  akPu4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4PFJetBtagging
+                                                  *
+                                                  akPu4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4PFpatJetsWithBtagging
+                                                  *
+                                                  akPu4PFJetAnalyzer
+                                                  )
+
+akPu4PFJetSequence_data = cms.Sequence(akPu4PFcorr
+                                                    *
+                                                    #akPu4PFJetID
+                                                    #*
+                                                    akPu4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4PFJetBtagging
+                                                    *
+                                                    akPu4PFNjettiness 
+                                                    *
+                                                    akPu4PFpatJetsWithBtagging
+                                                    *
+                                                    akPu4PFJetAnalyzer
+                                                    )
+
+akPu4PFJetSequence_jec = cms.Sequence(akPu4PFJetSequence_mc)
+akPu4PFJetSequence_mb = cms.Sequence(akPu4PFJetSequence_mc)
+
+akPu4PFJetSequence = cms.Sequence(akPu4PFJetSequence_jec)
+akPu4PFJetAnalyzer.genPtMin = cms.untracked.double(1)
+akPu4PFJetAnalyzer.jetPtMin = cms.double(1)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_mb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_mb_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets")
+                                                        )
+
+akPu4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4PFJets"),
+    payload = "AKPu4PF"
+    )
+
+akPu4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4PFbTagger = bTaggers("akPu4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4PFmatch = akPu4PFbTagger.match
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets"), matched = cms.InputTag("genParticles"))
+akPu4PFPatJetFlavourAssociationLegacy = akPu4PFbTagger.PatJetFlavourAssociationLegacy
+akPu4PFPatJetPartons = akPu4PFbTagger.PatJetPartons
+akPu4PFJetTracksAssociatorAtVertex = akPu4PFbTagger.JetTracksAssociatorAtVertex
+akPu4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+akPu4PFJetBProbabilityBJetTags = akPu4PFbTagger.JetBProbabilityBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFTrackCountingHighEffBJetTags = akPu4PFbTagger.TrackCountingHighEffBJetTags
+akPu4PFTrackCountingHighPurBJetTags = akPu4PFbTagger.TrackCountingHighPurBJetTags
+akPu4PFPatJetPartonAssociationLegacy = akPu4PFbTagger.PatJetPartonAssociationLegacy
+
+akPu4PFImpactParameterTagInfos = akPu4PFbTagger.ImpactParameterTagInfos
+akPu4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFJetProbabilityBJetTags = akPu4PFbTagger.JetProbabilityBJetTags
+
+akPu4PFSecondaryVertexTagInfos = akPu4PFbTagger.SecondaryVertexTagInfos
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4PFSecondaryVertexNegativeTagInfos = akPu4PFbTagger.SecondaryVertexNegativeTagInfos
+akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4PFNegativeCombinedSecondaryVertexBJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4PFPositiveCombinedSecondaryVertexBJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4PFNegativeCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4PFPositiveCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4PFSoftPFMuonsTagInfos = akPu4PFbTagger.SoftPFMuonsTagInfos
+akPu4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFSoftPFMuonBJetTags = akPu4PFbTagger.SoftPFMuonBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFNegativeSoftPFMuonByPtBJetTags = akPu4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4PFPositiveSoftPFMuonByPtBJetTags = akPu4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4PFPatJetFlavourIdLegacy = cms.Sequence(akPu4PFPatJetPartonAssociationLegacy*akPu4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4PFPatJetFlavourAssociation = akPu4PFbTagger.PatJetFlavourAssociation
+#akPu4PFPatJetFlavourId = cms.Sequence(akPu4PFPatJetPartons*akPu4PFPatJetFlavourAssociation)
+
+akPu4PFJetBtaggingIP       = cms.Sequence(akPu4PFImpactParameterTagInfos *
+            (akPu4PFTrackCountingHighEffBJetTags +
+             akPu4PFTrackCountingHighPurBJetTags +
+             akPu4PFJetProbabilityBJetTags +
+             akPu4PFJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4PFJetBtaggingSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexTagInfos
+            * (akPu4PFSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFCombinedSecondaryVertexBJetTags+
+                akPu4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingNegSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexNegativeTagInfos
+            * (akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexBJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingMu = cms.Sequence(akPu4PFSoftPFMuonsTagInfos * (akPu4PFSoftPFMuonBJetTags
+                +
+                akPu4PFSoftPFMuonByIP3dBJetTags
+                +
+                akPu4PFSoftPFMuonByPtBJetTags
+                +
+                akPu4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4PFJetBtagging = cms.Sequence(akPu4PFJetBtaggingIP
+            *akPu4PFJetBtaggingSV
+            *akPu4PFJetBtaggingNegSV
+#            *akPu4PFJetBtaggingMu
+            )
+
+akPu4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4PFJets"),
+        genJetMatch          = cms.InputTag("akPu4PFmatch"),
+        genPartonMatch       = cms.InputTag("akPu4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4PFJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4PFJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4PFpatJetsWithBtagging.userData.userFloats.src += ['akPu4PFNjettiness:tau1','akPu4PFNjettiness:tau2','akPu4PFNjettiness:tau3']
+
+akPu4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4PF"),
+                                                             jetName = cms.untracked.string("akPu4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4PFJetSequence_mc = cms.Sequence(
+                                                  #akPu4PFclean
+                                                  #*
+                                                  akPu4PFmatch
+                                                  #*
+                                                  #akPu4PFmatchGroomed
+                                                  *
+                                                  akPu4PFparton
+                                                  *
+                                                  akPu4PFcorr
+                                                  *
+                                                  #akPu4PFJetID
+                                                  #*
+                                                  akPu4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4PFJetBtagging
+                                                  *
+                                                  akPu4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4PFpatJetsWithBtagging
+                                                  *
+                                                  akPu4PFJetAnalyzer
+                                                  )
+
+akPu4PFJetSequence_data = cms.Sequence(akPu4PFcorr
+                                                    *
+                                                    #akPu4PFJetID
+                                                    #*
+                                                    akPu4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4PFJetBtagging
+                                                    *
+                                                    akPu4PFNjettiness 
+                                                    *
+                                                    akPu4PFpatJetsWithBtagging
+                                                    *
+                                                    akPu4PFJetAnalyzer
+                                                    )
+
+akPu4PFJetSequence_jec = cms.Sequence(akPu4PFJetSequence_mc)
+akPu4PFJetSequence_mb = cms.Sequence(akPu4PFJetSequence_mc)
+
+akPu4PFJetSequence = cms.Sequence(akPu4PFJetSequence_mb)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/akPu4PFJetSequence_pPb_mc_cff.py
@@ -1,0 +1,251 @@
+
+
+import FWCore.ParameterSet.Config as cms
+from HeavyIonsAnalysis.JetAnalysis.patHeavyIonSequences_cff import patJetGenJetMatch, patJetPartonMatch, patJetCorrFactors, patJets
+from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
+from HeavyIonsAnalysis.JetAnalysis.bTaggers_cff import *
+from RecoJets.JetProducers.JetIDParams_cfi import *
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+
+akPu4PFmatch = patJetGenJetMatch.clone(
+    src = cms.InputTag("akPu4PFJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFmatchGroomed = patJetGenJetMatch.clone(
+    src = cms.InputTag("ak4GenJets"),
+    matched = cms.InputTag("ak4GenJets"),
+    resolveByMatchQuality = cms.bool(False),
+    maxDeltaR = 0.4
+    )
+
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets")
+                                                        )
+
+akPu4PFcorr = patJetCorrFactors.clone(
+    useNPV = cms.bool(False),
+    useRho = cms.bool(False),
+#    primaryVertices = cms.InputTag("hiSelectedVertex"),
+    levels   = cms.vstring('L2Relative','L3Absolute'),
+    src = cms.InputTag("akPu4PFJets"),
+    payload = "AKPu4PF"
+    )
+
+akPu4PFJetID= cms.EDProducer('JetIDProducer', JetIDParams, src = cms.InputTag('akPu4CaloJets'))
+
+#akPu4PFclean   = heavyIonCleanedGenJets.clone(src = cms.InputTag('ak4GenJets'))
+
+akPu4PFbTagger = bTaggers("akPu4PF",0.4)
+
+#create objects locally since they dont load properly otherwise
+#akPu4PFmatch = akPu4PFbTagger.match
+akPu4PFparton = patJetPartonMatch.clone(src = cms.InputTag("akPu4PFJets"), matched = cms.InputTag("genParticles"))
+akPu4PFPatJetFlavourAssociationLegacy = akPu4PFbTagger.PatJetFlavourAssociationLegacy
+akPu4PFPatJetPartons = akPu4PFbTagger.PatJetPartons
+akPu4PFJetTracksAssociatorAtVertex = akPu4PFbTagger.JetTracksAssociatorAtVertex
+akPu4PFJetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+akPu4PFJetBProbabilityBJetTags = akPu4PFbTagger.JetBProbabilityBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFTrackCountingHighEffBJetTags = akPu4PFbTagger.TrackCountingHighEffBJetTags
+akPu4PFTrackCountingHighPurBJetTags = akPu4PFbTagger.TrackCountingHighPurBJetTags
+akPu4PFPatJetPartonAssociationLegacy = akPu4PFbTagger.PatJetPartonAssociationLegacy
+
+akPu4PFImpactParameterTagInfos = akPu4PFbTagger.ImpactParameterTagInfos
+akPu4PFImpactParameterTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFJetProbabilityBJetTags = akPu4PFbTagger.JetProbabilityBJetTags
+
+akPu4PFSecondaryVertexTagInfos = akPu4PFbTagger.SecondaryVertexTagInfos
+akPu4PFSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighEffBJetTags
+akPu4PFSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.SimpleSecondaryVertexHighPurBJetTags
+akPu4PFCombinedSecondaryVertexBJetTags = akPu4PFbTagger.CombinedSecondaryVertexBJetTags
+akPu4PFCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.CombinedSecondaryVertexV2BJetTags
+
+akPu4PFSecondaryVertexNegativeTagInfos = akPu4PFbTagger.SecondaryVertexNegativeTagInfos
+akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighEffBJetTags
+akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags = akPu4PFbTagger.NegativeSimpleSecondaryVertexHighPurBJetTags
+akPu4PFNegativeCombinedSecondaryVertexBJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexBJetTags
+akPu4PFPositiveCombinedSecondaryVertexBJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexBJetTags
+akPu4PFNegativeCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.NegativeCombinedSecondaryVertexV2BJetTags
+akPu4PFPositiveCombinedSecondaryVertexV2BJetTags = akPu4PFbTagger.PositiveCombinedSecondaryVertexV2BJetTags
+
+akPu4PFSoftPFMuonsTagInfos = akPu4PFbTagger.SoftPFMuonsTagInfos
+akPu4PFSoftPFMuonsTagInfos.primaryVertex = cms.InputTag("offlinePrimaryVertices")
+akPu4PFSoftPFMuonBJetTags = akPu4PFbTagger.SoftPFMuonBJetTags
+akPu4PFSoftPFMuonByIP3dBJetTags = akPu4PFbTagger.SoftPFMuonByIP3dBJetTags
+akPu4PFSoftPFMuonByPtBJetTags = akPu4PFbTagger.SoftPFMuonByPtBJetTags
+akPu4PFNegativeSoftPFMuonByPtBJetTags = akPu4PFbTagger.NegativeSoftPFMuonByPtBJetTags
+akPu4PFPositiveSoftPFMuonByPtBJetTags = akPu4PFbTagger.PositiveSoftPFMuonByPtBJetTags
+akPu4PFPatJetFlavourIdLegacy = cms.Sequence(akPu4PFPatJetPartonAssociationLegacy*akPu4PFPatJetFlavourAssociationLegacy)
+#Not working with our PU sub, but keep it here for reference
+#akPu4PFPatJetFlavourAssociation = akPu4PFbTagger.PatJetFlavourAssociation
+#akPu4PFPatJetFlavourId = cms.Sequence(akPu4PFPatJetPartons*akPu4PFPatJetFlavourAssociation)
+
+akPu4PFJetBtaggingIP       = cms.Sequence(akPu4PFImpactParameterTagInfos *
+            (akPu4PFTrackCountingHighEffBJetTags +
+             akPu4PFTrackCountingHighPurBJetTags +
+             akPu4PFJetProbabilityBJetTags +
+             akPu4PFJetBProbabilityBJetTags 
+            )
+            )
+
+akPu4PFJetBtaggingSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexTagInfos
+            * (akPu4PFSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFCombinedSecondaryVertexBJetTags+
+                akPu4PFCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingNegSV = cms.Sequence(akPu4PFImpactParameterTagInfos
+            *
+            akPu4PFSecondaryVertexNegativeTagInfos
+            * (akPu4PFNegativeSimpleSecondaryVertexHighEffBJetTags+
+                akPu4PFNegativeSimpleSecondaryVertexHighPurBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexBJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexBJetTags+
+                akPu4PFNegativeCombinedSecondaryVertexV2BJetTags+
+                akPu4PFPositiveCombinedSecondaryVertexV2BJetTags
+              )
+            )
+
+akPu4PFJetBtaggingMu = cms.Sequence(akPu4PFSoftPFMuonsTagInfos * (akPu4PFSoftPFMuonBJetTags
+                +
+                akPu4PFSoftPFMuonByIP3dBJetTags
+                +
+                akPu4PFSoftPFMuonByPtBJetTags
+                +
+                akPu4PFNegativeSoftPFMuonByPtBJetTags
+                +
+                akPu4PFPositiveSoftPFMuonByPtBJetTags
+              )
+            )
+
+akPu4PFJetBtagging = cms.Sequence(akPu4PFJetBtaggingIP
+            *akPu4PFJetBtaggingSV
+            *akPu4PFJetBtaggingNegSV
+#            *akPu4PFJetBtaggingMu
+            )
+
+akPu4PFpatJetsWithBtagging = patJets.clone(jetSource = cms.InputTag("akPu4PFJets"),
+        genJetMatch          = cms.InputTag("akPu4PFmatch"),
+        genPartonMatch       = cms.InputTag("akPu4PFparton"),
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("akPu4PFcorr")),
+        JetPartonMapSource   = cms.InputTag("akPu4PFPatJetFlavourAssociationLegacy"),
+	JetFlavourInfoSource   = cms.InputTag("akPu4PFPatJetFlavourAssociation"),
+        trackAssociationSource = cms.InputTag("akPu4PFJetTracksAssociatorAtVertex"),
+	useLegacyJetMCFlavour = True,
+        discriminatorSources = cms.VInputTag(cms.InputTag("akPu4PFSimpleSecondaryVertexHighEffBJetTags"),
+            cms.InputTag("akPu4PFSimpleSecondaryVertexHighPurBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexBJetTags"),
+            cms.InputTag("akPu4PFCombinedSecondaryVertexV2BJetTags"),
+            cms.InputTag("akPu4PFJetBProbabilityBJetTags"),
+            cms.InputTag("akPu4PFJetProbabilityBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByPtBJetTags"),
+            #cms.InputTag("akPu4PFSoftPFMuonByIP3dBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighEffBJetTags"),
+            cms.InputTag("akPu4PFTrackCountingHighPurBJetTags"),
+            ),
+        jetIDMap = cms.InputTag("akPu4PFJetID"),
+        addBTagInfo = True,
+        addTagInfos = True,
+        addDiscriminators = True,
+        addAssociatedTracks = True,
+        addJetCharge = False,
+        addJetID = False,
+        getJetMCFlavour = True,
+        addGenPartonMatch = True,
+        addGenJetMatch = True,
+        embedGenJetMatch = True,
+        embedGenPartonMatch = True,
+        # embedCaloTowers = False,
+        # embedPFCandidates = True
+        )
+
+akPu4PFNjettiness = Njettiness.clone(
+		    src = cms.InputTag("akPu4PFJets"),
+           	    R0  = cms.double( 0.4)
+)
+akPu4PFpatJetsWithBtagging.userData.userFloats.src += ['akPu4PFNjettiness:tau1','akPu4PFNjettiness:tau2','akPu4PFNjettiness:tau3']
+
+akPu4PFJetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = cms.InputTag("akPu4PFpatJetsWithBtagging"),
+                                                             genjetTag = 'ak4GenJets',
+                                                             rParam = 0.4,
+                                                             matchJets = cms.untracked.bool(False),
+                                                             matchTag = 'patJetsWithBtagging',
+                                                             pfCandidateLabel = cms.untracked.InputTag('particleFlow'),
+                                                             trackTag = cms.InputTag("generalTracks"),
+                                                             fillGenJets = True,
+                                                             isMC = True,
+							     doSubEvent = True,
+                                                             useHepMC = cms.untracked.bool(False),
+							     genParticles = cms.untracked.InputTag("genParticles"),
+							     eventInfoTag = cms.InputTag("generator"),
+                                                             doLifeTimeTagging = cms.untracked.bool(True),
+                                                             doLifeTimeTaggingExtras = cms.untracked.bool(False),
+                                                             bTagJetName = cms.untracked.string("akPu4PF"),
+                                                             jetName = cms.untracked.string("akPu4PF"),
+                                                             genPtMin = cms.untracked.double(5),
+                                                             hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+							     doTower = cms.untracked.bool(True),
+							     doSubJets = cms.untracked.bool(False),
+                                                             doGenSubJets = cms.untracked.bool(False),     
+                                                             subjetGenTag = cms.untracked.InputTag("ak4GenJets"),
+                                                             doGenTaus = True
+                                                             )
+
+akPu4PFJetSequence_mc = cms.Sequence(
+                                                  #akPu4PFclean
+                                                  #*
+                                                  akPu4PFmatch
+                                                  #*
+                                                  #akPu4PFmatchGroomed
+                                                  *
+                                                  akPu4PFparton
+                                                  *
+                                                  akPu4PFcorr
+                                                  *
+                                                  #akPu4PFJetID
+                                                  #*
+                                                  akPu4PFPatJetFlavourIdLegacy
+                                                  #*
+			                          #akPu4PFPatJetFlavourId  # Use legacy algo till PU implemented
+                                                  *
+                                                  akPu4PFJetTracksAssociatorAtVertex
+                                                  *
+                                                  akPu4PFJetBtagging
+                                                  *
+                                                  akPu4PFNjettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
+                                                  *
+                                                  akPu4PFpatJetsWithBtagging
+                                                  *
+                                                  akPu4PFJetAnalyzer
+                                                  )
+
+akPu4PFJetSequence_data = cms.Sequence(akPu4PFcorr
+                                                    *
+                                                    #akPu4PFJetID
+                                                    #*
+                                                    akPu4PFJetTracksAssociatorAtVertex
+                                                    *
+                                                    akPu4PFJetBtagging
+                                                    *
+                                                    akPu4PFNjettiness 
+                                                    *
+                                                    akPu4PFpatJetsWithBtagging
+                                                    *
+                                                    akPu4PFJetAnalyzer
+                                                    )
+
+akPu4PFJetSequence_jec = cms.Sequence(akPu4PFJetSequence_mc)
+akPu4PFJetSequence_mb = cms.Sequence(akPu4PFJetSequence_mc)
+
+akPu4PFJetSequence = cms.Sequence(akPu4PFJetSequence_mc)

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -19,7 +19,7 @@ do
                         do
 			    # no Cs Calo or pp jets
 			    
-                            if( [ $system == "pPb" ] ) && ( [ $radius -ne 4 ] || [ $sample != "jec" ] || [ $sub != "NONE" ] || [ $groom != "NONE" ] ) ; then 
+                            if ( [ $system == "pPb" ] ) && ( [ $radius -ne 4 ] || ( [ $sub != "NONE" ] && [ $sub != "Pu" ] ) || [ $groom != "NONE" ] ) ; then 
                                 continue
                             fi
                             if ( [ $object == "Calo" ] || [ $system == "pp" ] ) && ( [ $sub == "Cs" ] ) ; then

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_DATA_80X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_DATA_80X.py
@@ -62,7 +62,11 @@ process.GlobalTag.toGet.extend([
                  tag = cms.string("CentralityTable_HFtowersPlusTrunc200_EPOS5TeV_v80x01_mc"),
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
                  label = cms.untracked.string("HFtowersPlusTruncEpos")
-             )
+             ),
+	cms.PSet(record = cms.string("L1TGlobalPrescalesVetosRcd"),
+                tag = cms.string("L1TGlobalPrescalesVetos_Stage2v0_hlt"),
+                connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+                )
 ])
 
 #####################################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pPb_MC_80X.py
@@ -48,7 +48,8 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("CondCore.DBCommon.CondDBCommon_cfi")
  
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_miniAODv2_v1', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_2016_miniAODv2_v1', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '80X_mcRun2_asymptotic_v20', '')
 process.HiForest.GlobalTagLabel = process.GlobalTag.globaltag
 
 
@@ -62,7 +63,11 @@ process.GlobalTag.toGet.extend([
                  tag = cms.string("CentralityTable_HFtowersPlusTrunc200_EPOS5TeV_v80x01_mc"),
                  connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
                  label = cms.untracked.string("HFtowersPlusTruncEpos")
-             )
+             ),
+	cms.PSet(record = cms.string("L1TGlobalPrescalesVetosRcd"),
+                tag = cms.string("L1TGlobalPrescalesVetos_Stage2v0_hlt"),
+                connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+                )
 ])
 
 #####################################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
@@ -42,23 +42,26 @@ fi
 # Step 2: Setup each runForest on the appropriate sample    #
 #############################################################
 
-replacename=`cat runForestAOD_PbPb_DATA_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
-cat runForestAOD_PbPb_DATA_75X.py | sed 's@'$replacename'@"file:samples/PbPb_DATA_AOD.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_DATA_AOD.root@g' > test_runForestAOD_PbPb_DATA_75X.py
+#replacename=`cat runForestAOD_PbPb_DATA_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+#cat runForestAOD_PbPb_DATA_75X.py | sed 's@'$replacename'@"file:samples/PbPb_DATA_AOD.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_DATA_AOD.root@g' > test_runForestAOD_PbPb_DATA_75X.py
 
-replacename=`cat runForestAOD_pp_DATA_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
-cat runForestAOD_pp_DATA_75X.py | sed 's@'$replacename'@"file:samples/pp_DATA_AOD.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pp_DATA_AOD.root@g' > test_runForestAOD_pp_DATA_75X.py
+#replacename=`cat runForestAOD_pp_DATA_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+#cat runForestAOD_pp_DATA_75X.py | sed 's@'$replacename'@"file:samples/pp_DATA_AOD.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pp_DATA_AOD.root@g' > test_runForestAOD_pp_DATA_75X.py
 
-replacename=`cat runForestAOD_PbPb_MIX_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
-cat runForestAOD_PbPb_MIX_75X.py | sed 's@'$replacename'@"file:samples/PbPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_MCMIX_AODSIM.root@g' > test_runForestAOD_PbPb_MIX_75X.py
+#replacename=`cat runForestAOD_PbPb_MIX_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+#cat runForestAOD_PbPb_MIX_75X.py | sed 's@'$replacename'@"file:samples/PbPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_MCMIX_AODSIM.root@g' > test_runForestAOD_PbPb_MIX_75X.py
 
-replacename=`cat runForestAOD_PbPb_MB_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
-cat runForestAOD_PbPb_MB_75X.py | sed 's@'$replacename'@"file:samples/PbPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_MCMB_AODSIM.root@g' > test_runForestAOD_PbPb_MB_75X.py
+#replacename=`cat runForestAOD_PbPb_MB_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+#cat runForestAOD_PbPb_MB_75X.py | sed 's@'$replacename'@"file:samples/PbPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_PbPb_MCMB_AODSIM.root@g' > test_runForestAOD_PbPb_MB_75X.py
 
-replacename=`cat runForestAOD_pp_MC_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
-cat runForestAOD_pp_MC_75X.py | sed 's@'$replacename'@"file:samples/pp_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pp_MC_AODSIM.root@g' > test_runForestAOD_pp_MC_75X.py
+#replacename=`cat runForestAOD_pp_MC_75X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+#cat runForestAOD_pp_MC_75X.py | sed 's@'$replacename'@"file:samples/pp_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pp_MC_AODSIM.root@g' > test_runForestAOD_pp_MC_75X.py
 
 replacename=`cat runForestAOD_pPb_MC_80X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
 cat runForestAOD_pPb_MC_80X.py | sed 's@'$replacename'@"file:samples/pPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pPb_MC_AODSIM.root@g' > test_runForestAOD_pPb_MC_80X.py
+
+replacename=`cat runForestAOD_pPb_DATA_80X.py | grep -v '#' | grep -A10 process.source | grep root | sed 's@,@@g' | awk '{print $1}'`
+cat runForestAOD_pPb_DATA_80X.py | sed 's@'$replacename'@"file:samples/pPb_MC_AODSIM.root"@g' | sed 's@HiForestAOD.root@HiForestAOD_pPb_MC_AODSIM.root@g' > test_runForestAOD_pPb_DATA_80X.py
 
 #############################################################
 # Step 3: cmsRun each runForest                             #


### PR DESCRIPTION
Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Fixed the hcal and ecal jet info to fill from the towerCollection, since it's turned on in pPb AOD - re-initialized the jet sequences to include pPb-specific cfi's.

Also fixed the testing cfg to only look at the 80X scripts for now.  We need new samples at the MITHIG for testing the 80X samples - the full reco (with centrality, etc) are not available so the cfgs still fail

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@dgulhan @mverwe @cfmcginn 
