### PR TITLE
Fixing 758p3 for L2L3Residual handling in FactorizedJerCorrectorCalcu…

### DIFF
--- a/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
+++ b/CondFormats/JetMETObjects/interface/FactorizedJetCorrectorCalculator.h
@@ -76,7 +76,7 @@ class FactorizedJetCorrectorCalculator
     };
 
     enum VarTypes   {kJetPt,kJetEta,kJetPhi,kJetE,kJetEMF,kRelLepPt,kPtRel,kNPV,kJetA,kRho,kJPTrawE,kJPTrawEt,kJPTrawPt,kJPTrawEta,kJPTrawOff};
-    enum LevelTypes {kL1,kL2,kL3,kL4,kL5,kL6,kL7,kL1fj,kL1JPT};
+    enum LevelTypes {kL1,kL2,kL3,kL4,kL5,kL6,kL7,kL1fj,kL1JPT,kL2L3Res};
     FactorizedJetCorrectorCalculator();
     FactorizedJetCorrectorCalculator(const std::string& fLevels, const std::string& fTags, const std::string& fOptions="");
     FactorizedJetCorrectorCalculator(const std::vector<JetCorrectorParameters>& fParameters);

--- a/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
+++ b/CondFormats/JetMETObjects/src/FactorizedJetCorrectorCalculator.cc
@@ -42,6 +42,8 @@ FactorizedJetCorrectorCalculator::FactorizedJetCorrectorCalculator(const std::ve
       mLevels.push_back(kL2);
     else if (ss == "L3Absolute")
       mLevels.push_back(kL3);
+    else if (ss == "L2L3Residual")
+      mLevels.push_back(kL2L3Res);
     else if (ss == "L4EMF")
       mLevels.push_back(kL4);
     else if (ss == "L5Flavor")
@@ -52,6 +54,11 @@ FactorizedJetCorrectorCalculator::FactorizedJetCorrectorCalculator(const std::ve
       mLevels.push_back(kL7);
     else if (ss == "L1FastJet")
       mLevels.push_back(kL1fj);
+    else {
+      std::stringstream sserr;
+      sserr<<"unknown correction level "<<ss;
+      handleError("FactorizedJetCorrectorCalculator",sserr.str());
+    }
     mCorrectors.push_back(new SimpleJetCorrector(fParameters[i]));
     mBinTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().binVar()));
     mParTypes.push_back(mapping(mCorrectors[i]->parameters().definitions().parVar()));
@@ -82,6 +89,8 @@ void FactorizedJetCorrectorCalculator::initCorrectors(const std::string& fLevels
       mLevels.push_back(kL2);
     else if (tmp[i] == "L3Absolute")
       mLevels.push_back(kL3);
+    else if (tmp[i] == "L2L3Residual")
+      mLevels.push_back(kL2L3Res);
     else if (tmp[i] == "L4EMF")
       mLevels.push_back(kL4);
     else if (tmp[i] == "L5Flavor")

--- a/JetMETCorrections/Algorithms/src/LXXXCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/LXXXCorrector.cc
@@ -30,6 +30,8 @@ LXXXCorrector::LXXXCorrector(const JetCorrectorParameters& fParam, const edm::Pa
     mLevel = 5;
   else if (level == "L7Parton")
     mLevel = 7;
+  else if(level == "L2L3Residual")
+    mLevel = 8;
   else
     throw cms::Exception("LXXXCorrector")<<" unknown correction level "<<level; 
   vector<JetCorrectorParameters> vParam;

--- a/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
+++ b/JetMETCorrections/Algorithms/src/LXXXCorrectorImpl.cc
@@ -38,6 +38,8 @@ LXXXCorrectorImplMaker::make(edm::Event const&, edm::EventSetup const& fSetup)
 	level = 5;
       else if (levelName == "L7Parton")
 	level = 7;
+      else if (levelName == "L2L3Residual")
+	level = 8;
       else
 	throw cms::Exception("LXXXCorrectorImpl")<<" unknown correction level "<<levelName;
     });


### PR DESCRIPTION
…lator, fixed in official CMSSW 2016 (post-datataking), please see commit here that was copied verbatim - https://github.com/cms-sw/cmssw/commit/a07887f905cf146560333f341e732d8e27c61224

Was discussed with JME folks, historically corrections used to all just be folded into L2Relative, but in 2016 things were differentiated for clearer factorization. Hence this update.