### PR TITLE
Make jet sequences work for reco with 92X and 93X

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_cleanedPbPb.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/FullJetSequence_cleanedPbPb.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+#these producers are running in reco with 93X but not in 92X
+from HeavyIonsAnalysis.JetAnalysis.jets.HiRecoJets_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.HiRecoPFJets_cff import *
+
 #not in official reco yet
 from RecoHI.HiJetAlgos.hiFJGridEmptyAreaCalculator_cff import hiFJGridEmptyAreaCalculator
 
@@ -26,27 +30,24 @@ from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
 offlinePrimaryVertices.TrackLabel = 'highPurityTracks'
 
 jetSequences = cms.Sequence(
-    hiFJGridEmptyAreaCalculator +
-    
-    #jets already reconstructed in reco
-    #akPu3CaloJets +
-    #akPu3PFJets +
-    #akCs3PFJets +
-
-    #akPu4CaloJets +
-    #akPu4PFJets +
-    #akCs4PFJets +
-
-    #akPu5CaloJets +
-    #akPu5PFJets +
-
-    #to be added later
-    #akCsSoftDrop4PFJets +
-    #akCsSoftDrop5PFJets +
 
     highPurityTracks +
     offlinePrimaryVertices +
 
+    #these sequences are running in reco with 93X but not in 92X
+    PFTowers
+    *akPu3PFJets*akPu4PFJets*akPu5PFJets
+    *kt4PFJetsForRho
+    *hiFJRhoProducer
+    *hiFJGridEmptyAreaCalculator #not yet in 93X reco
+    *akCs3PFJets*akCs4PFJets
+
+    + akPu3CaloJets*akPu4CaloJets*akPu5CaloJets +
+
+    #to be added later
+    #akCsSoftDrop4PFJets +
+    #akCsSoftDrop5PFJets +
+    
     akPu3CaloJetSequence +
     akPu3PFJetSequence +
     akCs3PFJetSequence +

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/HiRecoJets_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/HiRecoJets_cff.py
@@ -1,0 +1,120 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoJets.Configuration.CaloTowersRec_cff import *
+
+## Default Parameter Sets
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+from RecoHI.HiJetAlgos.HiCaloJetParameters_cff import *
+
+## Calo Towers
+CaloTowerConstituentsMapBuilder = cms.ESProducer("CaloTowerConstituentsMapBuilder",
+    MapFile = cms.untracked.string('Geometry/CaloTopology/data/CaloTowerEEGeometric.map.gz')
+)
+
+caloTowers = cms.EDProducer("CaloTowerCandidateCreator",
+    src = cms.InputTag("towerMaker"),
+    e = cms.double(0.0),
+    verbose = cms.untracked.int32(0),
+    pt = cms.double(0.0),
+    minimumE = cms.double(0.0),
+    minimumEt = cms.double(0.0),
+    et = cms.double(0.0)
+)
+
+## Noise reducing PU subtraction algos
+
+## Iterative Cone
+iterativeConePu5CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("IterativeCone"),
+    rParam       = cms.double(0.5)
+    )
+iterativeConePu5CaloJets.radiusPU = 0.5
+
+## kT
+ktPu4CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("Kt"),
+    rParam       = cms.double(0.4)
+    )
+ktPu4CaloJets.radiusPU = 0.5
+
+ktPu6CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("Kt"),
+    rParam       = cms.double(0.6)
+    )
+ktPu6CaloJets.radiusPU = 0.7
+
+## anti-kT
+akPu5CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("AntiKt"),
+    rParam       = cms.double(0.5)
+    )
+akPu5CaloJets.radiusPU = 0.5
+
+akPu7CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("AntiKt"),
+    rParam       = cms.double(0.7)
+    )
+akPu7CaloJets.radiusPU = 0.7
+
+
+akPu5CaloJets.puPtMin = cms.double(10)
+akPu1CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.1), puPtMin = 4)
+akPu2CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.2), puPtMin = 4)
+akPu3CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.3), puPtMin = 6)
+akPu4CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.4), puPtMin = 8)
+akPu6CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.6), puPtMin = 12)
+akPu7CaloJets = akPu5CaloJets.clone(rParam       = cms.double(0.7), puPtMin = 14)
+
+ak5CaloJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiCaloJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("AntiKt"),
+    rParam       = cms.double(0.5)
+    )
+ak5CaloJets.doPUOffsetCorr = False
+ak1CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.1))
+ak2CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.2))
+ak3CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.3))
+ak4CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.4))
+ak6CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.6))
+ak7CaloJets = ak5CaloJets.clone(rParam       = cms.double(0.7))
+
+
+## Default Sequence
+hiRecoJets = cms.Sequence(
+    caloTowersRec*caloTowers*
+    iterativeConePu5CaloJets*
+    akPu3CaloJets*akPu4CaloJets*akPu5CaloJets
+    )
+
+## Extended Sequence
+hiRecoAllJets = cms.Sequence(
+    caloTowersRec*caloTowers*iterativeConePu5CaloJets
+    *ak1CaloJets*ak2CaloJets*ak3CaloJets*ak4CaloJets*ak5CaloJets*ak6CaloJets*ak7CaloJets
+    *akPu1CaloJets*akPu2CaloJets*akPu3CaloJets*akPu4CaloJets*akPu5CaloJets*akPu6CaloJets*akPu7CaloJets*
+    ktPu4CaloJets*ktPu6CaloJets
+    )
+
+

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/HiRecoPFJets_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/HiRecoPFJets_cff.py
@@ -1,0 +1,95 @@
+import FWCore.ParameterSet.Config as cms
+
+## Default Parameter Sets
+from RecoJets.JetProducers.AnomalousCellParameters_cfi import *
+from RecoHI.HiJetAlgos.HiPFJetParameters_cff import *
+
+#pseudo towers for noise suppression background subtraction
+PFTowers = cms.EDProducer("ParticleTowerProducer",
+                          src = cms.InputTag("particleFlowTmp"),
+                          useHF = cms.bool(False)
+                          )
+
+
+
+ak5PFJets = cms.EDProducer(
+    "FastjetJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    MultipleAlgoIteratorBlock,
+    jetAlgorithm = cms.string("AntiKt"),
+    rParam       = cms.double(0.5)
+    )
+ak5PFJets.src = cms.InputTag('particleFlowTmp')
+
+akPu5PFJets = ak5PFJets.clone(
+    jetType = cms.string('BasicJet'),
+    doPVCorrection = False,
+    doPUOffsetCorr = True,
+    subtractorName = cms.string("MultipleAlgoIterator"),    
+    src = cms.InputTag('PFTowers'),
+    doAreaFastjet = False
+    )
+
+
+
+akPu5PFJets.puPtMin = cms.double(25)
+akPu1PFJets = akPu5PFJets.clone(rParam       = cms.double(0.1), puPtMin = 10)
+akPu2PFJets = akPu5PFJets.clone(rParam       = cms.double(0.2), puPtMin = 10)
+akPu3PFJets = akPu5PFJets.clone(rParam       = cms.double(0.3), puPtMin = 15)
+akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
+akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
+akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
+
+kt4PFJetsForRho = cms.EDProducer(
+    "FastjetJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm = cms.string("Kt"),
+    rParam       = cms.double(0.4)
+)
+kt4PFJetsForRho.src = cms.InputTag('particleFlowTmp')
+kt4PFJetsForRho.doAreaFastjet = cms.bool(True)
+kt4PFJetsForRho.jetPtMin      = cms.double(0.0)
+kt4PFJetsForRho.GhostArea     = cms.double(0.005)
+
+hiFJRhoProducer = cms.EDProducer('HiFJRhoProducer',
+                                 jetSource = cms.InputTag('kt4PFJetsForRho'),
+                                 nExcl = cms.int32(2),
+                                 etaMaxExcl = cms.double(2.),
+                                 ptMinExcl = cms.double(20.),
+                                 nExcl2 = cms.int32(1),
+                                 etaMaxExcl2 = cms.double(3.),
+                                 ptMinExcl2 = cms.double(20.),
+                                 etaRanges = cms.vdouble(-5., -3., -2.1, -1.3, 1.3, 2.1, 3., 5.)
+)
+
+akCs4PFJets = cms.EDProducer(
+    "CSJetProducer",
+    HiPFJetParameters,
+    AnomalousCellParameters,
+    jetAlgorithm  = cms.string("AntiKt"),
+    rParam        = cms.double(0.4),
+    etaMap    = cms.InputTag('hiFJRhoProducer','mapEtaEdges'),
+    rho       = cms.InputTag('hiFJRhoProducer','mapToRho'),
+    rhom      = cms.InputTag('hiFJRhoProducer','mapToRhoM'),
+    csRParam  = cms.double(-1.),
+    csAlpha   = cms.double(2.),
+    writeJetsWithConst = cms.bool(True),
+    jetCollInstanceName = cms.string("pfParticlesCs")
+)
+akCs4PFJets.src           = cms.InputTag('particleFlowTmp')
+akCs4PFJets.doAreaFastjet = cms.bool(True)
+akCs4PFJets.jetPtMin      = cms.double(0.0)
+akCs4PFJets.useExplicitGhosts = cms.bool(True)
+akCs4PFJets.GhostArea     = cms.double(0.005)
+
+akCs3PFJets = akCs4PFJets.clone(rParam       = cms.double(0.3))
+
+hiRecoPFJets = cms.Sequence(
+    PFTowers
+    *akPu3PFJets*akPu4PFJets*akPu5PFJets
+    *kt4PFJetsForRho*hiFJRhoProducer
+    *akCs3PFJets*akCs4PFJets
+    )
+

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MB_92X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MB_92X.py
@@ -118,7 +118,7 @@ process.pfcandAnalyzer.doVS = cms.untracked.bool(False)
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzerCS_cfi")
 process.pfcandAnalyzerCS.skipCharged = False
 process.pfcandAnalyzerCS.pfPtMin = 0
