### PR TITLE
UE-subtracted PF isolation variables

### DIFF
--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -383,6 +383,25 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    std::vector<float> pfnIso4;
    std::vector<float> pfnIso5;
 
+   // photon pf isolation UE-subtracted
+   std::vector<float> pfcIso1subUE;
+   std::vector<float> pfcIso2subUE;
+   std::vector<float> pfcIso3subUE;
+   std::vector<float> pfcIso4subUE;
+   std::vector<float> pfcIso5subUE;
+
+   std::vector<float> pfpIso1subUE;
+   std::vector<float> pfpIso2subUE;
+   std::vector<float> pfpIso3subUE;
+   std::vector<float> pfpIso4subUE;
+   std::vector<float> pfpIso5subUE;
+
+   std::vector<float> pfnIso1subUE;
+   std::vector<float> pfnIso2subUE;
+   std::vector<float> pfnIso3subUE;
+   std::vector<float> pfnIso4subUE;
+   std::vector<float> pfnIso5subUE;
+
    // reco::Muon
    Int_t          nMu_;
    std::vector<float>  muPt_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -392,6 +392,24 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps) :
       tree_->Branch("pfnIso3",&pfnIso3);
       tree_->Branch("pfnIso4",&pfnIso4);
       tree_->Branch("pfnIso5",&pfnIso5);
+
+      tree_->Branch("pfcIso1subUE",&pfcIso1subUE);
+      tree_->Branch("pfcIso2subUE",&pfcIso2subUE);
+      tree_->Branch("pfcIso3subUE",&pfcIso3subUE);
+      tree_->Branch("pfcIso4subUE",&pfcIso4subUE);
+      tree_->Branch("pfcIso5subUE",&pfcIso5subUE);
+
+      tree_->Branch("pfpIso1subUE",&pfpIso1subUE);
+      tree_->Branch("pfpIso2subUE",&pfpIso2subUE);
+      tree_->Branch("pfpIso3subUE",&pfpIso3subUE);
+      tree_->Branch("pfpIso4subUE",&pfpIso4subUE);
+      tree_->Branch("pfpIso5subUE",&pfpIso5subUE);
+
+      tree_->Branch("pfnIso1subUE",&pfnIso1subUE);
+      tree_->Branch("pfnIso2subUE",&pfnIso2subUE);
+      tree_->Branch("pfnIso3subUE",&pfnIso3subUE);
+      tree_->Branch("pfnIso4subUE",&pfnIso4subUE);
+      tree_->Branch("pfnIso5subUE",&pfnIso5subUE);
     }
   }
 
@@ -731,6 +749,22 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
       pfnIso3.clear();
       pfnIso4.clear();
       pfnIso5.clear();
+
+      pfcIso1subUE.clear();
+      pfcIso2subUE.clear();
+      pfcIso3subUE.clear();
+      pfcIso4subUE.clear();
+      pfcIso5subUE.clear();
+      pfpIso1subUE.clear();
+      pfpIso2subUE.clear();
+      pfpIso3subUE.clear();
+      pfpIso4subUE.clear();
+      pfpIso5subUE.clear();
+      pfnIso1subUE.clear();
+      pfnIso2subUE.clear();
+      pfnIso3subUE.clear();
+      pfnIso4subUE.clear();
+      pfnIso5subUE.clear();
     }
   }
 
@@ -1497,6 +1531,24 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       pfpIso3.push_back( pfIso.getPfIso(*pho, 4, 0.3, 0.0, 0.0, 0.015 ));
       pfpIso4.push_back( pfIso.getPfIso(*pho, 4, 0.4, 0.0, 0.0, 0.015 ));
       pfpIso5.push_back( pfIso.getPfIso(*pho, 4, 0.5, 0.0, 0.0, 0.015 ));
+
+      pfcIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.1, 0.02, 0.0, 0 ));
+      pfcIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.2, 0.02, 0.0, 0 ));
+      pfcIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.3, 0.02, 0.0, 0 ));
+      pfcIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.4, 0.02, 0.0, 0 ));
+      pfcIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.5, 0.02, 0.0, 0 ));
+
+      pfnIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.1, 0.0, 0.0, 0 ));
+      pfnIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.2, 0.0, 0.0, 0 ));
+      pfnIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.3, 0.0, 0.0, 0 ));
+      pfnIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.4, 0.0, 0.0, 0 ));
+      pfnIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.5, 0.0, 0.0, 0 ));
+
+      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.1, 0.0, 0.0, 0.015 ));
+      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.2, 0.0, 0.0, 0.015 ));
+      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.3, 0.0, 0.0, 0.015 ));
+      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.4, 0.0, 0.0, 0.015 ));
+      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.5, 0.0, 0.0, 0.015 ));
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -50,6 +50,72 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
   return totalEt;
 }
 
