### PR TITLE
Back-compatibility for lepton 3DIP to 75X

### DIFF
--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -20,6 +20,7 @@
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 #include "RecoEgamma/EgammaTools/interface/EffectiveAreas.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
 using namespace std;
 
@@ -36,9 +37,9 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
 
    void fillGenParticles (const edm::Event&);
    void fillGenPileupInfo(const edm::Event&);
-   void fillElectrons    (const edm::Event&, const edm::EventSetup&, math::XYZPoint& pv);
-   void fillPhotons      (const edm::Event&, const edm::EventSetup&, math::XYZPoint& pv);
-   void fillMuons        (const edm::Event&, const edm::EventSetup&, math::XYZPoint& pv);
+   void fillElectrons    (const edm::Event&, const edm::EventSetup&, reco::Vertex& pv);
+   void fillPhotons      (const edm::Event&, const edm::EventSetup&, reco::Vertex& pv);
+   void fillMuons        (const edm::Event&, const edm::EventSetup&, reco::Vertex& pv);
 
    // Et and pT sums
    float getGenCalIso(edm::Handle<vector<reco::GenParticle> >&, reco::GenParticleCollection::const_iterator, float dRMax, bool removeMu, bool removeNu);
@@ -77,6 +78,7 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    edm::EDGetTokenT<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > > recHitsEE_;
 
    const CaloGeometry *geo;
+   const TransientTrackBuilder* tb;
 
    EffectiveAreas effectiveAreas_;
 
@@ -129,8 +131,10 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    vector<float>  eleEn_;
    vector<float>  eleD0_;
    vector<float>  eleDz_;
+   vector<float>  eleIP3D_;
    vector<float>  eleD0Err_;
    vector<float>  eleDzErr_;
+   vector<float>  eleIP3DErr_;
    vector<float>  eleTrkPt_;
    vector<float>  eleTrkEta_;
    vector<float>  eleTrkPhi_;
@@ -436,6 +440,10 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    vector<int>    muIsGood_;
    vector<float>  muD0_;
    vector<float>  muDz_;
+   vector<float>  muIP3D_;
+   vector<float>  muD0Err_;
+   vector<float>  muDzErr_;
+   vector<float>  muIP3DErr_;
    vector<float>  muChi2NDF_;
    vector<float>  muInnerD0_;
    vector<float>  muInnerDz_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/BuildFile.xml
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/BuildFile.xml
@@ -24,6 +24,9 @@
 <use   name="RecoHI/HiEgammaAlgos"/>
 <use   name="DataFormats/HeavyIonEvent"/>
 <use   name="HeavyIonsAnalysis/PhotonAnalysis"/>
+<use   name="TrackingTools/IPTools"/>
+<use   name="TrackingTools/Records"/>
+<use   name="TrackingTools/TransientTrack"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
 <flags   EDM_PLUGIN="1"/>

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -15,6 +15,8 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "TrackingTools/IPTools/interface/IPTools.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
 using namespace std;
 
@@ -115,8 +117,10 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps):
   tree_->Branch("eleEn",                 &eleEn_);
   tree_->Branch("eleD0",                 &eleD0_);
   tree_->Branch("eleDz",                 &eleDz_);
+  tree_->Branch("eleIP3D",               &eleIP3D_);
   tree_->Branch("eleD0Err",              &eleD0Err_);
   tree_->Branch("eleDzErr",              &eleDzErr_);
+  tree_->Branch("eleIP3DErr",            &eleIP3DErr_);
   tree_->Branch("eleTrkPt",              &eleTrkPt_);
   tree_->Branch("eleTrkEta",             &eleTrkEta_);
   tree_->Branch("eleTrkPhi",             &eleTrkPhi_);
@@ -433,6 +437,10 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps):
   tree_->Branch("muIsGood",              &muIsGood_);
   tree_->Branch("muD0",                  &muD0_);
   tree_->Branch("muDz",                  &muDz_);
+  tree_->Branch("muIP3D",                &muIP3D_);
+  tree_->Branch("muD0Err",               &muD0Err_);
+  tree_->Branch("muDzErr",               &muDzErr_);
+  tree_->Branch("muIP3DErr",             &muIP3DErr_);
   tree_->Branch("muChi2NDF",             &muChi2NDF_);
   tree_->Branch("muInnerD0",             &muInnerD0_);
   tree_->Branch("muInnerDz",             &muInnerDz_);
@@ -495,8 +503,10 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
   eleEn_                .clear();
   eleD0_                .clear();
   eleDz_                .clear();
+  eleIP3D_              .clear();
   eleD0Err_             .clear();
   eleDzErr_             .clear();
+  eleIP3DErr_           .clear();
   eleTrkPt_             .clear();
   eleTrkEta_            .clear();
   eleTrkPhi_            .clear();
