### PR TITLE
Fix for trkMVA branch in trackTree

### DIFF
--- a/HeavyIonsAnalysis/TrackAnalysis/python/TrkAnalyzers_cff.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/TrkAnalyzers_cff.py
@@ -7,7 +7,9 @@ anaTrack = ppTrack.clone(
     trackSrc = cms.InputTag("hiGeneralTracks"),
     vertexSrc = cms.vstring('hiSelectedVertex'),
     mvaSrc = cms.InputTag('hiGeneralTracks','MVAVals'),
-    pfCandSrc = cms.InputTag("particleFlowTmp"))
+    pfCandSrc = cms.InputTag("particleFlowTmp"),
+    doMVA = False   
+)
 
 pixelTrack = anaTrack.clone(
     trackPtMin = 0.4,

--- a/HeavyIonsAnalysis/TrackAnalysis/python/trackAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/trackAnalyzer_cfi.py
@@ -6,7 +6,7 @@ ppTrack = cms.EDAnalyzer(
     simTrackPtMin = cms.untracked.double(0.1),
     vertexSrc = cms.vstring('offlinePrimaryVertices'),
     trackSrc = cms.InputTag('generalTracks'),
-    mvaSrc = cms.InputTag("generalTracks","MVAVals"),
+    mvaSrc = cms.InputTag("generalTracks","MVAValues"),
     particleSrc = cms.InputTag('genParticles'),
     pfCandSrc = cms.InputTag('particleFlow'),
     beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot'),
@@ -20,6 +20,6 @@ ppTrack = cms.EDAnalyzer(
     tpEffSrc = cms.untracked.InputTag('mix','MergedTrackTruth'),
     # associateChi2 = cms.bool(False),
     associatorMap = cms.InputTag('tpRecoAssocHiGeneralTracks'),
-    doMVA = cms.untracked.bool(False),
+    doMVA = cms.untracked.bool(True),
     fillSimTrack = cms.untracked.bool(False)
 )

--- a/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
@@ -276,7 +276,7 @@ class TrackAnalyzer : public edm::EDAnalyzer {
     edm::EDGetTokenT<edm::View<reco::Track>> trackSrcView_;
     edm::EDGetTokenT<std::vector<reco::Track>> trackSrc_;
     edm::InputTag mvaSrcLabel_;
-    edm::EDGetTokenT<edm::ValueMap<float>> mvaSrc_;
+    edm::EDGetTokenT<std::vector<float>> mvaSrc_;
     edm::EDGetTokenT<reco::GenParticleCollection> particleSrc_;
     edm::EDGetTokenT<TrackingParticleCollection> tpEffSrc_;
     edm::EDGetTokenT<reco::PFCandidateCollection> pfCandSrc_;
@@ -334,7 +334,7 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig)
   trackSrcView_ = consumes<edm::View<reco::Track>>(trackSrcLabel_);
   if (doMVA_) {
     mvaSrcLabel_ = iConfig.getParameter<edm::InputTag>("mvaSrc");
-    mvaSrc_ = consumes<edm::ValueMap<float>>(mvaSrcLabel_);
+    mvaSrc_ = consumes<std::vector<float>>(mvaSrcLabel_);
   }
   if (doSimTrack_) {
     particleSrc_ = consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("particleSrc"));
@@ -540,7 +540,7 @@ TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& iSetu
     iEvent.getByToken(DeDxSrc_, DeDxMap);
   }
 
-  edm::Handle<edm::ValueMap<float>> mvaoutput;
+  edm::Handle<std::vector<float>> mvaoutput;
   if (doMVA_) {
     iEvent.getByToken(mvaSrc_, mvaoutput);
   }
@@ -629,7 +629,7 @@ TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& iSetu
         else
           pev_.trkMVA[pev_.nTrk] = -1;
       } else {
-        pev_.trkMVA[pev_.nTrk] = (*mvaoutput)[trackRef];//non algo = 11 behavior
+        pev_.trkMVA[pev_.nTrk] = (*mvaoutput)[it];//non algo = 11 behavior
       }
 
       if (mvaSrcLabel_.label() == "generalTracks") {
@@ -893,9 +893,9 @@ TrackAnalyzer::fillSimTracks(const edm::Event& iEvent, const edm::EventSetup& iS
           }
 
           if (mvaSrcLabel_.label() == "generalTracks") {
-            pev_.mtrkMVALoose[pev_.nParticle] = (!((pev_.mtrkAlgo[pev_.nParticle] == 4 && pev_.mtrkMVA[pev_.nParticle] < -0.7) || (pev_.mtrkAlgo[pev_.nParticle] == 5 && pev_.mtrkMVA[pev_.nParticle] < -0.1) || (pev_.mtrkAlgo[pev_.nParticle] == 6 && pev_.mtrkMVA[pev_.nParticle] < 0.3) || (pev_.mtrkAlgo[pev_.nParticle] == 7 && pev_.mtrkMVA[pev_.nParticle] < 0.4) || (pev_.mtrkAlgo[pev_.nParticle] == 8 && pev_.mtrkMVA[pev_.nParticle] < -0.2) || (pev_.mtrkAlgo[pev_.nParticle] == 9 && pev_.mtrkMVA[pev_.nParticle] < 0.0) ||(pev_.mtrkAlgo[pev_.nParticle] == 10 && pev_.mtrkMVA[pev_.nParticle] < -0.3)) || pev_.mtrkMVA[pev_.nParticle] == -99) &&  mtrk->quality(reco::TrackBase::qualityByName("highPurity"));
+            pev_.mtrkMVALoose[pev_.nParticle] = mtrk->quality(reco::TrackBase::qualityByName("highPurity"));
 
-            pev_.mtrkMVATight[pev_.nParticle] = (!((pev_.mtrkAlgo[pev_.nParticle] == 4 && pev_.mtrkMVA[pev_.nParticle] < -0.7) || (pev_.mtrkAlgo[pev_.nParticle] == 5 && pev_.mtrkMVA[pev_.nParticle] < -0.1) || (pev_.mtrkAlgo[pev_.nParticle] == 6 && pev_.mtrkMVA[pev_.nParticle] < 0.3) || (pev_.mtrkAlgo[pev_.nParticle] == 7 && pev_.mtrkMVA[pev_.nParticle] < 0.5) || (pev_.mtrkAlgo[pev_.nParticle] == 8 && pev_.mtrkMVA[pev_.nParticle] < 0.5) || (pev_.mtrkAlgo[pev_.nParticle] == 9 && pev_.mtrkMVA[pev_.nParticle] < 0.4) ||(pev_.mtrkAlgo[pev_.nParticle] == 10 && pev_.mtrkMVA[pev_.nParticle] < 0)) || pev_.mtrkMVA[pev_.nParticle] == -99) &&  mtrk->quality(reco::TrackBase::qualityByName("highPurity"));
+            pev_.mtrkMVATight[pev_.nParticle] = mtrk->quality(reco::TrackBase::qualityByName("highPurity"));
           } else if (mvaSrcLabel_.label() == "hiGeneralTracks") {
             pev_.mtrkMVATight[pev_.nParticle] = (!((pev_.mtrkAlgo[pev_.nParticle] == 4 && pev_.mtrkMVA[pev_.nParticle] < -0.77) || (pev_.mtrkAlgo[pev_.nParticle] == 5 && pev_.mtrkMVA[pev_.nParticle] < 0.35) || (pev_.mtrkAlgo[pev_.nParticle] == 6 && pev_.mtrkMVA[pev_.nParticle] < 0.77) || (pev_.mtrkAlgo[pev_.nParticle] == 7 && pev_.mtrkMVA[pev_.nParticle] < 0.35)) || pev_.mtrkMVA[pev_.nParticle] == -99) &&  mtrk->quality(reco::TrackBase::qualityByName("highPurity"));
           }


### PR DESCRIPTION
Fixed trkMVA branch for 10_3_1, and turned in on as default for pponAA setting.  It was broken in the past because the collection stored was swapped from an edm::ValueMap to a std::vector.

The values seem correlated with the highPurity bit, as expected, verifying the implementation:
https://www.dropbox.com/s/vndw4bg9afgvyg8/MVAs.png?dl=0


Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