+double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
+                                      double r1, double r2, double threshold,
+                                      double jWidth)
+{
+  double photonEta = photon.eta();
+  double photonPhi = photon.phi();
+  double totalEt = 0;
+
+  for (const auto& pf : *candidatesView) {
+    if ( pf.particleId() != pfId )   continue;
+    double pfEta = pf.eta();
+    double pfPhi = pf.phi();
+
+    double dEta = std::abs(photonEta - pfEta);
+    if (dEta > r1) continue;
+    if (dEta < jWidth)  continue;
+
+    // remove the photon itself
+    if ( pf.superClusterRef() == photon.superCluster() ) continue;
+
+    if(pf.particleId() == reco::PFCandidate::h){
+      float dz = std::abs(pf.vz() - vtx_.z());
+      if (dz > 0.2) continue;
+      double dxy = ((vtx_.x() - pf.vx())*pf.py() + (pf.vy() - vtx_.y())*pf.px()) / pf.pt();
+      if (std::abs(dxy) > 0.1) continue;
+    }
+
+    double dPhi = reco::deltaPhi(pfPhi, photonPhi);
+    double dR2 = dEta*dEta + dPhi*dPhi;
+    double pfPt = pf.pt();
+
+    // Jurassic Cone /////
+    if (dR2 < r2 * r2) continue;
+    if (pfPt < threshold) continue;
+    totalEt += pfPt;
+  }
+
+  double areaStrip = 4*M_PI*(r1-jWidth);   // strip area over which UE is estimated
+  double areaCone = M_PI*r1*r1;       // area inside which isolation is to be applied
+  if (jWidth > 0) {
+    // calculate overlap area between disk with radius r2 and rectangle of width jwidth
+    double angTmp = std::acos(jWidth / r1);
+    double lenTmp = std::sqrt(r1*r1 - jWidth*jWidth) * 2;
+    double areaTwoTriangles = lenTmp * jWidth;
+    double areaTwoArcs = 2 * (M_PI - 2*angTmp) * M_PI * r1 * r1;
+    areaCone -= (areaTwoTriangles + areaTwoArcs);
+  }
+
+  double areaInnerCone = 0;
+  if (r2 > jWidth) {
+    areaInnerCone = M_PI*r2*r2;
+    if (jWidth > 0) {
+      double angTmp = std::acos(jWidth / r2);
+      double lenTmp = std::sqrt(r2*r2 - jWidth*jWidth) * 2;
+      double areaTwoTriangles = lenTmp * jWidth;
+      double areaTwoArcs = 2 * (M_PI - 2*angTmp) * M_PI * r2 * r2;
+      areaInnerCone -= (areaTwoTriangles + areaTwoArcs);
+    }
+  }
+  areaStrip -= areaInnerCone;
+  areaCone -= areaInnerCone;
+
+  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth) - totalEt * (areaCone / areaStrip);
+  return subEt;
+}
+
 double pfIsoCalculator::getPfIso(const reco::GsfElectron& ele, int pfId,
                                  double r1, double r2, double threshold)
 {

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -94,7 +94,7 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
     double angTmp = std::acos(jWidth / r1);
     double lenTmp = std::sqrt(r1*r1 - jWidth*jWidth) * 2;
     double areaTwoTriangles = lenTmp * jWidth;
-    double areaTwoArcs = 2 * (M_PI - 2*angTmp) * M_PI * r1 * r1;
+    double areaTwoArcs = (M_PI - 2*angTmp) * r1 * r1;
     areaCone -= (areaTwoTriangles + areaTwoArcs);
   }
 
@@ -105,7 +105,7 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
       double angTmp = std::acos(jWidth / r2);
       double lenTmp = std::sqrt(r2*r2 - jWidth*jWidth) * 2;
       double areaTwoTriangles = lenTmp * jWidth;
-      double areaTwoArcs = 2 * (M_PI - 2*angTmp) * M_PI * r2 * r2;
+      double areaTwoArcs = (M_PI - 2*angTmp) * r2 * r2;
       areaInnerCone -= (areaTwoTriangles + areaTwoArcs);
     }
   }

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
@@ -16,6 +16,8 @@ class pfIsoCalculator
     pfIsoCalculator(const edm::Event &iEvent, const edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandidates, const math::XYZPoint& pv);
 
     double getPfIso(const reco::Photon& photon,  int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0);
+    double getPfIsoSubUE(const reco::Photon& photon,  int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0);
+
     double getPfIso(const reco::GsfElectron& ele, int pfId, double r1=0.4, double r2=0.00, double threshold=0);
 
   private:


### PR DESCRIPTION
add function to calculate PF isolation variables that are subtracted for UE
write those variables to branches in ggHiNtuplizer

Describe the Pull-Request:

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@bi-ran 