### PR TITLE
Fix memory leak and preshower issue in ecal scaling

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/plugins/BuildFile.xml
@@ -9,7 +9,6 @@
 <use   name="CondCore/PopCon"/>
 <use   name="JetMETCorrections/Objects"/>
 <use   name="Geometry/CaloGeometry"/>
-<use   name="RecoParticleFlow/PFClusterTools"/>
 <flags   EDM_PLUGIN="1"/>
 <library   file="*.cc" name="HiJetAlgosPlugins">
 </library>

--- a/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.h
+++ b/RecoHI/HiJetAlgos/plugins/EcalEscaleShiftPFProducer.h
@@ -12,7 +12,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 
 
 class EcalEscaleShiftPFProducer : public edm::EDProducer {
@@ -29,8 +28,6 @@ class EcalEscaleShiftPFProducer : public edm::EDProducer {
 
   edm::EDGetTokenT<reco::PFCandidateCollection> src_;  
   edm::EDGetTokenT<reco::PFCandidateCollection> pfCands_;  
-
-  std::shared_ptr<PFEnergyCalibration> calibrator_;
 
   bool removePreshower_;
   double scaleEE_, scaleEB_;

--- a/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
+++ b/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 ecalShiftParticleFlow = cms.EDProducer('EcalEscaleShiftPFProducer',
                                            src    = cms.InputTag('particleFlow'),
-                                           removePreshower = cms.bool(False), 
+                                           removePreshower = cms.bool(True), 
                                            scaleEB = cms.double(0.9928),
                                            scaleEE = cms.double(1.1537), 
 )

--- a/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
+++ b/RecoHI/HiJetAlgos/python/EcalEscaleShiftPFProducer_cff.py
@@ -4,8 +4,7 @@ import FWCore.ParameterSet.Config as cms
 ecalShiftParticleFlow = cms.EDProducer('EcalEscaleShiftPFProducer',
                                            src    = cms.InputTag('particleFlow'),
                                            removePreshower = cms.bool(False), 
-                                           scaleEB = cms.double(1.01),  # SETME
-                                           scaleEE = cms.double(1.15),  # SETME
-
+                                           scaleEB = cms.double(0.9928),
+                                           scaleEE = cms.double(1.1537), 
 )
 

--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -64,10 +64,6 @@ class PFEnergyCalibration
 		  double &ps1,double&ps2,
 		  bool crackCorrection=true) const;
 
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true) const;
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true) const;
-
-
   // ECAL+HCAL (abc) calibration, with E and eta dependent coefficients, for hadrons
   void energyEmHad(double t, double& e, double&h, double eta, double phi) const;
   
@@ -127,6 +123,8 @@ class PFEnergyCalibration
   double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double&, double&) const;
   double EcorrPS_ePSNil(double eEcal,double eta) const;
   double EcorrZoneAfterPS(double E, double eta) const;
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true) const;
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true) const;
 
   // The calibration functions
   double aBarrel(double x) const;


### PR DESCRIPTION
Describe the Pull-Request:
The new producer had a memory leak.
I also updated the code to take into account the preshower, which is now on by default.


Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