@@ -786,6 +796,10 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
   muIsGood_             .clear();
   muD0_                 .clear();
   muDz_                 .clear();
+  muIP3D_               .clear();
+  muD0Err_              .clear();
+  muDzErr_              .clear();
+  muIP3DErr_            .clear();
   muChi2NDF_            .clear();
   muInnerD0_            .clear();
   muInnerDz_            .clear();
@@ -816,12 +830,17 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
   e.getByToken(vtxCollection_, vtxHandle);
 
   // best-known primary vertex coordinates
-  math::XYZPoint pv(0, 0, 0);
-  for (vector<reco::Vertex>::const_iterator v = vtxHandle->begin(); v != vtxHandle->end(); ++v)
-    if (!v->isFake()) {
-      pv.SetXYZ(v->x(), v->y(), v->z());
+  reco::Vertex pv(math::XYZPoint(0, 0, -999), math::Error<3>::type());
+  //for (vector<reco::Vertex>::const_iterator v = vtxHandle->begin(); v != vtxHandle->end(); ++v)
+  for (const auto& v : *vtxHandle)
+    if (!v.isFake()) {
+      pv = v;
       break;
     }
+
+  edm::ESHandle<TransientTrackBuilder> trackBuilder;
+  es.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
+  tb = trackBuilder.product();
 
   if (doRecHitsEB_ || doRecHitsEE_) {
       edm::ESHandle<CaloGeometry> pGeo;
@@ -1010,7 +1029,7 @@ float ggHiNtuplizer::getGenTrkIso(edm::Handle<vector<reco::GenParticle> > &handl
   return ptSum;
 }
 
-void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es, math::XYZPoint& pv)
+void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es, reco::Vertex& pv)
 {
   // Fills tree branches with reco GSF electrons.
 
@@ -1045,7 +1064,8 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
   
 
   // loop over electrons
-  for (edm::View<reco::GsfElectron>::const_iterator ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
+  //for (edm::View<reco::GsfElectron>::const_iterator ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
+  for (auto ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
     eleCharge_           .push_back(ele->charge());
     eleChargeConsistent_ .push_back((int)ele->isGsfCtfScPixChargeConsistent());
     eleSCPixCharge_      .push_back(ele->scPixCharge());
@@ -1055,8 +1075,8 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
       eleCtfCharge_        .push_back(-99.);
     }
     eleEn_               .push_back(ele->energy());
-    eleD0_               .push_back(ele->gsfTrack()->dxy(pv));
-    eleDz_               .push_back(ele->gsfTrack()->dz(pv));
+    eleD0_               .push_back(ele->gsfTrack()->dxy(pv.position()));
+    eleDz_               .push_back(ele->gsfTrack()->dz(pv.position()));
     eleD0Err_            .push_back(ele->gsfTrack()->dxyError());
     eleDzErr_            .push_back(ele->gsfTrack()->dzError());
     eleTrkPt_            .push_back(ele->gsfTrack()->pt());
@@ -1096,6 +1116,18 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
     // eleSigmaIEtaIEta_2012_.push_back(isnan(vCovEle[0]) ? 0. : sqrt(vCovEle[0]));
     eleSigmaIEtaIEta_2012_.push_back(ele->full5x5_sigmaIetaIeta() );
 
+    //Initialize with nonphysical values
+    float eleIP3D = -999;
+    float eleIP3DErr = -999;
+    if (pv.isValid()) {
+      //3DImpact parameter
+      reco::TransientTrack tt = tb->build(ele->gsfTrack().get());
+      eleIP3D = IPTools::absoluteImpactParameter3D(tt, pv).second.value();
+      eleIP3DErr = IPTools::absoluteImpactParameter3D(tt, pv).second.error();
+    }
+    eleIP3D_               .push_back(eleIP3D);
+    eleIP3DErr_            .push_back(eleIP3DErr);
+
     // isolation
     reco::GsfElectron::PflowIsolationVariables pfIso = ele->pfIsolationVariables();
     elePFChIso_          .push_back(pfIso.sumChargedHadronPt);
@@ -1104,7 +1136,7 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
     elePFPUIso_          .push_back(pfIso.sumPUPt);
 
     //calculation on-fly
-    pfIsoCalculator pfIsoCal(e,es, pfCollection_, voronoiBkgPF_, pv);
+    pfIsoCalculator pfIsoCal(e,es, pfCollection_, voronoiBkgPF_, pv.position());
     if (fabs(ele->superCluster()->eta()) > 1.566) {
       elePFChIso03_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.3, 0.015, 0.));
       elePFChIso04_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.4, 0.015, 0.));
@@ -1206,7 +1238,7 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
   } // electrons loop
 }
 
