### PR TITLE
Producer for ecal-shifted PFCandidates

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="CondCore/PopCon"/>
 <use   name="JetMETCorrections/Objects"/>
 <use   name="Geometry/CaloGeometry"/>
+<use   name="RecoParticleFlow/PFClusterTools"/>
 <flags   EDM_PLUGIN="1"/>
 <library   file="*.cc" name="HiJetAlgosPlugins">
 </library>

--- a/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.cc
@@ -1,0 +1,142 @@
+// -*- C++ -*-
+//
+// Package:    EcalEscaleShiftPFProducer
+// Class:      EcalEscaleShiftPFProducer
+// 
+/**\class EcalEscaleShiftPFProducer EcalEscaleShiftPFProducer.cc RecoHI/EcalEscaleShiftPFProducer/src/EcalEscaleShiftPFProducer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+
+// system include files
+#include <memory>
+
+// user include files
+#include "RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+EcalEscaleShiftPFProducer::EcalEscaleShiftPFProducer(const edm::ParameterSet& iConfig) :
+  calibrator_(new PFEnergyCalibration)
+{
+   //register your products  
+  src_ = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  removePreshower_ = iConfig.getParameter<bool>("removePreshower");
+  scaleEB_ = iConfig.getParameter<double>("scaleEB");
+  scaleEE_ = iConfig.getParameter<double>("scaleEE");
+
+  produces<reco::PFCandidateCollection>();
+  
+  //now do what ever other initialization is needed
+  
+
+
+}
+
+
+EcalEscaleShiftPFProducer::~EcalEscaleShiftPFProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+EcalEscaleShiftPFProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   edm::Handle<reco::PFCandidateCollection> inputsHandle;
+   iEvent.getByToken(src_, inputsHandle);
+
+   const reco::PFCandidateCollection pfcand = *(inputsHandle.product());
+
+
+   auto prod = std::make_unique<reco::PFCandidateCollection>();
+   
+   for(reco::PFCandidateCollection::const_iterator pfcItr=pfcand.begin();
+       pfcItr!=pfcand.end(); pfcItr++) {
+     
+     reco::PFCandidate *scaledPFCand  = pfcItr->clone();
+     
+       
+     if(pfcItr->particleId()==4){
+     
+     /*
+       std::cout<<" photon px "<<pfcItr->px()<<std::endl;
+       std::cout<<" photon py "<<pfcItr->py()<<std::endl;
+       std::cout<<" photon pz "<<pfcItr->pz()<<std::endl;
+     */
+       
+
+       if(fabs(pfcItr->eta())< 1.44) scaledPFCand->rescaleMomentum(scaleEB_);
+       else if(!removePreshower_ || (pfcItr->pS1Energy()==0 && pfcItr->pS2Energy()==0) ) scaledPFCand->rescaleMomentum(scaleEE_); 
+       else{
+	 /*
+	 std::cout<<" photon ps1 E "<<pfcItr->pS1Energy()<<std::endl;
+	 std::cout<<" photon ps2 E "<<pfcItr->pS2Energy()<<std::endl;
+	 std::cout<<" photon E "<<pfcItr->energy()<<std::endl;
+	 std::cout<<" photon ecal E "<<pfcItr->ecalEnergy()<<std::endl;
+	 std::cout<<" photon raw ecal E "<<pfcItr->rawEcalEnergy()<<std::endl;	       
+	 std::cout<<" position at ECAL entrance "<<pfcItr->positionAtECALEntrance()<<std::endl;
+	 double correctedEnergy = calibrator_->Ecorr(pfcItr->rawEcalEnergy(),pfcItr->pS1Energy(),pfcItr->pS2Energy(),pfcItr->eta(),pfcItr->phi(), false);
+	 std::cout<<" correctedEnergy "<<correctedEnergy<<std::endl;
+	 */
+
+	 //  FIXME:  This ain't really working right yet, use removePreshower = False
+	 double correctedEnergy = calibrator_->Ecorr(pfcItr->rawEcalEnergy()*scaleEE_,pfcItr->pS1Energy(),pfcItr->pS2Energy(),pfcItr->eta(),pfcItr->phi(), false); 
+	 if(pfcItr->energy()>0)scaledPFCand->rescaleMomentum(correctedEnergy/pfcItr->energy());
+
+
+       }
+       
+
+     }
+     
+     prod->push_back(*scaledPFCand);
+     
+   }
+   
+   
+   iEvent.put(std::move(prod));
+
+
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+EcalEscaleShiftPFProducer::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+EcalEscaleShiftPFProducer::endJob() {
+}
+
+//define this as a plug-in                                                                                                                                                                                                                                                                
+DEFINE_FWK_MODULE(EcalEscaleShiftPFProducer);

--- a/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.h
@@ -1,0 +1,39 @@
+#ifndef EcalEscaleShiftPFProducer_h
+#define EcalEscaleShiftPFProducer_h
+
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
+
+
+class EcalEscaleShiftPFProducer : public edm::EDProducer {
+ public:
+  explicit EcalEscaleShiftPFProducer(const edm::ParameterSet&);
+  ~EcalEscaleShiftPFProducer() override;
+  
+ private:
+  void beginJob() override ;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endJob() override ;
+
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<reco::PFCandidateCollection> src_;  
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCands_;  
+
+  std::shared_ptr<PFEnergyCalibration> calibrator_;
+
+  bool removePreshower_;
+  double scaleEE_, scaleEB_;
+  
+};
+#endif

--- a/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
+++ b/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+
+ecalShiftParticleFlow = cms.EDProducer('EcalEscaleShiftPFProducer',
+                                           src    = cms.InputTag('particleFlow'),
+                                           removePreshower = cms.bool(False), 
+                                           scaleEB = cms.double(1.01),  # SETME
+                                           scaleEE = cms.double(1.15),  # SETME
+
+)
+

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -64,6 +64,10 @@ class PFEnergyCalibration
 		  double &ps1,double&ps2,
 		  bool crackCorrection=true) const;
 
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true) const;
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true) const;
+
+
   // ECAL+HCAL (abc) calibration, with E and eta dependent coefficients, for hadrons
   void energyEmHad(double t, double& e, double&h, double eta, double phi) const;
   
@@ -123,8 +127,6 @@ class PFEnergyCalibration
   double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double&, double&) const;
   double EcorrPS_ePSNil(double eEcal,double eta) const;
   double EcorrZoneAfterPS(double E, double eta) const;
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true) const;
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true) const;
 
   // The calibration functions
   double aBarrel(double x) const;


### PR DESCRIPTION
A new EDProducer is added which copies the reco::PFCandidate collection with label particleFlow and shifts the barrel and endcap energy scales.   
The scale shifts are currently set to dummy settings of 1.01 and 1.15, respectively.
Please update them with more accurate numbers. 

An attempt was made to remove the pre-shower contribution before correcting the EE energy, but this is not yet giving sensible results.  Keep removePreshower set to False for now, which is default value.

This code runs, but has not been thoroughly tested.  Please run it on the relval samples with the wrong e-scale, so we can see it gives sensible results. 

To activate the code, add the following snippet to the **bottom** of your cfg.

from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
process = MassReplaceInputTag(process,"particleFlow","ecalShiftParticleFlow")
process.load("RecoHI.HiJetAlgos.EcalEscaleShiftPFProducer_cff")
process.ana_step.insert(0,process.ecalShiftParticleFlow)


