### PR TITLE
retrieve l1 prescales from correct source

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/python/hltanalysis_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hltanalysis_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 hltanalysis = cms.EDAnalyzer('HLTBitAnalyzer',
     HLTProcessName = cms.string('HLT'),
     hltresults = cms.InputTag('TriggerResults::HLT'),
-    l1results = cms.InputTag(''),
+    l1results = cms.InputTag('gtStage2Digis'),
     UseTFileService = cms.untracked.bool(True),
     RunParameters = cms.PSet(
         isData = cms.untracked.bool(True)),


### PR DESCRIPTION
also protect against trying to read empty l1 info and segfaulting - now a warning is printed instead. saving l1 info in hltanalysis is also enabled by default

this works for both v1 and v2 of prompt reco, and reproduces the l1 prescales found on wbm

i think a better solution would be to have our own hlt analyser, but this will do for now..

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No