-void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, math::XYZPoint& pv)
+void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, reco::Vertex& pv)
 {
   // Fills tree branches with photons.
 
@@ -1442,7 +1474,7 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
 
     if(doPfIso_)
     {
-      pfIsoCalculator pfIso(e,es, pfCollection_, voronoiBkgPF_, pv);
+      pfIsoCalculator pfIso(e,es, pfCollection_, voronoiBkgPF_, pv.position());
       // particle flow isolation
       pfcIso1.push_back( pfIso.getPfIso(*pho, 1, 0.1, 0.02, 0.0, 0 ));
       pfcIso2.push_back( pfIso.getPfIso(*pho, 1, 0.2, 0.02, 0.0, 0 ));
@@ -1559,7 +1591,7 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
   } // photons loop
 }
 
-void ggHiNtuplizer::fillMuons(const edm::Event& e, const edm::EventSetup& es, math::XYZPoint& pv)
+void ggHiNtuplizer::fillMuons(const edm::Event& e, const edm::EventSetup& es, reco::Vertex& pv)
 {
   // Fills tree branches with reco muons.
 
@@ -1576,8 +1608,22 @@ void ggHiNtuplizer::fillMuons(const edm::Event& e, const edm::EventSetup& es, ma
     muCharge_.push_back(mu->charge());
     muType_  .push_back(mu->type());
     muIsGood_.push_back((int) muon::isGoodMuon(*mu, muon::selectionTypeFromString("TMOneStationTight")));
-    muD0_    .push_back(mu->muonBestTrack()->dxy(pv));
-    muDz_    .push_back(mu->muonBestTrack()->dz(pv));
+    muD0_    .push_back(mu->muonBestTrack()->dxy(pv.position()));
+    muDz_    .push_back(mu->muonBestTrack()->dz(pv.position()));
+    muD0Err_ .push_back(mu->muonBestTrack()->dxyError());
+    muDzErr_ .push_back(mu->muonBestTrack()->dzError());
+    
+    //Initialize with nonphysical values
+    float muIP3D = -999;
+    float muIP3DErr = -999;
+    if (pv.isValid()) {
+      //3DImpact parameter
+      reco::TransientTrack tt = tb->build(mu->muonBestTrack().get());
+      muIP3D = IPTools::absoluteImpactParameter3D(tt, pv).second.value();
+      muIP3DErr = IPTools::absoluteImpactParameter3D(tt, pv).second.error();
+    }
+    muIP3D_    .push_back(muIP3D);
+    muIP3DErr_ .push_back(muIP3DErr);
 
     const reco::TrackRef glbMu = mu->globalTrack();
     const reco::TrackRef innMu = mu->innerTrack();
@@ -1598,8 +1644,8 @@ void ggHiNtuplizer::fillMuons(const edm::Event& e, const edm::EventSetup& es, ma
       muPixelHits_   .push_back(-99);
       muTrkQuality_  .push_back(-99);
     } else {
-      muInnerD0_     .push_back(innMu->dxy(pv));
-      muInnerDz_     .push_back(innMu->dz(pv));
+      muInnerD0_     .push_back(innMu->dxy(pv.position()));
+      muInnerDz_     .push_back(innMu->dz(pv.position()));
       muTrkLayers_   .push_back(innMu->hitPattern().trackerLayersWithMeasurement());
       muPixelLayers_ .push_back(innMu->hitPattern().pixelLayersWithMeasurement());
       muPixelHits_   .push_back(innMu->hitPattern().numberOfValidPixelHits());

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -831,7 +831,6 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
 
   // best-known primary vertex coordinates
   reco::Vertex pv(math::XYZPoint(0, 0, -999), math::Error<3>::type());
-  //for (vector<reco::Vertex>::const_iterator v = vtxHandle->begin(); v != vtxHandle->end(); ++v)
   for (const auto& v : *vtxHandle)
     if (!v.isFake()) {
       pv = v;
@@ -1064,8 +1063,7 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
   
 
   // loop over electrons
-  //for (edm::View<reco::GsfElectron>::const_iterator ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
-  for (auto ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
+  for (edm::View<reco::GsfElectron>::const_iterator ele = gsfElectronsHandle->begin(); ele != gsfElectronsHandle->end(); ++ele) {
     eleCharge_           .push_back(ele->charge());
     eleChargeConsistent_ .push_back((int)ele->isGsfCtfScPixChargeConsistent());
     eleSCPixCharge_      .push_back(ele->scPixCharge());


### PR DESCRIPTION
Describe the Pull-Request:
Backward compatibility for 2015 PbPb data

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

@bi-ran 

same as [PR](https://github.com/CmsHI/cmssw/pull/193) for the lepton 3DIP but w/o the muon selectors since not available
