### PR TITLE
Adding matched track quality variables for pfcandAnalyzer

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
@@ -16,7 +16,7 @@ class TreePFCandEventData
 {
   public:
     void SetTree(TTree * t) { tree_ = t; }
-    void SetBranches(bool doJets, bool doMC, bool doCaloEnergy);
+    void SetBranches(bool doJets, bool doMC, bool doCaloEnergy, bool doTrackMatching);
     void Clear();
 
     Int_t nPFpart_;
@@ -31,6 +31,12 @@ class TreePFCandEventData
     std::vector<Float_t> pfEcalEraw_;
     std::vector<Float_t> pfHcalE_;
     std::vector<Float_t> pfHcalEraw_;
+
+    std::vector<Int_t> trkAlgo_;
+    std::vector<Float_t> trkPtError_;
+    std::vector<Float_t> trkNHit_;
+    std::vector<Float_t> trkChi2_;
+    std::vector<Float_t> trkNdof_;
     
     Int_t nGENpart_;
     std::vector<Int_t> genPDGId_;
@@ -65,6 +71,7 @@ class HiPFCandAnalyzer : public edm::EDAnalyzer {
     edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidatePF_;
     edm::EDGetTokenT<reco::GenParticleCollection> genLabel_;
     edm::EDGetTokenT<pat::JetCollection> jetLabel_;
+    edm::EDGetTokenT<reco::TrackCollection> trkLabel_;
 
     TreePFCandEventData pfEvt_;
     TTree *pfTree_;
@@ -79,4 +86,5 @@ class HiPFCandAnalyzer : public edm::EDAnalyzer {
     bool doMC_;
     bool doCaloEnergy_;
     bool skipCharged_;
+    bool doTrackMatching_;
 };

--- a/HeavyIonsAnalysis/JetAnalysis/python/pfcandAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/pfcandAnalyzer_cfi.py
@@ -13,6 +13,9 @@ pfcandAnalyzer = cms.EDAnalyzer(
     doJets           = cms.bool(False),
     doCaloEnergy     = cms.bool(True),
     skipCharged      = cms.bool(False),
+  
+    doTrackMatching  = cms.bool(False),
+    trackLabel       = cms.InputTag("generalTracks")
     )
 
 pfcandAnalyzerCS = pfcandAnalyzer.clone(

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
@@ -119,27 +119,20 @@ HiPFCandAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
       //find the track key
       unsigned int trackKey = pfcand.trackRef().key();     
 
-      //loop through tracks looking for this key 
-      for(unsigned int it=0; it<tracks->size(); ++it){
-        //if these are matched...
-        if(trackKey == it){
-          const reco::Track & trk = (*tracks)[it];
+      if(trackKey < tracks->size()){
+          const reco::Track & trk = (*tracks)[trackKey];
           pfEvt_.trkAlgo_.push_back( trk.algo() );  
           pfEvt_.trkPtError_.push_back( trk.ptError() );  
           pfEvt_.trkNHit_.push_back( trk.numberOfValidHits() );  
           pfEvt_.trkChi2_.push_back( trk.chi2() );  
           pfEvt_.trkNdof_.push_back( trk.ndof() );  
-          break;
-        }
-        
-        //if we didn't find a match...
-        if( it == tracks->size()-1){
-          pfEvt_.trkAlgo_.push_back( -999 );  
-          pfEvt_.trkPtError_.push_back( -999 );  
-          pfEvt_.trkNHit_.push_back( -999 );  
-          pfEvt_.trkChi2_.push_back( 0 );  
-          pfEvt_.trkNdof_.push_back( -999 );  
-        }
+      }
+      else{
+        pfEvt_.trkAlgo_.push_back( -999 );  
+        pfEvt_.trkPtError_.push_back( -999 );  
+        pfEvt_.trkNHit_.push_back( -999 );  
+        pfEvt_.trkChi2_.push_back( 0 );  
+        pfEvt_.trkNdof_.push_back( -999 );  
       }
     }
   }

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -26,13 +26,13 @@ process.HiForest.HiForestVersion = cms.string(version)
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        "file:/eos/cms/store/hidata/HIRun2018A/HIMinimumBias0/AOD/PromptReco-v2/000/327/078/00000/7F80481A-9412-6444-8ED6-DF598F6D4F8E.root"
+        "file:/afs/cern.ch/work/r/rbi/public/forest/step2_t0streamer_RAW2DIGI_L1Reco_RECO.root"
         ),
     )
 
 # Number of events we want to process, -1 = all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(1)
     )
 
 ###############################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -26,13 +26,13 @@ process.HiForest.HiForestVersion = cms.string(version)
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        "file:/afs/cern.ch/work/r/rbi/public/forest/step2_t0streamer_RAW2DIGI_L1Reco_RECO.root"
+        "file:/eos/cms/store/hidata/HIRun2018A/HIMinimumBias0/AOD/PromptReco-v2/000/327/078/00000/7F80481A-9412-6444-8ED6-DF598F6D4F8E.root"
         ),
     )
 
 # Number of events we want to process, -1 = all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(100)
     )
 
 ###############################################################################
@@ -93,6 +93,8 @@ process.akPu4PFJets.jetPtMin = 1
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
+process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
+process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -32,7 +32,7 @@ process.source = cms.Source("PoolSource",
 
 # Number of events we want to process, -1 = all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10)
+    input = cms.untracked.int32(1)
     )
 
 ###############################################################################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -32,7 +32,7 @@ process.source = cms.Source("PoolSource",
 
 # Number of events we want to process, -1 = all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1)
+    input = cms.untracked.int32(10)
     )
 
 ###############################################################################
@@ -94,7 +94,6 @@ process.akPu4PFJets.jetPtMin = 1
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
-process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
@@ -124,7 +124,6 @@ process.akCs6PFcorr.payload = "AK4PF"
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
-process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
@@ -123,6 +123,8 @@ process.akCs6PFcorr.payload = "AK4PF"
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
+process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
+process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
@@ -93,6 +93,8 @@ process.akPu4PFJets.jetPtMin = 1
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
+process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
+process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
@@ -94,7 +94,6 @@ process.akPu4PFJets.jetPtMin = 1
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
-process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -93,6 +93,8 @@ process.akPu4PFJets.jetPtMin = 1
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
+process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
+process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -94,7 +94,6 @@ process.akPu4PFJets.jetPtMin = 1
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
-process.pfcandAnalyzerCS.doTrackMatching  = cms.bool(True)
 
 ###############################################################################
 


### PR DESCRIPTION
Describe the Pull-Request:

This change adds an option to loop over the track collection and match tracks with their charged pf candidate partner in the pfcandAnalyzer tree.  The quality variables of the matched track are then output into the tree.  5 branches have been added.  The matching between pfcand and track should be exact (not done via eta/phi matching).

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@cfmcginn Could you please take a look at the distributions and make sure the matching looks reasonable to you?