-process.pfcandAnalyzer.doVS = cms.untracked.bool(False)
+process.pfcandAnalyzerCS.doVS = cms.untracked.bool(False)
 
 #####################################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MB_92X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_PbPb_MB_92X.py
@@ -26,7 +26,8 @@ process.HiForest.HiForestVersion = cms.string(version)
 process.source = cms.Source("PoolSource",
                             duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
                             fileNames = cms.untracked.vstring(
-                                "file:samples/PbPb_MC_RECODEBUG.root"
+                                "file:/afs/cern.ch/user/m/mverweij/merge/xexe/step3_RAW2DIGI_L1Reco_RECO_1.root",
+#samples/PbPb_MC_RECODEBUG.root"
                                 )
                             )
 
@@ -96,6 +97,9 @@ process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cff')
 process.HiGenParticleAna.genParticleSrc = cms.untracked.InputTag("genParticles")
 # Temporary disactivation - until we have DIGI & RECO in CMSSW_7_5_7_patch4
 process.HiGenParticleAna.doHI = False
+#making cuts looser so that we can actually check dNdEta
+process.HiGenParticleAna.ptMin = cms.untracked.double(0.)  #default is 5
+process.HiGenParticleAna.etaMax = cms.untracked.double(5.) #default is 2
 
 
 #####################################################################################
