### PR TITLE
raise min pt to 0.4 for gen analyser

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_HI_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_HI_MB_103X.py
@@ -94,7 +94,7 @@ process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cfi')
 process.load('HeavyIonsAnalysis.TrackAnalysis.HiGenAnalyzer_cfi')
 # making cuts looser so that we can actually check dNdEta
-process.HiGenParticleAna.ptMin = cms.untracked.double(0.) # default is 5
+process.HiGenParticleAna.ptMin = cms.untracked.double(0.4) # default is 5
 process.HiGenParticleAna.etaMax = cms.untracked.double(5.) # default is 2
 
 ###############################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_HI_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_HI_MIX_103X.py
@@ -96,7 +96,7 @@ process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cfi')
 process.load('HeavyIonsAnalysis.TrackAnalysis.HiGenAnalyzer_cfi')
 # making cuts looser so that we can actually check dNdEta
-process.HiGenParticleAna.ptMin = cms.untracked.double(0.) # default is 5
+process.HiGenParticleAna.ptMin = cms.untracked.double(0.4) # default is 5
 process.HiGenParticleAna.etaMax = cms.untracked.double(5.) # default is 2
 
 ###############################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
@@ -102,7 +102,7 @@ process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cfi')
 process.load('HeavyIonsAnalysis.TrackAnalysis.HiGenAnalyzer_cfi')
 # making cuts looser so that we can actually check dNdEta
-process.HiGenParticleAna.ptMin = cms.untracked.double(0.) # default is 5
+process.HiGenParticleAna.ptMin = cms.untracked.double(0.4) # default is 5
 process.HiGenParticleAna.etaMax = cms.untracked.double(5.) # default is 2
 
 ###############################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -102,7 +102,7 @@ process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.load('HeavyIonsAnalysis.EventAnalysis.runanalyzer_cfi')
 process.load('HeavyIonsAnalysis.TrackAnalysis.HiGenAnalyzer_cfi')
 # making cuts looser so that we can actually check dNdEta
-process.HiGenParticleAna.ptMin = cms.untracked.double(0.) # default is 5
+process.HiGenParticleAna.ptMin = cms.untracked.double(0.4) # default is 5
 process.HiGenParticleAna.etaMax = cms.untracked.double(5.) # default is 2
 
 ###############################################################################


### PR DESCRIPTION
raise min pt of saved gen particles to 0.4 gev. overall forest file size is reduced by ~23%.
comparison of forest output before/after change can be found at /afs/cern.ch/work/r/rbi/public/forest/validation/genanalyserminpt-181105/comparison/

will merge this early tomorrow if there are no comments

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

@ttrk 