### PR TITLE
Backport HiFJGridEmptyAreaCalculator and fix bug

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -189,7 +189,6 @@ HiFJGridEmptyAreaCalculator::calculateGridRho(const edm::Event& iEvent, const ed
    //use ony the particles within the eta range
    if (pfCandidate.eta() < ymin_ || pfCandidate.eta() >= ymax_ ) continue;
    int jeta = tileIndexEta(&pfCandidate);
-   //if(jeta<0) std::cout << "ymin_: " << ymin_ << " ymax_: " << ymax_ << " eta pf candidates: " << pfCandidate.eta() << std::endl;
    int jphi = tileIndexPhi(&pfCandidate);
    scalarPt[jeta][jphi] += pfCandidate.pt();
   }
@@ -372,10 +371,8 @@ HiFJGridEmptyAreaCalculator::tileIndexEta(const reco::PFCandidate *pfCand)  {
   // speed-critical step. It's not at all clear why.
   int iy = int(floor( (pfCand->eta() - ymin_) / dy_ ));
   //if (iy < 0 || iy >= ny_) return -1;
-  if (iy < 0 || iy >= ny_) {
-    std::cout << "iy: " << iy << " ny_: " << ny_ << " dy_: " << dy_ << " eta pf cand: " << pfCand->eta() << std::endl;
+  if (iy < 0 || iy >= ny_) 
     return -1;
-  }
   
   assert (iy < ny_ && iy >= 0);
 

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -189,7 +189,7 @@ HiFJGridEmptyAreaCalculator::calculateGridRho(const edm::Event& iEvent, const ed
    //use ony the particles within the eta range
    if (pfCandidate.eta() < ymin_ || pfCandidate.eta() >= ymax_ ) continue;
    int jeta = tileIndexEta(&pfCandidate);
-   if(jeta<0) std::cout << "ymin_: " << ymin_ << " ymax_: " << ymax_ << " eta pf candidates: " << pfCandidate.eta() << std::endl;
+   //if(jeta<0) std::cout << "ymin_: " << ymin_ << " ymax_: " << ymax_ << " eta pf candidates: " << pfCandidate.eta() << std::endl;
    int jphi = tileIndexPhi(&pfCandidate);
    scalarPt[jeta][jphi] += pfCandidate.pt();
   }

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc
@@ -15,11 +15,32 @@ using namespace edm;
 
 
 HiFJGridEmptyAreaCalculator::HiFJGridEmptyAreaCalculator(const edm::ParameterSet& iConfig):
-  gridWidth_(iConfig.getUntrackedParameter<double>("gridWidth",0.005)),
-  band_(iConfig.getUntrackedParameter<double>("bandWidth",0.2)),
-  hiBinCut_(iConfig.getUntrackedParameter<int>("hiBinCut",60)),
-  doCentrality_(iConfig.getUntrackedParameter<bool>("doCentrality",true))
+  gridWidth_(iConfig.getParameter<double>("gridWidth")),
+  band_(iConfig.getParameter<double>("bandWidth")),
+  hiBinCut_(iConfig.getParameter<int>("hiBinCut")),
+  doCentrality_(iConfig.getParameter<bool>("doCentrality")),
+  keepGridInfo_(iConfig.getParameter<bool>("keepGridInfo"))
 {
+  ymin_ = -99;
+  ymax_ = -99;
+  dy_ = -99;
+  dphi_ = -99;
+  tileArea_ = - 99;
+  
+  dyJet_ = 99;
+  yminJet_ = - 99;
+  ymaxJet_ = -99;
+  totalInboundArea_ = -99;
+  etaminJet_= -99;
+  etamaxJet_ = -99;
+  
+  ny_ = 0;
+  nphi_ = 0;
+  ntotal_ = 0;
+ 
+  ntotalJet_ = 0;
+  nyJet_ = 0;
+    
   pfCandsToken_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfCandSource" ));
   mapEtaToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapEtaEdges" ));
   mapRhoToken_ = consumes<std::vector<double> >(iConfig.getParameter<edm::InputTag>( "mapToRho" ));
@@ -34,11 +55,12 @@ HiFJGridEmptyAreaCalculator::HiFJGridEmptyAreaCalculator(const edm::ParameterSet
   produces<std::vector<double > >("mapToRhoCorr1Bin");
   produces<std::vector<double > >("mapToRhoMCorr1Bin");
   //rho calculation on a grid using median
-  produces<std::vector<double > >("mapRhoVsEtaGrid");
-  produces<std::vector<double > >("mapMeanRhoVsEtaGrid");
-  produces<std::vector<double > >("mapEtaMaxGrid");
-  produces<std::vector<double > >("mapEtaMinGrid");
-  
+  if(keepGridInfo_){
+    produces<std::vector<double > >("mapRhoVsEtaGrid");
+    produces<std::vector<double > >("mapMeanRhoVsEtaGrid");
+    produces<std::vector<double > >("mapEtaMaxGrid");
+    produces<std::vector<double > >("mapEtaMinGrid");
+  }
 }
 
 
@@ -50,7 +72,6 @@ HiFJGridEmptyAreaCalculator::~HiFJGridEmptyAreaCalculator()
 
 }
 
-// ------------ method called to produce the data  ------------
 void
 HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
@@ -70,82 +91,84 @@ HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& 
   int hiBin = -1;
   bool doEmptyArea = true; 
   if(doCentrality_){
-   edm::Handle<int> cbin_;
-   iEvent.getByToken(centralityBinToken_,cbin_);
-   hiBin = *cbin_;
+    edm::Handle<int> cbin;
+    iEvent.getByToken(centralityBinToken_,cbin);
+    hiBin = *cbin;
    
-   if(hiBin < hiBinCut_) doEmptyArea = false;
+    if(hiBin < hiBinCut_) doEmptyArea = false;
   }
   
   //Define output vectors
   int neta = (int)mapEtaRanges->size();
    
-  std::auto_ptr<std::vector<double>> mapToRhoCorrOut ( new std::vector<double>(neta-1,1e-6));
-  std::auto_ptr<std::vector<double>> mapToRhoMCorrOut ( new std::vector<double>(neta-1,1e-6));
-  std::auto_ptr<std::vector<double>> mapToRhoCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
-  std::auto_ptr<std::vector<double>> mapToRhoMCorr1BinOut ( new std::vector<double>(neta-1,1e-6));
+  auto mapToRhoCorrOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoMCorrOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoCorr1BinOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
+  auto mapToRhoMCorr1BinOut = std::make_unique<std::vector<double>>(neta-1,1e-6);
 
-  setup_grid(mapEtaRanges->at(0), mapEtaRanges->at(neta-1));
+  setupGrid(mapEtaRanges->at(0), mapEtaRanges->at(neta-1));
   
   //calculate empty area correction over full acceptance leaving eta bands on the sides
-  double all_acceptance_corr = 1;
+  double allAcceptanceCorr = 1;
   if(doEmptyArea){
-   _eta_min_jet = mapEtaRanges->at(0) - band_;
-   _eta_max_jet = mapEtaRanges->at(neta-1) + band_;
+    etaminJet_ = mapEtaRanges->at(0) - band_;
+    etamaxJet_ = mapEtaRanges->at(neta-1) + band_;
   
-   calculate_area_fraction_of_jets(iEvent, iSetup);
+    calculateAreaFractionOfJets(iEvent, iSetup);
   
-   all_acceptance_corr =  _total_inbound_area;
+    allAcceptanceCorr =  totalInboundArea_;
   }
   
   //calculate empty area correction in each eta range
   for(int ieta = 0; ieta<(neta-1); ieta++) {
    
-   double correction_kt = 1;   
-   double rho = mapRho->at(ieta);
-   double rhoM = mapRhoM->at(ieta);
+    double correctionKt = 1;   
+    double rho = mapRho->at(ieta);
+    double rhoM = mapRhoM->at(ieta);
     
-   if(doEmptyArea){
-    double eta_min = mapEtaRanges->at(ieta);
-    double eta_max = mapEtaRanges->at(ieta+1);
+    if(doEmptyArea){
+      double etamin = mapEtaRanges->at(ieta);
+      double etamax = mapEtaRanges->at(ieta+1);
       
-    _eta_min_jet = eta_min + band_;  
-    _eta_max_jet = eta_max - band_;  
+      etaminJet_ = etamin + band_;  
+      etamaxJet_ = etamax - band_;  
    
-    calculate_area_fraction_of_jets(iEvent, iSetup);
-    correction_kt = _total_inbound_area;
-   }
+      calculateAreaFractionOfJets(iEvent, iSetup);
+      correctionKt = totalInboundArea_;
+    }
    
-   mapToRhoCorrOut->at(ieta) = correction_kt*rho;
-   mapToRhoMCorrOut->at(ieta) = correction_kt*rhoM;
+    mapToRhoCorrOut->at(ieta) = correctionKt*rho;
+    mapToRhoMCorrOut->at(ieta) = correctionKt*rhoM;
    
-   mapToRhoCorr1BinOut->at(ieta) = all_acceptance_corr*rho;
-   mapToRhoMCorr1BinOut->at(ieta) = all_acceptance_corr*rhoM;
+    mapToRhoCorr1BinOut->at(ieta) = allAcceptanceCorr*rho;
+    mapToRhoMCorr1BinOut->at(ieta) = allAcceptanceCorr*rhoM;
   }
 
-  iEvent.put(mapToRhoCorrOut,"mapToRhoCorr");
-  iEvent.put(mapToRhoMCorrOut,"mapToRhoMCorr");
-  iEvent.put(mapToRhoCorr1BinOut,"mapToRhoCorr1Bin");
-  iEvent.put(mapToRhoMCorr1BinOut,"mapToRhoMCorr1Bin");
+  iEvent.put(std::move(mapToRhoCorrOut),"mapToRhoCorr");
+  iEvent.put(std::move(mapToRhoMCorrOut),"mapToRhoMCorr");
+  iEvent.put(std::move(mapToRhoCorr1BinOut),"mapToRhoCorr1Bin");
+  iEvent.put(std::move(mapToRhoMCorr1BinOut),"mapToRhoMCorr1Bin");
   
   //calculate rho from grid as a function of eta over full range using PF candidates
-  calculate_grid_rho(iEvent, iSetup);
+  
+  auto mapRhoVsEtaGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapMeanRhoVsEtaGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapEtaMaxGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  auto mapEtaMinGridOut = std::make_unique<std::vector<double>>(ny_,0.);
+  calculateGridRho(iEvent, iSetup);
+  if(keepGridInfo_){
+    for(int ieta = 0; ieta < ny_; ieta++) {
+      mapRhoVsEtaGridOut->at(ieta) = rhoVsEta_[ieta];
+      mapMeanRhoVsEtaGridOut->at(ieta) = meanRhoVsEta_[ieta];
+      mapEtaMaxGridOut->at(ieta) = etaMaxGrid_[ieta];
+      mapEtaMinGridOut->at(ieta) = etaMinGrid_[ieta];
+    }
 
-  std::auto_ptr<std::vector<double>> mapRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
-  std::auto_ptr<std::vector<double>> mapMeanRhoVsEtaGridOut ( new std::vector<double>(_ny,0.));
-  std::auto_ptr<std::vector<double>> mapEtaMaxGridOut ( new std::vector<double>(_ny,0.));
-  std::auto_ptr<std::vector<double>> mapEtaMinGridOut ( new std::vector<double>(_ny,0.));
-  for(int ieta = 0; ieta < _ny; ieta++) {
-   mapRhoVsEtaGridOut->at(ieta) = _rho_vs_eta[ieta];
-   mapMeanRhoVsEtaGridOut->at(ieta) = _mean_rho_vs_eta[ieta];
-   mapEtaMaxGridOut->at(ieta) = _eta_max_grid[ieta];
-   mapEtaMinGridOut->at(ieta) = _eta_min_grid[ieta];
+    iEvent.put(std::move(mapRhoVsEtaGridOut),"mapRhoVsEtaGrid");
+    iEvent.put(std::move(mapMeanRhoVsEtaGridOut),"mapMeanRhoVsEtaGrid");
+    iEvent.put(std::move(mapEtaMaxGridOut),"mapEtaMaxGrid");
+    iEvent.put(std::move(mapEtaMinGridOut),"mapEtaMinGrid");
   }
-
-  iEvent.put(mapRhoVsEtaGridOut,"mapRhoVsEtaGrid");
-  iEvent.put(mapMeanRhoVsEtaGridOut,"mapMeanRhoVsEtaGrid");
-  iEvent.put(mapEtaMaxGridOut,"mapEtaMaxGrid");
-  iEvent.put(mapEtaMinGridOut,"mapEtaMinGrid");
 }
 
 //----------------------------------------------------------------------
@@ -154,9 +177,9 @@ HiFJGridEmptyAreaCalculator::produce(edm::Event& iEvent, const edm::EventSetup& 
 // tell the background estimator that it has a new event, composed
 // of the specified particles.
 void
-HiFJGridEmptyAreaCalculator::calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+HiFJGridEmptyAreaCalculator::calculateGridRho(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
-  vector<vector<double>> scalar_pt(_ny, vector<double>(_nphi, 0.0));
+  vector<vector<double>> scalarPt(ny_, vector<double>(nphi_, 0.0));
   
   edm::Handle<reco::PFCandidateCollection> pfCands;
   iEvent.getByToken(pfCandsToken_, pfCands);
@@ -164,108 +187,109 @@ HiFJGridEmptyAreaCalculator::calculate_grid_rho(const edm::Event& iEvent, const 
   for(unsigned icand = 0; icand < pfCandidateColl->size(); icand++) {
    const reco::PFCandidate pfCandidate = pfCandidateColl->at(icand);
    //use ony the particles within the eta range
-   if (pfCandidate.eta() < _ymin || pfCandidate.eta() > _ymax ) continue;
-   int jeta = tile_index_eta(&pfCandidate);
-   int jphi = tile_index_phi(&pfCandidate);
-   scalar_pt[jeta][jphi] += pfCandidate.pt();
+   if (pfCandidate.eta() < ymin_ || pfCandidate.eta() >= ymax_ ) continue;
+   int jeta = tileIndexEta(&pfCandidate);
+   if(jeta<0) std::cout << "ymin_: " << ymin_ << " ymax_: " << ymax_ << " eta pf candidates: " << pfCandidate.eta() << std::endl;
+   int jphi = tileIndexPhi(&pfCandidate);
+   scalarPt[jeta][jphi] += pfCandidate.pt();
   }
   
- _rho_vs_eta.resize(_ny);
- _mean_rho_vs_eta.resize(_ny);
-  for(int jeta = 0; jeta < _ny; jeta++){
+  rhoVsEta_.resize(ny_);
+  meanRhoVsEta_.resize(ny_);
+  for(int jeta = 0; jeta < ny_; jeta++){
   
- 	 _rho_vs_eta[jeta] = 0;
- 	 _mean_rho_vs_eta[jeta] = 0;
-	 vector<double> rho_vs_phi;
-	 int n_empty = 0;
-	
-	for(int jphi = 0; jphi < _nphi; jphi++){
-	  double binpt = scalar_pt[jeta][jphi];
-	  _mean_rho_vs_eta[jeta] += binpt;
+    rhoVsEta_[jeta] = 0;
+    meanRhoVsEta_[jeta] = 0;
+    vector<double> rhoVsPhi;
+    int nEmpty = 0;
+    
+    for(int jphi = 0; jphi < nphi_; jphi++){
+      double binpt = scalarPt[jeta][jphi];
+      meanRhoVsEta_[jeta] += binpt;
       //fill in the vector for median calculation
-	  if(binpt > 0) rho_vs_phi.push_back(binpt);
-	  else n_empty++;
-	 } 
-	 _mean_rho_vs_eta[jeta] /= ((double)_nphi);
-     _mean_rho_vs_eta[jeta] /= _tile_area;
+      if(binpt > 0) rhoVsPhi.push_back(binpt);
+      else nEmpty++;
+    }
+    meanRhoVsEta_[jeta] /= ((double)nphi_);
+    meanRhoVsEta_[jeta] /= tileArea_;
 
-	 //median calculation
-	 sort(rho_vs_phi.begin(), rho_vs_phi.end());
-	 //use only the nonzero grid cells for median calculation;
-	 int n_full = _nphi - n_empty;
-	 if(n_full == 0){
- 	  _rho_vs_eta[jeta] = 0;
- 	  continue;
-	 }
-	 if (n_full  % 2 == 0)
-     {
-       _rho_vs_eta[jeta] = (rho_vs_phi[(int)(n_full / 2 - 1)] + rho_vs_phi[(int)(n_full / 2)]) / 2;
-     }
-     else 
-     {
-       _rho_vs_eta[jeta] = rho_vs_phi[(int)(n_full / 2)];
-     }
-     //correct for empty cells 
-	 _rho_vs_eta[jeta] *= (((double) n_full)/((double) _nphi));
-	 //normalize to area
-     _rho_vs_eta[jeta] /= _tile_area;
+    //median calculation
+    sort(rhoVsPhi.begin(), rhoVsPhi.end());
+    //use only the nonzero grid cells for median calculation;
+    int nFull = nphi_ - nEmpty;
+    if(nFull == 0){
+      rhoVsEta_[jeta] = 0;
+      continue;
+    }
+    if (nFull  % 2 == 0)
+      {
+        rhoVsEta_[jeta] = (rhoVsPhi[(int)(nFull / 2 - 1)] + rhoVsPhi[(int)(nFull / 2)]) / 2;
+      }
+    else 
+      {
+        rhoVsEta_[jeta] = rhoVsPhi[(int)(nFull / 2)];
+      }
+    //correct for empty cells 
+    rhoVsEta_[jeta] *= (((double) nFull)/((double) nphi_));
+    //normalize to area
+    rhoVsEta_[jeta] /= tileArea_;
   }
 }
 
 void
-HiFJGridEmptyAreaCalculator::calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup){
+HiFJGridEmptyAreaCalculator::calculateAreaFractionOfJets(const edm::Event& iEvent, const edm::EventSetup& iSetup){
   edm::Handle<edm::View<reco::Jet> > jets;
   iEvent.getByToken(jetsToken_, jets);
   
   //calculate jet kt area fraction inside boundary by grid
-  _total_inbound_area = 0;
+  totalInboundArea_ = 0;
   
   for(auto jet = jets->begin(); jet != jets->end(); ++jet) {
-   if (jet->eta() < _eta_min_jet || jet->eta() > _eta_max_jet) continue;
+    if (jet->eta() < etaminJet_ || jet->eta() > etamaxJet_) continue;
    
-   double area_kt = jet->jetArea(); 
-   setup_grid_jet(&*jet);
-   std::vector<std::pair<int, int> > pf_indices_jet;
-   std::vector<std::pair<int, int> > pf_indices_jet_inbound;
-   int n_constit_jet = 0;
-   int n_constit_jet_inbound = 0;
-   for(auto daughter : jet->getJetConstituentsQuick()){
-   	auto pfCandidate = static_cast<const reco::PFCandidate*>(daughter);
+    double areaKt = jet->jetArea(); 
+    setupGridJet(&*jet);
+    std::vector<std::pair<int, int> > pfIndicesJet;
+    std::vector<std::pair<int, int> > pfIndicesJetInbound;
+    int nConstitJet = 0;
+    int nConstitJetInbound = 0;
+    for(auto daughter : jet->getJetConstituentsQuick()){
+      auto pfCandidate = static_cast<const reco::PFCandidate*>(daughter);
 
-	int jeta = tile_index_eta_jet(&*pfCandidate);
-	int jphi = tile_index_phi(&*pfCandidate);
-	pf_indices_jet.push_back(std::make_pair(jphi, jeta));
-	n_constit_jet++;
-	if (pfCandidate->eta() < _eta_min_jet && pfCandidate->eta() > _eta_max_jet) continue;
-	pf_indices_jet_inbound.push_back(std::make_pair(jphi, jeta));
-	n_constit_jet_inbound++;
+	  int jeta = tileIndexEtaJet(&*pfCandidate);
+	  int jphi = tileIndexPhi(&*pfCandidate);
+	  pfIndicesJet.push_back(std::make_pair(jphi, jeta));
+	  nConstitJet++;
+	  if (pfCandidate->eta() < etaminJet_ && pfCandidate->eta() > etamaxJet_) continue;
+	  pfIndicesJetInbound.push_back(std::make_pair(jphi, jeta));
+	  nConstitJetInbound++;
    }   
    
    //if the jet is well within the eta range just add the area
-   if(n_constit_jet == n_constit_jet_inbound){
-	_total_inbound_area += area_kt;
+   if(nConstitJet == nConstitJetInbound){
+	totalInboundArea_ += areaKt;
     continue;
    }
    
    //for jets that fall outside of eta range calculate fraction of area
    //inside the range with a grid
    int nthis = 0;
-   if (n_constit_jet > 0) nthis = num_jet_grid_cells(pf_indices_jet);
+   if (nConstitJet > 0) nthis = numJetGridCells(pfIndicesJet);
 
-   int nthis_inbound = 0;
-   if (n_constit_jet_inbound > 0) nthis_inbound = num_jet_grid_cells(pf_indices_jet_inbound);
+   int nthisInbound = 0;
+   if (nConstitJetInbound > 0) nthisInbound = numJetGridCells(pfIndicesJetInbound);
    
   
-   double fraction_area = ((double)nthis_inbound)/((double)nthis);
-   _total_inbound_area += area_kt*fraction_area;    
+   double fractionArea = ((double)nthisInbound)/((double)nthis);
+   totalInboundArea_ += areaKt*fractionArea;    
   } 
   
   //divide by the total area in that range
-  _total_inbound_area /= ((_eta_max_jet - _eta_min_jet)*twopi);
+  totalInboundArea_ /= ((etamaxJet_ - etaminJet_)*twopi_);
   
   //the fraction can still be greater than 1 because kt area fraction inside 
   //the range can differ from what we calculated with the grid
-  if (_total_inbound_area > 1) _total_inbound_area = 1;
+  if (totalInboundArea_ > 1) totalInboundArea_ = 1;
 }
 
 
@@ -275,45 +299,45 @@ HiFJGridEmptyAreaCalculator::calculate_area_fraction_of_jets(const edm::Event& i
 //----------------------------------------------------------------------
 // configure the grid
 void
-HiFJGridEmptyAreaCalculator::setup_grid(double eta_min, double eta_max) {
+HiFJGridEmptyAreaCalculator::setupGrid(double etamin, double etamax) {
 
   // since we've exchanged the arguments of the grid constructor,
   // there's a danger of calls with exchanged ymax,spacing arguments -- 
   // the following check should catch most such situations.
-  _ymin = eta_min;
-  _ymax = eta_max;
+  ymin_ = etamin;
+  ymax_ = etamax;
   
-  assert(_ymax - _ymin >= gridWidth_);
+  assert(ymax_ - ymin_ >= gridWidth_);
 
   // this grid-definition code is becoming repetitive -- it should
   // probably be moved somewhere central...
-  double ny_double = (_ymax-_ymin) / gridWidth_;
-  _ny = int(ny_double+0.5);
-  _dy = (_ymax-_ymin) / _ny;
+  double nyDouble = (ymax_ - ymin_) / gridWidth_;
+  ny_ = int(nyDouble+0.5);
+  dy_ = (ymax_ - ymin_) / ny_;
   
-  _nphi = int (twopi / gridWidth_ + 0.5);
-  _dphi = twopi / _nphi;
+  nphi_ = int (twopi_ / gridWidth_ + 0.5);
+  dphi_ = twopi_ / nphi_;
 
   // some sanity checking (could throw a fastjet::Error)
-  assert(_ny >= 1 && _nphi >= 1);
+  assert(ny_ >= 1 && nphi_ >= 1);
 
-  _ntotal = _nphi * _ny;
+  ntotal_ = nphi_ * ny_;
   //_scalar_pt.resize(_ntotal);
-  _tile_area = _dy * _dphi;
+  tileArea_ = dy_ * dphi_;
   
   
-  _eta_max_grid.resize(_ny);
-  _eta_min_grid.resize(_ny);
-  for(int jeta = 0; jeta < _ny; jeta++){
-   _eta_min_grid[jeta] = eta_min + _dy*((double)jeta);
-   _eta_max_grid[jeta] = eta_min + _dy*((double)jeta + 1.);
+  etaMaxGrid_.resize(ny_);
+  etaMinGrid_.resize(ny_);
+  for(int jeta = 0; jeta < ny_; jeta++){
+   etaMinGrid_[jeta] = etamin + dy_*((double)jeta);
+   etaMaxGrid_[jeta] = etamin + dy_*((double)jeta + 1.);
   }
 }
 
 //----------------------------------------------------------------------
 // retrieve the grid tile index for a given PseudoJet
 int
-HiFJGridEmptyAreaCalculator::tile_index_phi(const reco::PFCandidate *pfCand)  {
+HiFJGridEmptyAreaCalculator::tileIndexPhi(const reco::PFCandidate *pfCand)  {
   // directly taking int does not work for values between -1 and 0
   // so use floor instead
   // double iy_double = (p.rap() - _ymin) / _dy;
@@ -325,9 +349,9 @@ HiFJGridEmptyAreaCalculator::tile_index_phi(const reco::PFCandidate *pfCand)  {
   // though answers are identical and the routine here is not the
   // speed-critical step. It's not at all clear why.
  
-  int iphi = int( (pfCand->phi() + (twopi/2.))/_dphi );
-  assert(iphi >= 0 && iphi <= _nphi);
-  if (iphi == _nphi) iphi = 0; // just in case of rounding errors
+  int iphi = int( (pfCand->phi() + (twopi_/2.))/dphi_ );
+  assert(iphi >= 0 && iphi <= nphi_);
+  if (iphi == nphi_) iphi = 0; // just in case of rounding errors
 
   return iphi;
 }
@@ -335,7 +359,7 @@ HiFJGridEmptyAreaCalculator::tile_index_phi(const reco::PFCandidate *pfCand)  {
 //----------------------------------------------------------------------
 // retrieve the grid tile index for a given PseudoJet
 int
-HiFJGridEmptyAreaCalculator::tile_index_eta(const reco::PFCandidate *pfCand)  {
+HiFJGridEmptyAreaCalculator::tileIndexEta(const reco::PFCandidate *pfCand)  {
   // directly taking int does not work for values between -1 and 0
   // so use floor instead
   // double iy_double = (p.rap() - _ymin) / _dy;
@@ -346,10 +370,14 @@ HiFJGridEmptyAreaCalculator::tile_index_eta(const reco::PFCandidate *pfCand)  {
   // writing it as below gives a huge speed gain (factor two!). Even
   // though answers are identical and the routine here is not the
   // speed-critical step. It's not at all clear why.
-  int iy = int(floor( (pfCand->eta() - _ymin) / _dy ));
-  if (iy < 0 || iy >= _ny) return -1;
+  int iy = int(floor( (pfCand->eta() - ymin_) / dy_ ));
+  //if (iy < 0 || iy >= ny_) return -1;
+  if (iy < 0 || iy >= ny_) {
+    std::cout << "iy: " << iy << " ny_: " << ny_ << " dy_: " << dy_ << " eta pf cand: " << pfCand->eta() << std::endl;
+    return -1;
+  }
   
-  assert (iy < _ny && iy >= 0);
+  assert (iy < ny_ && iy >= 0);
 
   return iy;
 }
@@ -360,25 +388,25 @@ HiFJGridEmptyAreaCalculator::tile_index_eta(const reco::PFCandidate *pfCand)  {
 //----------------------------------------------------------------------
 // configure the grid
 void
-HiFJGridEmptyAreaCalculator::setup_grid_jet(const reco::Jet *jet) {
+HiFJGridEmptyAreaCalculator::setupGridJet(const reco::Jet *jet) {
 
   // since we've exchanged the arguments of the grid constructor,
   // there's a danger of calls with exchanged ymax,spacing arguments -- 
   // the following check should catch most such situations.
-  _yminjet = jet->eta()-0.6;
-  _ymaxjet = jet->eta()+0.6;
+  yminJet_ = jet->eta()-0.6;
+  ymaxJet_ = jet->eta()+0.6;
   
-  assert(_ymaxjet - _yminjet >= gridWidth_);
+  assert(ymaxJet_ - yminJet_ >= gridWidth_);
 
   // this grid-definition code is becoming repetitive -- it should
   // probably be moved somewhere central...
-  double ny_double = (_ymaxjet-_yminjet) / gridWidth_;
-  _nyjet = int(ny_double+0.5);
-  _dyjet = (_ymaxjet-_yminjet) / _nyjet;
+  double nyDouble = (ymaxJet_ - yminJet_) / gridWidth_;
+  nyJet_ = int(nyDouble+0.5);
+  dyJet_ = (ymaxJet_ - yminJet_) / nyJet_;
   
-  assert(_nyjet >= 1);
+  assert(nyJet_ >= 1);
 
-  _ntotaljet = _nphi * _nyjet;
+  ntotalJet_ = nphi_ * nyJet_;
   //_scalar_pt.resize(_ntotal);
 }
 
@@ -386,7 +414,7 @@ HiFJGridEmptyAreaCalculator::setup_grid_jet(const reco::Jet *jet) {
 //----------------------------------------------------------------------
 // retrieve the grid tile index for a given PseudoJet
 int
-HiFJGridEmptyAreaCalculator::tile_index_eta_jet(const reco::PFCandidate *pfCand) {
+HiFJGridEmptyAreaCalculator::tileIndexEtaJet(const reco::PFCandidate *pfCand) {
   // directly taking int does not work for values between -1 and 0
   // so use floor instead
   // double iy_double = (p.rap() - _ymin) / _dy;
@@ -397,62 +425,65 @@ HiFJGridEmptyAreaCalculator::tile_index_eta_jet(const reco::PFCandidate *pfCand)
   // writing it as below gives a huge speed gain (factor two!). Even
   // though answers are identical and the routine here is not the
   // speed-critical step. It's not at all clear why.
-  int iyjet = int(floor( (pfCand->eta() - _yminjet) / _dy ));
-  if (iyjet < 0 || iyjet >= _nyjet) return -1;
+  int iyjet = int(floor( (pfCand->eta() - yminJet_) / dy_ ));
+  if (iyjet < 0 || iyjet >= nyJet_) return -1;
   
-  assert (iyjet < _nyjet && iyjet >= 0);
+  assert (iyjet < nyJet_ && iyjet >= 0);
 
   return iyjet;
 }
 
 int 
-HiFJGridEmptyAreaCalculator::num_jet_grid_cells( std::vector<std::pair<int, int> >& indices )
+HiFJGridEmptyAreaCalculator::numJetGridCells( std::vector<std::pair<int, int> >& indices )
 {
   int ngrid = 0;
   //sort phi eta grid indices in phi
   std::sort(indices.begin(),indices.end());
-  int lowest_jphi = indices[0].first;
-  int lowest_jeta = indices[0].second;
-  int highest_jeta = lowest_jeta;
+  int lowestJPhi = indices[0].first;
+  int lowestJEta = indices[0].second;
+  int highestJEta = lowestJEta;
     
   //for each fixed phi value calculate the number of grids in eta
   for(unsigned int iconst = 1; iconst < indices.size(); iconst++){
-   int jphi = indices[iconst].first;
-   int jeta = indices[iconst].second;
-   if (jphi == lowest_jphi){
-	if (jeta < lowest_jeta) lowest_jeta = jeta;
-	if (jeta > highest_jeta) highest_jeta = jeta;
-   }else{
-	lowest_jphi = jphi;
-	ngrid += highest_jeta - lowest_jeta + 1;
-    lowest_jeta = jeta;
-    highest_jeta = jeta;
-   }
+     int jphi = indices[iconst].first;
+     int jeta = indices[iconst].second;
+     if (jphi == lowestJPhi){
+	  if (jeta < lowestJEta) lowestJEta = jeta;
+	  if (jeta > highestJEta) highestJEta = jeta;
+     }else{
+	  lowestJPhi = jphi;
+	  ngrid += highestJEta - lowestJEta + 1;
+      lowestJEta = jeta;
+      highestJEta = jeta;
+    }
   }
-  ngrid += highest_jeta - lowest_jeta + 1;
+  ngrid += highestJEta - lowestJEta + 1;
   return ngrid;
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HiFJGridEmptyAreaCalculator::beginJob()
+void
+HiFJGridEmptyAreaCalculator::beginStream(edm::StreamID)
 {
-
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HiFJGridEmptyAreaCalculator::endJob() {
+void
+HiFJGridEmptyAreaCalculator::endStream() {
 }
- 
-// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+
 void HiFJGridEmptyAreaCalculator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  //The following says we do not know what parameters are allowed so do no validation
-  // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
-  desc.setUnknown();
-  descriptions.addDefault(desc);
+  desc.add<edm::InputTag>("jetSource",edm::InputTag("kt4PFJets"));
+  desc.add<edm::InputTag>("CentralityBinSrc",edm::InputTag("centralityBin"));
+  desc.add<edm::InputTag>("mapEtaEdges",edm::InputTag("mapEtaEdges"));
+  desc.add<edm::InputTag>("mapToRho",edm::InputTag("mapToRho"));
+  desc.add<edm::InputTag>("mapToRhoM",edm::InputTag("mapToRhoM"));
+  desc.add<edm::InputTag>("pfCandSource",edm::InputTag("particleFlow"));
+  desc.add<double>("gridWidth",0.05);
+  desc.add<double>("bandWidth",0.2);
+  desc.add<bool>("doCentrality", true);
+  desc.add<int>("hiBinCut",100);
+  desc.add<bool>("keepGridInfo",false);
+  descriptions.add("hiFJGridEmptyAreaCalculator",desc);
 }
 
 DEFINE_FWK_MODULE(HiFJGridEmptyAreaCalculator);
-

--- a/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
+++ b/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.h
@@ -9,19 +9,20 @@
 #include <vector>
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
-#include "TMath.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
+class HiFJGridEmptyAreaCalculator : public edm::stream::EDProducer<> {
    public:
       explicit HiFJGridEmptyAreaCalculator(const edm::ParameterSet&);
       ~HiFJGridEmptyAreaCalculator();
@@ -29,9 +30,9 @@ class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
+      virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
+      virtual void endStream() override;
       
   /// @name setting a new event
   //\{
@@ -44,44 +45,67 @@ class HiFJGridEmptyAreaCalculator : public edm::EDProducer {
 private:
 
   /// configure the grid
-  void setup_grid(double eta_min, double eta_max);
-  void setup_grid_jet(const reco::Jet *jet);
+  void setupGrid(double eta_min, double eta_max);
+  void setupGridJet(const reco::Jet *jet);
 
   /// retrieve the grid cell index for a given PseudoJet
-  int tile_index_jet(const reco::PFCandidate *pfCand);
-  int tile_index_eta(const reco::PFCandidate *pfCand);
-  int tile_index_eta_jet(const reco::PFCandidate *pfCand);
-  int tile_index_phi(const reco::PFCandidate *pfCand);
+  int tileIndexJet(const reco::PFCandidate *pfCand);
+  int tileIndexEta(const reco::PFCandidate *pfCand);
+  int tileIndexEtaJet(const reco::PFCandidate *pfCand);
+  int tileIndexPhi(const reco::PFCandidate *pfCand);
   
   ///number of grid cells that overlap with jet constituents filling in the in between area
-  int num_jet_grid_cells( std::vector<std::pair<int, int> >& indices );
+  int numJetGridCells( std::vector<std::pair<int, int> >& indices );
   
   /// calculates the area of jets that fall within the eta 
   /// range by scaling kt areas using grid areas
-  void calculate_area_fraction_of_jets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  void calculate_grid_rho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculateAreaFractionOfJets(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void calculateGridRho(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   
   /// information about the grid
-  const double twopi = 2*TMath::Pi(); 
+  const double twopi_ = 2*M_PI;
   
-  ///internal parameters for grid 
-  double _ymin, _ymax, _dy, _dphi, _tile_area, //parameters of grid covering the full acceptance
-  _dyjet, _yminjet, _ymaxjet, _total_inbound_area, //parameters of grid around jets
-  _eta_min_jet, _eta_max_jet; //leave bands at boundaries
-  int _ny, _nphi, _ntotal, //for the grid calculation covering the full acceptance
-  _ntotaljet, _nyjet; //for the grid calculation around each jet
+  ///internal parameters for grid
+
+  //parameters of grid covering the full acceptance
+  double ymin_;
+  double ymax_;
+  double dy_;
+  double dphi_;
+  double tileArea_;
+
+  //parameters of grid around jets
+  double dyJet_;
+  double yminJet_;
+  double ymaxJet_;
+  double totalInboundArea_;
+
+  //leave bands at boundaries
+  double etaminJet_;
+  double etamaxJet_;
+
+  //for the grid calculation covering the full acceptance
+  int ny_;
+  int nphi_;
+  int ntotal_;
+
+  //for the grid calculation around each jet
+  int ntotalJet_;
+  int nyJet_;
   
   ///input parameters
-  double gridWidth_, band_;
+  double gridWidth_;
+  double band_;
   int hiBinCut_;
   bool doCentrality_;
+  bool keepGridInfo_;
   
-  std::vector<double> _rho_vs_eta;
-  std::vector<double> _mean_rho_vs_eta;
-  std::vector<double> _eta_max_grid;
-  std::vector<double> _eta_min_grid;
+  std::vector<double> rhoVsEta_;
+  std::vector<double> meanRhoVsEta_;
+  std::vector<double> etaMaxGrid_;
+  std::vector<double> etaMinGrid_;
   
-  int n_tiles()  {return _ntotal;}
+  int n_tiles()  {return ntotal_;}
   
   /// input tokens
   edm::EDGetTokenT<edm::View<reco::Jet>>                 jetsToken_;
@@ -95,4 +119,3 @@ private:
 };
 
 #endif
-

--- a/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiFJGridEmptyAreaCalculator_cff.py
@@ -1,15 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
 hiFJGridEmptyAreaCalculator = cms.EDProducer('HiFJGridEmptyAreaCalculator',
-                                 gridWidth = cms.untracked.double(0.05),
-                                 bandWidth = cms.untracked.double(0.2),
+                                 gridWidth = cms.double(0.05),
+                                 bandWidth = cms.double(0.2),
                                  mapEtaEdges = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
                                  mapToRho = cms.InputTag('hiFJRhoProducer','mapToRho'),
                                  mapToRhoM = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
                                  pfCandSource = cms.InputTag('particleFlowTmp'),
                                  jetSource = cms.InputTag('kt4PFJets'),
-								 doCentrality = cms.untracked.bool(True),
-								 hiBinCut = cms.untracked.int32(100),    
-								 CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
+		  		 doCentrality = cms.bool(True),
+				 hiBinCut = cms.int32(100),    
+				 CentralityBinSrc = cms.InputTag("centralityBin","HFtowers"),
 )
 


### PR DESCRIPTION
This PR backports HiFJGridEmptyAreaCalculator code to our 75X forest branch and fixes a bug.

Bug description:
It happens for the very rare case where a PF candidate has eta exactly equal to 5. There was a “=” sign missing in the code. To be exact in this line of code: 

https://github.com/mverwe/cmssw/blob/emptyAreaFixBugAndBackport/RecoHI/HiJetAlgos/plugins/HiFJGridEmptyAreaCalculator.cc#L190

that line was: if (pfCandidate.eta() < ymin_ || pfCandidate.eta() > ymax_ ) continue;
which results in a -1 index which doesn’t work as a position in a vector