### PR TITLE
clear arrays for b-tagging variables

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -838,6 +838,43 @@ HiInclusiveJetAnalyzer::beginJob() {
   */
   TH1D::SetDefaultSumw2();
 
+  if (doLifeTimeTagging_) {
+    /* clear arrays */
+    memset(jets_.discr_csvV1, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_csvV2, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_muByIp3, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_muByPt, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_prob, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_probb, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_tcHighEff, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_tcHighPur, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_ssvHighEff, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_ssvHighPur, 0, MAXJETS * sizeof(float));
+
+    memset(jets_.ndiscr_ssvHighEff, 0, MAXJETS * sizeof(float));
+    memset(jets_.ndiscr_ssvHighPur, 0, MAXJETS * sizeof(float));
+    memset(jets_.ndiscr_csvV1, 0, MAXJETS * sizeof(float));
+    memset(jets_.ndiscr_csvV2, 0, MAXJETS * sizeof(float));
+    memset(jets_.ndiscr_muByPt, 0, MAXJETS * sizeof(float));
+
+    memset(jets_.pdiscr_csvV1, 0, MAXJETS * sizeof(float));
+    memset(jets_.pdiscr_csvV2, 0, MAXJETS * sizeof(float));
+
+    memset(jets_.nsvtx, 0, MAXJETS * sizeof(int));
+    memset(jets_.svtxntrk, 0, MAXJETS * sizeof(int));
+    memset(jets_.svtxdl, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxdls, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxdl2d, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxdls2d, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxm, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxpt, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxmcorr, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxnormchi2, 0, MAXJETS * sizeof(float));
+    memset(jets_.svJetDeltaR, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxTrkSumChi2, 0, MAXJETS * sizeof(float));
+    memset(jets_.svtxTrkNetCharge, 0, MAXJETS * sizeof(int));
+    memset(jets_.svtxNtrkInCone, 0, MAXJETS * sizeof(int));
+  }
 }
 
 


### PR DESCRIPTION
reset arrays to 0 at start of jet analyser. this prevents rubbish values from being stored in some branches for the first event of most jet analyser trees.

a scan of the affected variables show changes only in the first event. variable distributions after the fix can be found at /afs/cern.ch/work/r/rbi/public/forest/validation/clearbtagarrays-181106/comparison/*.pdf

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

@InnaKucher @cfmcginn 
