### PR TITLE
Fix for pu with ntuple758p3

### DIFF
--- a/RecoHI/HiJetAlgos/interface/PuWithNtuple.h
+++ b/RecoHI/HiJetAlgos/interface/PuWithNtuple.h
@@ -20,6 +20,7 @@ class PuWithNtuple : public PileUpSubtractor {
 
     bool sumRecHits_;
     bool dropZeroTowers_;
+    bool isOrphanInputRun_;
 
     double minimumTowersFraction_;
 

--- a/RecoHI/HiJetAlgos/plugins/plugins.cc
+++ b/RecoHI/HiJetAlgos/plugins/plugins.cc
@@ -3,6 +3,7 @@
 #include "RecoHI/HiJetAlgos/interface/ParametrizedSubtractor.h"
 #include "RecoHI/HiJetAlgos/interface/ReflectedIterator.h"
 #include "RecoHI/HiJetAlgos/interface/VoronoiSubtractor.h"
+#include "RecoHI/HiJetAlgos/interface/PuWithNtuple.h"
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -14,6 +15,7 @@ DEFINE_EDM_PLUGIN(PileUpSubtractorFactory,MultipleAlgoIterator,"MultipleAlgoIter
 DEFINE_EDM_PLUGIN(PileUpSubtractorFactory,ParametrizedSubtractor,"ParametrizedSubtractor");
 DEFINE_EDM_PLUGIN(PileUpSubtractorFactory,ReflectedIterator,"ReflectedIterator");
 DEFINE_EDM_PLUGIN(PileUpSubtractorFactory,VoronoiSubtractor,"VoronoiSubtractor");
+DEFINE_EDM_PLUGIN(PileUpSubtractorFactory,PuWithNtuple,"PuWithNtuple");
 
 
 

--- a/RecoHI/HiJetAlgos/src/PuWithNtuple.cc
+++ b/RecoHI/HiJetAlgos/src/PuWithNtuple.cc
@@ -22,6 +22,7 @@ PuWithNtuple::PuWithNtuple(const edm::ParameterSet& iConfig, edm::ConsumesCollec
 
   Neta_ = 82;
 
+  isOrphanInputRun_ = false;
   tree_ = fs_->make<TTree>("puTree","");
 
   tree_->Branch("nref",&nref,"nref/I");
@@ -270,6 +271,13 @@ void PuWithNtuple::calculatePedestal( vector<fastjet::PseudoJet> const & coll )
 	    }
 	 LogDebug("PileUpSubtractor")<<" ieta : "<<it<<" Pedestals : "<<emean_[it]<<"  "<<esigma_[it]<<"\n";
       }
+
+
+   if(isOrphanInputRun_){   
+     tree_->Fill();
+     isOrphanInputRun_ = false;
+   }
+
 }
 
 
@@ -278,6 +286,7 @@ void PuWithNtuple::calculateOrphanInput(vector<fastjet::PseudoJet> & orphanInput
 
   LogDebug("PileUpSubtractor")<<"The subtractor calculating orphan input...\n";
 
+  isOrphanInputRun_ = true;
   (*fjInputs_) = fjOriginalInputs_;
 
   vector<int> jettowers; // vector of towers indexed by "user_index"
@@ -380,9 +389,6 @@ void PuWithNtuple::calculateOrphanInput(vector<fastjet::PseudoJet> & orphanInput
   }
 
   //  cout<<"Number of jets : "<<nref<<endl;
-
-  tree_->Fill();
-
 }
 
 


### PR DESCRIPTION
This ought to make sure the plugin PuWithNtuple shows up for use (checj before the pr and after with edmPluginDump). Also fixes a bug with how the PuWithNtuple tree fills; if done in current position the mean and rms are always from first iteration. Added a boolean that switches on and off so that fills only occur after second calculation of pedestals. That way mean0, rms0 are from first iteration and mean1, rms1 are from second iteration excluding jets