@@ -110,9 +114,11 @@ process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.skipCharged = False
 process.pfcandAnalyzer.pfPtMin = 0
+process.pfcandAnalyzer.doVS = cms.untracked.bool(False)
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzerCS_cfi")
 process.pfcandAnalyzerCS.skipCharged = False
 process.pfcandAnalyzerCS.pfPtMin = 0
+process.pfcandAnalyzer.doVS = cms.untracked.bool(False)
 
 #####################################################################################
 
@@ -154,8 +160,8 @@ process.ana_step = cms.Path(
                             process.hiCleanedGenFilters + 
                             process.jetSequences +
                             process.hiFJRhoAnalyzer +
-                            process.ggHiNtuplizer +
-                            process.ggHiNtuplizerGED +
+                            #process.ggHiNtuplizer +
+                            #process.ggHiNtuplizerGED +
                             process.pfcandAnalyzer +
                             process.pfcandAnalyzerCS +
                             process.HiForest +

--- a/RecoHI/HiJetAlgos/plugins/HiSignalParticleProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiSignalParticleProducer.cc
@@ -1,0 +1,119 @@
+// -*- C++ -*-
+//
+// Package:    HiSignalParticleProducer
+// Class:      HiSignalParticleProducer
+// 
+/**\class HiSignalParticleProducer HiSignalParticleProducer.cc yetkin/HiSignalParticleProducer/src/HiSignalParticleProducer.cc
+ Description: <one line class summary>
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Yetkin Yilmaz
+//         Created:  Tue Jul 21 04:26:01 EDT 2009
+//
+//
+
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/GeometryVector/interface/VectorUtil.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+
+#include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+using namespace std;
+using namespace edm;
+
+
+//
+// class decleration
+//
+
+class HiSignalParticleProducer : public edm::EDProducer {
+public:
+  explicit HiSignalParticleProducer(const edm::ParameterSet&);
+  ~HiSignalParticleProducer();
+
+private:
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<edm::View<reco::GenParticle> > genParticleSrc_;
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+
+HiSignalParticleProducer::HiSignalParticleProducer(const edm::ParameterSet& iConfig) :
+  genParticleSrc_(consumes<edm::View<reco::GenParticle> >(iConfig.getParameter<edm::InputTag>("src")))
+{
+  std::string alias = (iConfig.getParameter<InputTag>( "src")).label();
+  produces<reco::GenParticleCollection>().setBranchAlias (alias);
+}
+
+HiSignalParticleProducer::~HiSignalParticleProducer()
+{
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+
+void
+HiSignalParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+  using namespace reco;
+
+  //auto_ptr<GenParticleCollection> signalGenParticles;
+  //signalGenParticles = auto_ptr<GenParticleCollection>(new GenParticleCollection);
+
+  auto signalGenParticles = std::make_unique<reco::GenParticleCollection>();
+    
+  edm::Handle<edm::View<GenParticle> > genParticles;
+  iEvent.getByToken(genParticleSrc_,genParticles);
+
+  int genParticleSize = genParticles->size();
+  for(int igenParticle = 0; igenParticle < genParticleSize; ++igenParticle){
+    reco::GenParticle genParticle = (*genParticles)[igenParticle];
+    if(genParticle.collisionId()==0) {
+      signalGenParticles->push_back(genParticle);
+    }
+  }
+
+  iEvent.put(std::move(signalGenParticles));
+}
+
+DEFINE_FWK_MODULE(HiSignalParticleProducer);

--- a/RecoHI/HiJetAlgos/python/HiSignalParticleProducer_cfi.py
+++ b/RecoHI/HiJetAlgos/python/HiSignalParticleProducer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+
+hiSignalGenParticles = cms.EDProducer('HiSignalParticleProducer',
+                                    src    = cms.InputTag('genParticles')
+                                    )
+


### PR DESCRIPTION
- photon analyzers are disabled because they were giving an error about not finding some super cluster collection
- pt and eta cuts for gen particles loosened
- jet reconstruction now running in the same way as we already have in 93X. 92X doesn't have this in the reco (yet) so I activate a rereco of jets

All was tested using this input file: root://cms-xrd-global.cern.ch//store/user/mnguyen/hydjetDrum5_XeXe_b0_930/hydjetDrum5_XeXe_b0_930/crab_Hydjet_Quenched_XeXe_B0_5442GeV_HIRECO_930/170927_090559/0000/step3_RAW2DIGI_L1Reco_RECO_1.root

I'm seeing some MVA related warnings/errors but they don't kill the run:
>> ERROR                         : 0-th variable of the event is NaN --> return MVA value -999,
>> ERROR                         :  that's all I can do, please fix or remove this event.
@ikucher maybe related to b-tagging?