### PR TITLE
fix, clean up rec hit analyser

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/rechitanalyzer_cfi.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/rechitanalyzer_cfi.py
@@ -1,26 +1,38 @@
 import FWCore.ParameterSet.Config as cms
 
 rechitanalyzer = cms.EDAnalyzer("RecHitTreeProducer",
-    EBRecHitSrc = cms.untracked.InputTag("ecalRecHit","EcalRecHitsEB"),
-    EERecHitSrc = cms.untracked.InputTag("ecalRecHit","EcalRecHitsEE"),
-    BasicClusterSrc1 = cms.untracked.InputTag("islandBasicClusters","islandBarrelBasicClusters"),
-    hcalHFRecHitSrc = cms.untracked.InputTag("hfreco"),
-    hcalHBHERecHitSrc = cms.untracked.InputTag("hbhereco"),
-    towersSrc = cms.untracked.InputTag("towerMaker"),
-    JetSrc = cms.untracked.InputTag("iterativeConePu5CaloJets"),
-    zdcRecHitSrc = cms.untracked.InputTag("zdcreco"),
-    castorRecHitSrc = cms.untracked.InputTag("castorreco"),
-    zdcDigiSrc = cms.untracked.InputTag("hcalDigis"),
-    vtxSrc = cms.untracked.InputTag("hiSelectedVertex"),
-    useJets = cms.untracked.bool(True),
-    doBasicClusters = cms.untracked.bool(False),
-    doTowers = cms.untracked.bool(True),
-    doEcal = cms.untracked.bool(False),
-    doHcal = cms.untracked.bool(False),
-    hasVtx = cms.untracked.bool(True),
-    doFastJet = cms.untracked.bool(False),
-    FastJetTag = cms.untracked.InputTag("kt4CaloJets"),
-    doEbyEonly = cms.untracked.bool(False),
+    doEbyEonly = cms.bool(False),
+    doBasicClusters = cms.bool(False),
+    doTowers = cms.bool(True),
+    doEcal = cms.bool(False),
+    doHBHE = cms.bool(False),
+    doHF = cms.bool(True),
+    doFastJet = cms.bool(False),
+    doCASTOR = cms.bool(True),
+    doZDCRecHit = cms.bool(False),
+    doZDCDigi = cms.bool(False),
+
+    EBRecHitSrc = cms.InputTag("ecalRecHit","EcalRecHitsEB"),
+    EERecHitSrc = cms.InputTag("ecalRecHit","EcalRecHitsEE"),
+    BasicClusterSrc = cms.InputTag("islandBasicClusters","islandBarrelBasicClusters"),
+    hcalHFRecHitSrc = cms.InputTag("hfreco"),
+    hcalHBHERecHitSrc = cms.InputTag("hbhereco"),
+    towersSrc = cms.InputTag("towerMaker"),
+    FastJetRhoTag = cms.InputTag("kt4CaloJets"),
+    FastJetSigmaTag = cms.InputTag("kt4CaloJets"),
+    castorRecHitSrc = cms.InputTag("castorreco"),
+    zdcRecHitSrc = cms.InputTag("zdcreco"),
+    zdcDigiSrc = cms.InputTag("hcalDigis"),
+
+    nZdcTs = cms.int32(10),
+    calZDCDigi = cms.bool(True),
+
+    hasVtx = cms.bool(True),
+    vtxSrc = cms.InputTag("hiSelectedVertex"),
+    useJets = cms.bool(False),
+    JetSrc = cms.InputTag("iterativeConePu5CaloJets"),
+    saveBothVtx = cms.bool(False),
+
     HFtowerMin = cms.untracked.double(3),
     HFlongMin = cms.untracked.double(0.5),
     HFshortMin = cms.untracked.double(0.85),     
@@ -29,27 +41,23 @@ rechitanalyzer = cms.EDAnalyzer("RecHitTreeProducer",
     EBTreePtMin = cms.untracked.double(15),
     EETreePtMin = cms.untracked.double(15),
     TowerTreePtMin = cms.untracked.double(-9999),
-    doHF = cms.untracked.bool(True)
     )
 
 pfTowers = rechitanalyzer.clone(
-    doEcal  = cms.untracked.bool(False),
-    doHcal  = cms.untracked.bool(False),
-    hasVtx  = cms.untracked.bool(False),
-    doFastJet = cms.untracked.bool(False),
-    towersSrc = cms.untracked.InputTag("PFTowers"),
+    doHF = cms.bool(False),
+    hasVtx = cms.bool(False),
+    towersSrc = cms.InputTag("PFTowers"),
     TowerTreePtMin = cms.untracked.double(-99),
     )
 
 rechitanalyzerpp = rechitanalyzer.clone(
-    vtxSrc = cms.untracked.InputTag("offlinePrimaryVerticesWithBS"),
-    JetSrc = cms.untracked.InputTag("ak4CaloJets"),
-    doHF = cms.untracked.bool(False)
+    doHF = cms.bool(False),
+    vtxSrc = cms.InputTag("offlinePrimaryVerticesWithBS"),
+    JetSrc = cms.InputTag("ak4CaloJets"),
     )
 
 pfTowerspp = pfTowers.clone(
-    vtxSrc = cms.untracked.InputTag("offlinePrimaryVerticesWithBS"),
-    JetSrc = cms.untracked.InputTag("ak4CaloJets"),
-    doHF = cms.untracked.bool(False),
-    doTowers = cms.untracked.bool(False)
+    doHF = cms.bool(False),
+    vtxSrc = cms.InputTag("offlinePrimaryVerticesWithBS"),
+    JetSrc = cms.InputTag("ak4CaloJets"),
     )

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -153,18 +153,16 @@ process.CSVscikitTags.weightFile = cms.FileInPath(
 ###############################################################################
 
 #########################
-# ZDC RecHit Producer
+# RecHits & pfTowers (HF, Castor & ZDC)
 #########################
+# ZDC RecHit Producer
 process.load('RecoHI.ZDCRecHit.QWZDC2018Producer_cfi')
 process.load('RecoHI.ZDCRecHit.QWZDC2018RecHit_cfi')
 
-###############################################################################
-
-#########################
-# RecHits & pfTowers (HF, Castor & ZDC)
-#########################
 process.load('HeavyIonsAnalysis.JetAnalysis.rechitanalyzer_cfi')
-process.rechitanalyzerpp.zdcRecHitSrc = cms.untracked.InputTag("QWzdcreco")
+process.rechitanalyzerpp.doZDCRecHit = True
+process.rechitanalyzerpp.zdcRecHitSrc = cms.InputTag("QWzdcreco")
+process.pfTowerspp.doHF = False
 
 ###############################################################################
 #Recover peripheral primary vertices


### PR DESCRIPTION
fix a bug in the rec hit analyzer (branch pointing to wrong variable), and some clean up:
avoid writing variables that are not filled
avoid filling variables that are not written
(saves ~20% of total foresting time)

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

no changes except removal of variables that are not filled: comparisons at /afs/cern.ch/work/r/rbi/public/forest/validation/cleanrechitanalyser-181128/comparison/*.pdf