### PR TITLE
Fixes to cleanup and pf cand jet cuts

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -168,6 +168,7 @@ private:
   double rParam;
   double hardPtMin_;
   double jetPtMin_;
+  double jetAbsEtaMax_;
   bool doGenTaus_;
   bool doGenSym_;
   bool doSubJets_;

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
@@ -113,6 +113,7 @@ private:
 
   // cuts
   Double_t        pfPtMin_;
+  Double_t        pfAbsEtaMax_;
   Double_t        jetPtMin_;
   Double_t        genPtMin_;
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_nominalPP.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_nominalPP.py
@@ -13,23 +13,21 @@ ak4GenJets = ak5GenJets.clone(rParam = 0.4)
 from RecoJets.JetProducers.PFJetParameters_cfi import *
 from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
 akSoftDrop4PFJets = cms.EDProducer(
-    "FastjetJetProducer",
+    "SoftDropJetProducer",
     PFJetParameters,
     AnomalousCellParameters,
     jetAlgorithm = cms.string("AntiKt"),
     rParam       = cms.double(0.4),
-    useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
     R0   = cms.double(0.4),
+    useOnlyCharged = cms.bool(False),
     useExplicitGhosts = cms.bool(True),
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
 )
-akSoftDrop5PFJets = akSoftDrop4PFJets.clone(rParam = cms.double(0.5), R0 = cms.double(0.5))
 
 from HeavyIonsAnalysis.JetAnalysis.akSoftDrop4GenJets_cfi import akSoftDrop4GenJets
-akSoftDrop5GenJets = akSoftDrop4GenJets.clone(rParam = 0.5)
 
 #Filter PF jets
 akFilter4PFJets = cms.EDProducer(
@@ -45,7 +43,6 @@ akFilter4PFJets = cms.EDProducer(
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
 )
-akFilter5PFJets = akFilter4PFJets.clone(rParam = cms.double(0.5))
 
 from RecoJets.Configuration.GenJetParticles_cff import *
 from RecoHI.HiJetAlgos.HiGenJets_cff import *
@@ -53,15 +50,25 @@ from HeavyIonsAnalysis.JetAnalysis.makePartons_cff import myPartons
 
 from HeavyIonsAnalysis.JetAnalysis.jets.ak3PFJetSequence_pp_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pp_mc_cff import *
-from HeavyIonsAnalysis.JetAnalysis.jets.ak5PFJetSequence_pp_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.ak4CaloJetSequence_pp_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akSoftDrop4PFJetSequence_pp_mc_cff import *
-from HeavyIonsAnalysis.JetAnalysis.jets.akSoftDrop5PFJetSequence_pp_mc_cff import *
 
 highPurityTracks = cms.EDFilter("TrackSelector",
                                 src = cms.InputTag("generalTracks"),
                                 cut = cms.string('quality("highPurity")')
 )
+
+from RecoJets.JetProducers.nJettinessAdder_cfi import Njettiness
+ak3GenNjettiness = Njettiness.clone(
+                    src = cms.InputTag("ak3GenJets"),
+                    R0  = cms.double( 0.3 )
+)
+
+ak4GenNjettiness = Njettiness.clone(
+                    src = cms.InputTag("ak4GenJets"),
+                    R0  = cms.double( 0.4 )
+)
+
 
 # Other radii jets and calo jets need to be reconstructed
 jetSequences = cms.Sequence(
@@ -69,20 +76,15 @@ jetSequences = cms.Sequence(
     genParticlesForJets +
     ak3GenJets +
     ak4GenJets +
-    ak5GenJets +
+    ak3GenNjettiness + 
+    ak4GenNjettiness + 
     ak3PFJets +
-    ak5PFJets +
     akSoftDrop4PFJets +
-    akSoftDrop5PFJets +
     akFilter4PFJets +
-    akFilter5PFJets +
     akSoftDrop4GenJets +
-    akSoftDrop5GenJets +
     highPurityTracks +
     ak3PFJetSequence +
     ak4PFJetSequence +
-    ak5PFJetSequence +
     ak4CaloJetSequence +
-    akSoftDrop4PFJetSequence +
-    akSoftDrop5PFJetSequence
+    akSoftDrop4PFJetSequence
 )

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -118,6 +118,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
   rParam = iConfig.getParameter<double>("rParam");
   hardPtMin_ = iConfig.getUntrackedParameter<double>("hardPtMin",4);
   jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
+  jetAbsEtaMax_ = iConfig.getUntrackedParameter<double>("jetAbsEtaMax", 5.1);
 
   if(isMC_){
     //genjetTag_ = consumes<vector<reco::GenJet> > (iConfig.getParameter<InputTag>("genjetTag"));
@@ -1032,6 +1033,7 @@ HiInclusiveJetAnalyzer::analyze(const Event& iEvent,
     const reco::Jet& jet = (*jets)[j];
 
     if(jet.pt() < jetPtMin_) continue;
+    if(TMath::Abs(jet.eta()) > jetAbsEtaMax_) continue;
     if (useJEC_ && usePat_){
       jets_.rawpt[jets_.nref]=(*patjets)[j].correctedJet("Uncorrected").pt();
     }

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
@@ -52,6 +52,7 @@ HiPFCandAnalyzer::HiPFCandAnalyzer(const edm::ParameterSet& iConfig)
   pfCandidatePF_ = consumes<reco::PFCandidateCollection> (pfCandidateLabel_);
   pfCandidateView_ = consumes<reco::CandidateView> (pfCandidateLabel_);
   pfPtMin_ = iConfig.getParameter<double>("pfPtMin");
+  pfAbsEtaMax_ = iConfig.getUntrackedParameter<double>("pfAbsEtaMax", 5.1);
   genPtMin_ = iConfig.getParameter<double>("genPtMin");
   jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
 
@@ -147,8 +148,10 @@ HiPFCandAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     }
 
     double pt =  pfCandidate.pt();
+    double eta =  pfCandidate.eta();
     double energy = pfCandidate.energy();
     if(pt<=pfPtMin_) continue;
+    if(TMath::Abs(eta) > pfAbsEtaMax_) continue;
 
     int id = pfCandidate.particleId();
     if(skipCharged_ && (abs(id) == 1 || abs(id) == 3)) continue;

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_75X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_75X.py
@@ -80,7 +80,6 @@ process.load('HeavyIonsAnalysis.JetAnalysis.jets.ak4CaloJetSequence_pp_data_cff'
 
 process.load('HeavyIonsAnalysis.JetAnalysis.jets.ak3PFJetSequence_pp_data_cff')
 process.load('HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pp_data_cff')
-process.load('HeavyIonsAnalysis.JetAnalysis.jets.ak5PFJetSequence_pp_data_cff')
 
 process.highPurityTracks = cms.EDFilter("TrackSelector",
                                         src = cms.InputTag("generalTracks"),
@@ -91,12 +90,10 @@ process.highPurityTracks = cms.EDFilter("TrackSelector",
 
 process.jetSequences = cms.Sequence(
     process.ak3PFJets +
-    process.ak5PFJets +
     process.highPurityTracks +
     process.ak4CaloJetSequence +
     process.ak3PFJetSequence +
-    process.ak4PFJetSequence +
-    process.ak5PFJetSequence
+    process.ak4PFJetSequence
     )
 
 # How to turn on the jet constituents 


### PR DESCRIPTION
Fixes to Marta's cleanup work based on runTest.sh output, and two additional cuts to pfcandanalyzer and hiinclusivejetanalyzer for absolute eta maximum (frequently we really dont need to keep HF info, will save space on smaller forests)