### PR TITLE
Modified the genMatchIndex finding to remove a bug related to the pre…

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -1830,8 +1830,11 @@ HiInclusiveJetAnalyzer::analyze(const Event& iEvent,
       
       for(int ijet = 0 ; ijet < jets_.nref; ++ijet){
         // poor man's matching, someone fix please
-        if(fabs(genjet.pt()-jets_.refpt[ijet])<0.00001 &&
-           fabs(genjet.eta()-jets_.refeta[ijet])<0.00001){
+	double deltaPt = fabs(genjet.pt()-jets_.refpt[ijet]); //Note: precision of this ~ .0001, so cut .01
+	double deltaEta = fabs(genjet.eta()-jets_.refeta[ijet]); //Note: precision of this is  ~.0000001, but keep it low, .0001 is well below cone size and typical pointing resolution
+	double deltaPhi = fabs(reco::deltaPhi(genjet.phi(), jets_.refphi[ijet])); //Note: precision of this is  ~.0000001, but keep it low, .0001 is well below cone size and typical pointing resolution
+
+	if(deltaPt < 0.01 && deltaEta < .0001 && deltaPhi < .0001){
           if(genjet_pt>genPtMin_) {
             jets_.genmatchindex[jets_.ngen] = (int)ijet;
             jets_.gendphijt[jets_.ngen] = reco::deltaPhi(jets_.refphi[ijet],genjet.phi());


### PR DESCRIPTION
…cision of floating point and the pt matching requirement between gen and ref collection; reduced tightness of cuts and add phi match

See presentation in HIJetReco here: https://twiki.cern.ch/twiki/pub/CMS/HiJetReco2015/genMatchIndexFailure_20170317.pdf

Counterpart to this PR for 758p3 foresting brach: https://github.com/CmsHI/cmssw/pull/114
