### PR TITLE
Update PF isolation calculation for photons

### DIFF
--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -57,6 +57,7 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    bool runOnParticleGun_;
    bool useValMapIso_;
    bool doPfIso_;
+   bool removePhotonPfIsoFootprint_;
    bool doEReg_;
    bool doEffectiveAreas_;
    bool doVID_;
@@ -79,6 +80,8 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
    edm::EDGetTokenT<reco::ConversionCollection> conversionsToken_;
    edm::EDGetTokenT<edm::View<reco::PFCandidate> >    pfCollection_;
+
+   edm::EDGetToken particleBasedIsolationPhoton_;
 
    edm::EDGetTokenT<EcalRecHitCollection> recHitsEB_;
    edm::EDGetTokenT<EcalRecHitCollection> recHitsEE_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -368,42 +368,54 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    std::vector<int> rhBCIdx_;    // index of this rechit's BC in the SC
 
    // photon pf isolation stuff
-   std::vector<float> pfcIso1;
-   std::vector<float> pfcIso2;
-   std::vector<float> pfcIso3;
-   std::vector<float> pfcIso4;
-   std::vector<float> pfcIso5;
+   std::vector<float> pfcIso1_;
+   std::vector<float> pfcIso2_;
+   std::vector<float> pfcIso3_;
+   std::vector<float> pfcIso4_;
+   std::vector<float> pfcIso5_;
 
-   std::vector<float> pfpIso1;
-   std::vector<float> pfpIso2;
-   std::vector<float> pfpIso3;
-   std::vector<float> pfpIso4;
-   std::vector<float> pfpIso5;
+   std::vector<float> pfpIso1_;
+   std::vector<float> pfpIso2_;
+   std::vector<float> pfpIso3_;
+   std::vector<float> pfpIso4_;
+   std::vector<float> pfpIso5_;
 
-   std::vector<float> pfnIso1;
-   std::vector<float> pfnIso2;
-   std::vector<float> pfnIso3;
-   std::vector<float> pfnIso4;
-   std::vector<float> pfnIso5;
+   std::vector<float> pfnIso1_;
+   std::vector<float> pfnIso2_;
+   std::vector<float> pfnIso3_;
+   std::vector<float> pfnIso4_;
+   std::vector<float> pfnIso5_;
+
+   std::vector<float> pfpIso1subSC_;
+   std::vector<float> pfpIso2subSC_;
+   std::vector<float> pfpIso3subSC_;
+   std::vector<float> pfpIso4subSC_;
+   std::vector<float> pfpIso5subSC_;
 
    // photon pf isolation UE-subtracted
-   std::vector<float> pfcIso1subUE;
-   std::vector<float> pfcIso2subUE;
-   std::vector<float> pfcIso3subUE;
-   std::vector<float> pfcIso4subUE;
-   std::vector<float> pfcIso5subUE;
+   std::vector<float> pfcIso1subUE_;
+   std::vector<float> pfcIso2subUE_;
+   std::vector<float> pfcIso3subUE_;
+   std::vector<float> pfcIso4subUE_;
+   std::vector<float> pfcIso5subUE_;
 
-   std::vector<float> pfpIso1subUE;
-   std::vector<float> pfpIso2subUE;
-   std::vector<float> pfpIso3subUE;
-   std::vector<float> pfpIso4subUE;
-   std::vector<float> pfpIso5subUE;
+   std::vector<float> pfpIso1subUE_;
+   std::vector<float> pfpIso2subUE_;
+   std::vector<float> pfpIso3subUE_;
+   std::vector<float> pfpIso4subUE_;
+   std::vector<float> pfpIso5subUE_;
 
-   std::vector<float> pfnIso1subUE;
-   std::vector<float> pfnIso2subUE;
-   std::vector<float> pfnIso3subUE;
-   std::vector<float> pfnIso4subUE;
-   std::vector<float> pfnIso5subUE;
+   std::vector<float> pfnIso1subUE_;
+   std::vector<float> pfnIso2subUE_;
+   std::vector<float> pfnIso3subUE_;
+   std::vector<float> pfnIso4subUE_;
+   std::vector<float> pfnIso5subUE_;
+
+   std::vector<float> pfpIso1subSCsubUE_;
+   std::vector<float> pfpIso2subSCsubUE_;
+   std::vector<float> pfpIso3subSCsubUE_;
+   std::vector<float> pfpIso4subSCsubUE_;
+   std::vector<float> pfpIso5subSCsubUE_;
 
    // reco::Muon
    Int_t          nMu_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -1554,11 +1554,11 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       }
 
       // particle flow isolation
-      pfcIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
       pfpIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
       pfpIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
@@ -1579,11 +1579,11 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       pfpIso4subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, false) - scEt);
       pfpIso5subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, false) - scEt);
 
-      pfcIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
       pfpIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
       pfpIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -1554,54 +1554,53 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       }
 
       // particle flow isolation
-      pfcIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      pfpIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      pfnIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      double scEt = pho->superCluster()->rawEnergy() / std::cosh(pho->superCluster()->eta());
-      pfpIso1subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, false) - scEt);
-      pfpIso2subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, false) - scEt);
-      pfpIso3subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, false) - scEt);
-      pfpIso4subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, false) - scEt);
-      pfpIso5subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, false) - scEt);
+      pfpIso1subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso2subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso3subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso4subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso5subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
 
-      pfcIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfcIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      pfpIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfpIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      pfnIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+      pfnIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
 
-      pfpIso1subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, false) - scEt);
-      pfpIso2subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, false) - scEt);
-      pfpIso3subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, false) - scEt);
-      pfpIso4subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, false) - scEt);
-      pfpIso5subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, false) - scEt);
+      pfpIso1subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso2subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso3subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso4subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
+      pfpIso5subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, pfIsoCalculator::removeSCenergy));
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -1151,19 +1151,19 @@ void ggHiNtuplizer::fillElectrons(const edm::Event& e, const edm::EventSetup& es
     // calculation on the fly
     pfIsoCalculator pfIsoCal(e, pfCollection_, pv.position());
     if (std::abs(ele->superCluster()->eta()) > 1.566) {
-      elePFChIso03_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.3, 0.015, 0.));
-      elePFChIso04_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.4, 0.015, 0.));
-      elePFPhoIso03_         .push_back(pfIsoCal.getPfIso(*ele, 4, 0.3, 0.08, 0.));
-      elePFPhoIso04_         .push_back(pfIsoCal.getPfIso(*ele, 4, 0.4, 0.08, 0.));
+      elePFChIso03_          .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h,     0.3, 0.015, 0.));
+      elePFChIso04_          .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h,     0.4, 0.015, 0.));
+      elePFPhoIso03_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::gamma, 0.3, 0.08, 0.));
+      elePFPhoIso04_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::gamma, 0.4, 0.08, 0.));
     } else {
-      elePFChIso03_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.3, 0.0, 0.));
-      elePFChIso04_          .push_back(pfIsoCal.getPfIso(*ele, 1, 0.4, 0.0, 0.));
-      elePFPhoIso03_         .push_back(pfIsoCal.getPfIso(*ele, 4, 0.3, 0.0, 0.));
-      elePFPhoIso04_         .push_back(pfIsoCal.getPfIso(*ele, 4, 0.4, 0.0, 0.));
+      elePFChIso03_          .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h,     0.3, 0.0, 0.));
+      elePFChIso04_          .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h,     0.4, 0.0, 0.));
+      elePFPhoIso03_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::gamma, 0.3, 0.0, 0.));
+      elePFPhoIso04_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::gamma, 0.4, 0.0, 0.));
     }
 
-    elePFNeuIso03_         .push_back(pfIsoCal.getPfIso(*ele, 5, 0.3, 0., 0.));
-    elePFNeuIso04_         .push_back(pfIsoCal.getPfIso(*ele, 5, 0.4, 0., 0.));
+    elePFNeuIso03_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h0, 0.3, 0., 0.));
+    elePFNeuIso04_         .push_back(pfIsoCal.getPfIso(*ele, reco::PFCandidate::h0, 0.4, 0., 0.));
 
     eleR9_               .push_back(ele->r9());
     eleE3x3_             .push_back(ele->r9()*ele->superCluster()->energy());
@@ -1514,41 +1514,41 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
     if (doPfIso_) {
       pfIsoCalculator pfIso(e, pfCollection_, pv.position());
       // particle flow isolation
-      pfcIso1.push_back( pfIso.getPfIso(*pho, 1, 0.1, 0.02, 0.0, 0 ));
-      pfcIso2.push_back( pfIso.getPfIso(*pho, 1, 0.2, 0.02, 0.0, 0 ));
-      pfcIso3.push_back( pfIso.getPfIso(*pho, 1, 0.3, 0.02, 0.0, 0 ));
-      pfcIso4.push_back( pfIso.getPfIso(*pho, 1, 0.4, 0.02, 0.0, 0 ));
-      pfcIso5.push_back( pfIso.getPfIso(*pho, 1, 0.5, 0.02, 0.0, 0 ));
+      pfcIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0 ));
+      pfcIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0 ));
+      pfcIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0 ));
+      pfcIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0 ));
+      pfcIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0 ));
 
-      pfnIso1.push_back( pfIso.getPfIso(*pho, 5, 0.1, 0.0, 0.0, 0 ));
-      pfnIso2.push_back( pfIso.getPfIso(*pho, 5, 0.2, 0.0, 0.0, 0 ));
-      pfnIso3.push_back( pfIso.getPfIso(*pho, 5, 0.3, 0.0, 0.0, 0 ));
-      pfnIso4.push_back( pfIso.getPfIso(*pho, 5, 0.4, 0.0, 0.0, 0 ));
-      pfnIso5.push_back( pfIso.getPfIso(*pho, 5, 0.5, 0.0, 0.0, 0 ));
+      pfnIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0 ));
+      pfnIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0 ));
+      pfnIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0 ));
+      pfnIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0 ));
+      pfnIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0 ));
 
-      pfpIso1.push_back( pfIso.getPfIso(*pho, 4, 0.1, 0.0, 0.0, 0.015 ));
-      pfpIso2.push_back( pfIso.getPfIso(*pho, 4, 0.2, 0.0, 0.0, 0.015 ));
-      pfpIso3.push_back( pfIso.getPfIso(*pho, 4, 0.3, 0.0, 0.0, 0.015 ));
-      pfpIso4.push_back( pfIso.getPfIso(*pho, 4, 0.4, 0.0, 0.0, 0.015 ));
-      pfpIso5.push_back( pfIso.getPfIso(*pho, 4, 0.5, 0.0, 0.0, 0.015 ));
+      pfpIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0.015 ));
+      pfpIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0.015 ));
+      pfpIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0.015 ));
+      pfpIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0.015 ));
+      pfpIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0.015 ));
 
-      pfcIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.1, 0.02, 0.0, 0 ));
-      pfcIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.2, 0.02, 0.0, 0 ));
-      pfcIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.3, 0.02, 0.0, 0 ));
-      pfcIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.4, 0.02, 0.0, 0 ));
-      pfcIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 1, 0.5, 0.02, 0.0, 0 ));
+      pfcIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0 ));
+      pfcIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0 ));
+      pfcIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0 ));
+      pfcIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0 ));
+      pfcIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0 ));
 
-      pfnIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.1, 0.0, 0.0, 0 ));
-      pfnIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.2, 0.0, 0.0, 0 ));
-      pfnIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.3, 0.0, 0.0, 0 ));
-      pfnIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.4, 0.0, 0.0, 0 ));
-      pfnIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 5, 0.5, 0.0, 0.0, 0 ));
+      pfnIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0 ));
+      pfnIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0 ));
+      pfnIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0 ));
+      pfnIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0 ));
+      pfnIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0 ));
 
-      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.1, 0.0, 0.0, 0.015 ));
-      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.2, 0.0, 0.0, 0.015 ));
-      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.3, 0.0, 0.0, 0.015 ));
-      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.4, 0.0, 0.0, 0.015 ));
-      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, 4, 0.5, 0.0, 0.0, 0.015 ));
+      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0.015 ));
+      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0.015 ));
+      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0.015 ));
+      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0.015 ));
+      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0.015 ));
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -1544,11 +1544,11 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       pfnIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
       pfnIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
-      pfpIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0.015, true, particlesInIsoMap));
+      pfpIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
       pfcIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
       pfcIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
@@ -1562,11 +1562,11 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       pfnIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
       pfnIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
-      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0.015, true, particlesInIsoMap));
-      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0.015, true, particlesInIsoMap));
+      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -381,41 +381,53 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps) :
     }
 
     if (doPfIso_) {
-      tree_->Branch("pfcIso1",&pfcIso1);
-      tree_->Branch("pfcIso2",&pfcIso2);
-      tree_->Branch("pfcIso3",&pfcIso3);
-      tree_->Branch("pfcIso4",&pfcIso4);
-      tree_->Branch("pfcIso5",&pfcIso5);
+      tree_->Branch("pfcIso1",&pfcIso1_);
+      tree_->Branch("pfcIso2",&pfcIso2_);
+      tree_->Branch("pfcIso3",&pfcIso3_);
+      tree_->Branch("pfcIso4",&pfcIso4_);
+      tree_->Branch("pfcIso5",&pfcIso5_);
 
-      tree_->Branch("pfpIso1",&pfpIso1);
-      tree_->Branch("pfpIso2",&pfpIso2);
-      tree_->Branch("pfpIso3",&pfpIso3);
-      tree_->Branch("pfpIso4",&pfpIso4);
-      tree_->Branch("pfpIso5",&pfpIso5);
+      tree_->Branch("pfpIso1",&pfpIso1_);
+      tree_->Branch("pfpIso2",&pfpIso2_);
+      tree_->Branch("pfpIso3",&pfpIso3_);
+      tree_->Branch("pfpIso4",&pfpIso4_);
+      tree_->Branch("pfpIso5",&pfpIso5_);
 
-      tree_->Branch("pfnIso1",&pfnIso1);
-      tree_->Branch("pfnIso2",&pfnIso2);
-      tree_->Branch("pfnIso3",&pfnIso3);
-      tree_->Branch("pfnIso4",&pfnIso4);
-      tree_->Branch("pfnIso5",&pfnIso5);
+      tree_->Branch("pfnIso1",&pfnIso1_);
+      tree_->Branch("pfnIso2",&pfnIso2_);
+      tree_->Branch("pfnIso3",&pfnIso3_);
+      tree_->Branch("pfnIso4",&pfnIso4_);
+      tree_->Branch("pfnIso5",&pfnIso5_);
 
-      tree_->Branch("pfcIso1subUE",&pfcIso1subUE);
-      tree_->Branch("pfcIso2subUE",&pfcIso2subUE);
-      tree_->Branch("pfcIso3subUE",&pfcIso3subUE);
-      tree_->Branch("pfcIso4subUE",&pfcIso4subUE);
-      tree_->Branch("pfcIso5subUE",&pfcIso5subUE);
+      tree_->Branch("pfpIso1subSC",&pfpIso1subSC_);
+      tree_->Branch("pfpIso2subSC",&pfpIso2subSC_);
+      tree_->Branch("pfpIso3subSC",&pfpIso3subSC_);
+      tree_->Branch("pfpIso4subSC",&pfpIso4subSC_);
+      tree_->Branch("pfpIso5subSC",&pfpIso5subSC_);
 
-      tree_->Branch("pfpIso1subUE",&pfpIso1subUE);
-      tree_->Branch("pfpIso2subUE",&pfpIso2subUE);
-      tree_->Branch("pfpIso3subUE",&pfpIso3subUE);
-      tree_->Branch("pfpIso4subUE",&pfpIso4subUE);
-      tree_->Branch("pfpIso5subUE",&pfpIso5subUE);
+      tree_->Branch("pfcIso1subUE",&pfcIso1subUE_);
+      tree_->Branch("pfcIso2subUE",&pfcIso2subUE_);
+      tree_->Branch("pfcIso3subUE",&pfcIso3subUE_);
+      tree_->Branch("pfcIso4subUE",&pfcIso4subUE_);
+      tree_->Branch("pfcIso5subUE",&pfcIso5subUE_);
 
-      tree_->Branch("pfnIso1subUE",&pfnIso1subUE);
-      tree_->Branch("pfnIso2subUE",&pfnIso2subUE);
-      tree_->Branch("pfnIso3subUE",&pfnIso3subUE);
-      tree_->Branch("pfnIso4subUE",&pfnIso4subUE);
-      tree_->Branch("pfnIso5subUE",&pfnIso5subUE);
+      tree_->Branch("pfpIso1subUE",&pfpIso1subUE_);
+      tree_->Branch("pfpIso2subUE",&pfpIso2subUE_);
+      tree_->Branch("pfpIso3subUE",&pfpIso3subUE_);
+      tree_->Branch("pfpIso4subUE",&pfpIso4subUE_);
+      tree_->Branch("pfpIso5subUE",&pfpIso5subUE_);
+
+      tree_->Branch("pfnIso1subUE",&pfnIso1subUE_);
+      tree_->Branch("pfnIso2subUE",&pfnIso2subUE_);
+      tree_->Branch("pfnIso3subUE",&pfnIso3subUE_);
+      tree_->Branch("pfnIso4subUE",&pfnIso4subUE_);
+      tree_->Branch("pfnIso5subUE",&pfnIso5subUE_);
+
+      tree_->Branch("pfpIso1subSCsubUE",&pfpIso1subSCsubUE_);
+      tree_->Branch("pfpIso2subSCsubUE",&pfpIso2subSCsubUE_);
+      tree_->Branch("pfpIso3subSCsubUE",&pfpIso3subSCsubUE_);
+      tree_->Branch("pfpIso4subSCsubUE",&pfpIso4subSCsubUE_);
+      tree_->Branch("pfpIso5subSCsubUE",&pfpIso5subSCsubUE_);
     }
   }
 
@@ -740,37 +752,47 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
 
     //photon pf isolation stuff
     if (doPfIso_) {
-      pfcIso1.clear();
-      pfcIso2.clear();
-      pfcIso3.clear();
-      pfcIso4.clear();
-      pfcIso5.clear();
-      pfpIso1.clear();
-      pfpIso2.clear();
-      pfpIso3.clear();
-      pfpIso4.clear();
-      pfpIso5.clear();
-      pfnIso1.clear();
-      pfnIso2.clear();
-      pfnIso3.clear();
-      pfnIso4.clear();
-      pfnIso5.clear();
+      pfcIso1_.clear();
+      pfcIso2_.clear();
+      pfcIso3_.clear();
+      pfcIso4_.clear();
+      pfcIso5_.clear();
+      pfpIso1_.clear();
+      pfpIso2_.clear();
+      pfpIso3_.clear();
+      pfpIso4_.clear();
+      pfpIso5_.clear();
+      pfnIso1_.clear();
+      pfnIso2_.clear();
+      pfnIso3_.clear();
+      pfnIso4_.clear();
+      pfnIso5_.clear();
+      pfpIso1subSC_.clear();
+      pfpIso2subSC_.clear();
+      pfpIso3subSC_.clear();
+      pfpIso4subSC_.clear();
+      pfpIso5subSC_.clear();
 
-      pfcIso1subUE.clear();
-      pfcIso2subUE.clear();
-      pfcIso3subUE.clear();
-      pfcIso4subUE.clear();
-      pfcIso5subUE.clear();
-      pfpIso1subUE.clear();
-      pfpIso2subUE.clear();
-      pfpIso3subUE.clear();
-      pfpIso4subUE.clear();
-      pfpIso5subUE.clear();
-      pfnIso1subUE.clear();
-      pfnIso2subUE.clear();
-      pfnIso3subUE.clear();
-      pfnIso4subUE.clear();
-      pfnIso5subUE.clear();
+      pfcIso1subUE_.clear();
+      pfcIso2subUE_.clear();
+      pfcIso3subUE_.clear();
+      pfcIso4subUE_.clear();
+      pfcIso5subUE_.clear();
+      pfpIso1subUE_.clear();
+      pfpIso2subUE_.clear();
+      pfpIso3subUE_.clear();
+      pfpIso4subUE_.clear();
+      pfpIso5subUE_.clear();
+      pfnIso1subUE_.clear();
+      pfnIso2subUE_.clear();
+      pfnIso3subUE_.clear();
+      pfnIso4subUE_.clear();
+      pfnIso5subUE_.clear();
+      pfpIso1subSCsubUE_.clear();
+      pfpIso2subSCsubUE_.clear();
+      pfpIso3subSCsubUE_.clear();
+      pfpIso4subSCsubUE_.clear();
+      pfpIso5subSCsubUE_.clear();
     }
   }
 
@@ -1532,41 +1554,54 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       }
 
       // particle flow isolation
-      pfcIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
 
-      pfnIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
-      pfpIso1.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso2.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso3.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso4.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso5.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso1_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso2_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso3_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso4_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso5_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
 
-      pfcIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
-      pfcIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
+      double scEt = pho->superCluster()->rawEnergy() / std::cosh(pho->superCluster()->eta());
+      pfpIso1subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, false) - scEt);
+      pfpIso2subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, false) - scEt);
+      pfpIso3subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, false) - scEt);
+      pfpIso4subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, false) - scEt);
+      pfpIso5subSC_.push_back( pfIso.getPfIso(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, false) - scEt);
 
-      pfnIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfnIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfcIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.1, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.02, 0.0, 0, true, particlesInIsoMap));
+      pfcIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.02, 0.0, 0, true, particlesInIsoMap));
 
-      pfpIso1subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso2subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso3subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso4subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
-      pfpIso5subUE.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfpIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+
+      pfnIso1subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.1, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso2subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso3subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso4subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, true, particlesInIsoMap));
+      pfnIso5subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.5, 0.0, 0.0, 0, true, particlesInIsoMap));
+
+      pfpIso1subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.1, 0.0, 0.0, 0, false) - scEt);
+      pfpIso2subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, false) - scEt);
+      pfpIso3subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, false) - scEt);
+      pfpIso4subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, false) - scEt);
+      pfpIso5subSCsubUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.5, 0.0, 0.0, 0, false) - scEt);
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/python/ggHiNtuplizer_cfi.py
+++ b/HeavyIonsAnalysis/PhotonAnalysis/python/ggHiNtuplizer_cfi.py
@@ -33,11 +33,15 @@ ggHiNtuplizer = cms.EDAnalyzer("ggHiNtuplizer",
     effAreasConfigFile = cms.FileInPath('HeavyIonsAnalysis/PhotonAnalysis/data/EffectiveAreas_94X_v0'),
     doPfIso            = cms.bool(True),
     particleFlowCollection = cms.InputTag("particleFlow"),
+    removePhotonPfIsoFootprint = cms.bool(False),
+    particleBasedIsolationPhoton = cms.InputTag("DUMMY"),
 )
 
 ggHiNtuplizerGED = ggHiNtuplizer.clone(
     doElectrons              = True,
     doMuons                  = True,
     recoPhotonSrc            = 'gedPhotons',
-    recoPhotonHiIsolationMap = 'photonIsolationHIProducerppGED'
+    recoPhotonHiIsolationMap = 'photonIsolationHIProducerppGED',
+    removePhotonPfIsoFootprint = True,
+    particleBasedIsolationPhoton = cms.InputTag("particleBasedIsolation", "gedPhotons")
 )

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -11,31 +11,79 @@ pfIsoCalculator::pfIsoCalculator(const edm::Event &iEvent,
   vtx_ = pv;
 }
 
+// copied from https://github.com/cms-sw/cmssw/blob/master/RecoEgamma/PhotonIdentification/plugins/PhotonIDValueMapProducer.cc#L26
+template <class T>
+bool pfIsoCalculator::isInFootprint(const T& footprint,
+                   const edm::Ptr<reco::Candidate>& candidate)
+{
+    for (auto& it : footprint) {
+        if (it.key() == candidate.key())
+            return true;
+    }
+    return false;
+}
+
 double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
                                  double r1, double r2, double threshold,
-                                 double jWidth)
+                                 double jWidth, bool removeFootprint, std::vector<reco::PFCandidateRef> particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
   double totalEt = 0;
 
-  for (const auto& pf : *candidatesView) {
-    if ( pf.particleId() != pfId )   continue;
-    double pfEta = pf.eta();
-    double pfPhi = pf.phi();
+  for (auto pf = candidatesView->begin(); pf != candidatesView->end(); ++pf) {
+    if ( pf->particleId() != pfId )   continue;
+    double pfEta = pf->eta();
+    double pfPhi = pf->phi();
 
     double dEta = std::abs(photonEta - pfEta);
     double dPhi = reco::deltaPhi(pfPhi, photonPhi);
     double dR2 = dEta*dEta + dPhi*dPhi;
-    double pfPt = pf.pt();
+    double pfPt = pf->pt();
 
-    // remove the photon itself
-    if ( pf.superClusterRef() == photon.superCluster() ) continue;
+    if (removeFootprint) {
+      // remove the photon itself and associated PF candidates
+      if ( pf->superClusterRef() == photon.superCluster() ) {
 
-    if(pf.particleId() == reco::PFCandidate::h){
-      float dz = std::abs(pf.vz() - vtx_.z());
+        /*
+        std::cout << "----- PF cand has same SC ref : indexPF = " << (pf - candidatesView->begin()) << std::endl;
+        std::cout << "pfPt = " << pfPt << std::endl;
+        std::cout << "pfEta = " << pfEta << std::endl;
+        std::cout << "pfPhi = " << pfPhi << std::endl;
+        std::cout << "pf.particleId() = " << pf->particleId() << std::endl;
+        std::cout << "photonEt = " << photon.et() << std::endl;
+        std::cout << "photonEta = " << photonEta << std::endl;
+        std::cout << "photonPhi = " << photonPhi << std::endl;
+        std::cout << "dR = " << std::sqrt(dR2) << std::endl;
+        std::cout << "pfPt/photonEt = " << pfPt / photon.et() << std::endl;
+        std::cout << "pfPt/photonEt SC raw Et = " << pfPt / (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta())) << std::endl;
+        */
+        continue;
+      }
+      edm::Ptr<reco::Candidate> candPtr(candidatesView, pf - candidatesView->begin());
+      if ( isInFootprint(particlesInIsoMap, candPtr) ) {
+
+        /*
+        std::cout << "----- PF cand is footprint : indexPF = " << (pf - candidatesView->begin()) << std::endl;
+        std::cout << "pfPt = " << pfPt << std::endl;
+        std::cout << "pfEta = " << pfEta << std::endl;
+        std::cout << "pfPhi = " << pfPhi << std::endl;
+        std::cout << "pf.particleId() = " << pf->particleId() << std::endl;
+        std::cout << "photonEt = " << photon.et() << std::endl;
+        std::cout << "photonEta = " << photonEta << std::endl;
+        std::cout << "photonPhi = " << photonPhi << std::endl;
+        std::cout << "dR = " << std::sqrt(dR2) << std::endl;
+        std::cout << "pfPt/photonEt = " << pfPt / photon.et() << std::endl;
+        std::cout << "pfPt/photonEt SC raw Et = " << pfPt / (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta())) << std::endl;
+        */
+        continue;
+      }
+    }
+
+    if(pf->particleId() == reco::PFCandidate::h){
+      float dz = std::abs(pf->vz() - vtx_.z());
       if (dz > 0.2) continue;
-      double dxy = ((vtx_.x() - pf.vx())*pf.py() + (pf.vy() - vtx_.y())*pf.px()) / pf.pt();
+      double dxy = ((vtx_.x() - pf->vx())*pf->py() + (pf->vy() - vtx_.y())*pf->px()) / pf->pt();
       if (std::abs(dxy) > 0.1) continue;
     }
 
@@ -52,34 +100,42 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
 
 double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
                                       double r1, double r2, double threshold,
-                                      double jWidth)
+                                      double jWidth, bool removeFootprint, std::vector<reco::PFCandidateRef> particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
   double totalEt = 0;
 
-  for (const auto& pf : *candidatesView) {
-    if ( pf.particleId() != pfId )   continue;
-    double pfEta = pf.eta();
-    double pfPhi = pf.phi();
+  for (auto pf = candidatesView->begin(); pf != candidatesView->end(); ++pf) {
+    if ( pf->particleId() != pfId )   continue;
+    double pfEta = pf->eta();
+    double pfPhi = pf->phi();
 
     double dEta = std::abs(photonEta - pfEta);
     if (dEta > r1) continue;
     if (dEta < jWidth)  continue;
 
-    // remove the photon itself
-    if ( pf.superClusterRef() == photon.superCluster() ) continue;
+    if (removeFootprint) {
+      // remove the photon itself and associated PF candidates
+      if ( pf->superClusterRef() == photon.superCluster() ) {
+        continue;
+      }
+      edm::Ptr<reco::Candidate> candPtr(candidatesView, pf - candidatesView->begin());
+      if ( isInFootprint(particlesInIsoMap, candPtr) ) {
+        continue;
+      }
+    }
 
-    if(pf.particleId() == reco::PFCandidate::h){
-      float dz = std::abs(pf.vz() - vtx_.z());
+    if(pf->particleId() == reco::PFCandidate::h){
+      float dz = std::abs(pf->vz() - vtx_.z());
       if (dz > 0.2) continue;
-      double dxy = ((vtx_.x() - pf.vx())*pf.py() + (pf.vy() - vtx_.y())*pf.px()) / pf.pt();
+      double dxy = ((vtx_.x() - pf->vx())*pf->py() + (pf->vy() - vtx_.y())*pf->px()) / pf->pt();
       if (std::abs(dxy) > 0.1) continue;
     }
 
     double dPhi = reco::deltaPhi(pfPhi, photonPhi);
     double dR2 = dEta*dEta + dPhi*dPhi;
-    double pfPt = pf.pt();
+    double pfPt = pf->pt();
 
     // Jurassic Cone /////
     if (dR2 < r2 * r2) continue;
@@ -112,7 +168,7 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
   areaStrip -= areaInnerCone;
   areaCone -= areaInnerCone;
 
-  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth) - totalEt * (areaCone / areaStrip);
+  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth, removeFootprint, particlesInIsoMap) - totalEt * (areaCone / areaStrip);
   return subEt;
 }
 
@@ -123,23 +179,23 @@ double pfIsoCalculator::getPfIso(const reco::GsfElectron& ele, int pfId,
   double elePhi = ele.phi();
   double totalEt = 0.;
 
-  for (const auto& pf : *candidatesView) {
-    if ( pf.particleId() != pfId )   continue;
-    double pfEta = pf.eta();
-    double pfPhi = pf.phi();
+  for (auto pf = candidatesView->begin(); pf != candidatesView->end(); ++pf) {
+    if ( pf->particleId() != pfId )   continue;
+    double pfEta = pf->eta();
+    double pfPhi = pf->phi();
 
     double dEta = std::abs(eleEta - pfEta);
     double dPhi = reco::deltaPhi(pfPhi, elePhi);
     double dR2 = dEta*dEta + dPhi*dPhi;
-    double pfPt = pf.pt();
+    double pfPt = pf->pt();
 
     // remove electron itself
-    if (pf.particleId() == reco::PFCandidate::e) continue;
+    if (pf->particleId() == reco::PFCandidate::e) continue;
 
-    if (pf.particleId() == reco::PFCandidate::h) {
-      float dz = std::abs(pf.vz() - vtx_.z());
+    if (pf->particleId() == reco::PFCandidate::h) {
+      float dz = std::abs(pf->vz() - vtx_.z());
       if (dz > 0.2) continue;
-      double dxy = ((vtx_.x() - pf.vx())*pf.py() + (pf.vy() - vtx_.y())*pf.px()) / pf.pt();
+      double dxy = ((vtx_.x() - pf->vx())*pf->py() + (pf->vy() - vtx_.y())*pf->px()) / pf->pt();
       if (std::abs(dxy) > 0.1) continue;
     }
 

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -25,7 +25,7 @@ bool pfIsoCalculator::isInFootprint(const T& footprint,
 
 double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
                                  double r1, double r2, double threshold,
-                                 double jWidth, int footprintRemoval, std::vector<reco::PFCandidateRef> particlesInIsoMap)
+                                 double jWidth, int footprintRemoval, const std::vector<reco::PFCandidateRef>& particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
@@ -76,7 +76,7 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
 
 double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
                                       double r1, double r2, double threshold,
-                                      double jWidth, int footprintRemoval, std::vector<reco::PFCandidateRef> particlesInIsoMap)
+                                      double jWidth, int footprintRemoval, const std::vector<reco::PFCandidateRef>& particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -44,38 +44,10 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
     if (removeFootprint) {
       // remove the photon itself and associated PF candidates
       if ( pf->superClusterRef() == photon.superCluster() ) {
-
-        /*
-        std::cout << "----- PF cand has same SC ref : indexPF = " << (pf - candidatesView->begin()) << std::endl;
-        std::cout << "pfPt = " << pfPt << std::endl;
-        std::cout << "pfEta = " << pfEta << std::endl;
-        std::cout << "pfPhi = " << pfPhi << std::endl;
-        std::cout << "pf.particleId() = " << pf->particleId() << std::endl;
-        std::cout << "photonEt = " << photon.et() << std::endl;
-        std::cout << "photonEta = " << photonEta << std::endl;
-        std::cout << "photonPhi = " << photonPhi << std::endl;
-        std::cout << "dR = " << std::sqrt(dR2) << std::endl;
-        std::cout << "pfPt/photonEt = " << pfPt / photon.et() << std::endl;
-        std::cout << "pfPt/photonEt SC raw Et = " << pfPt / (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta())) << std::endl;
-        */
         continue;
       }
       edm::Ptr<reco::Candidate> candPtr(candidatesView, pf - candidatesView->begin());
       if ( isInFootprint(particlesInIsoMap, candPtr) ) {
-
-        /*
-        std::cout << "----- PF cand is footprint : indexPF = " << (pf - candidatesView->begin()) << std::endl;
-        std::cout << "pfPt = " << pfPt << std::endl;
-        std::cout << "pfEta = " << pfEta << std::endl;
-        std::cout << "pfPhi = " << pfPhi << std::endl;
-        std::cout << "pf.particleId() = " << pf->particleId() << std::endl;
-        std::cout << "photonEt = " << photon.et() << std::endl;
-        std::cout << "photonEta = " << photonEta << std::endl;
-        std::cout << "photonPhi = " << photonPhi << std::endl;
-        std::cout << "dR = " << std::sqrt(dR2) << std::endl;
-        std::cout << "pfPt/photonEt = " << pfPt / photon.et() << std::endl;
-        std::cout << "pfPt/photonEt SC raw Et = " << pfPt / (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta())) << std::endl;
-        */
         continue;
       }
     }

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -25,11 +25,15 @@ bool pfIsoCalculator::isInFootprint(const T& footprint,
 
 double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
                                  double r1, double r2, double threshold,
-                                 double jWidth, bool removeFootprint, std::vector<reco::PFCandidateRef> particlesInIsoMap)
+                                 double jWidth, int footprintRemoval, std::vector<reco::PFCandidateRef> particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
   double totalEt = 0;
+
+  if (footprintRemoval == pfIsoCalculator::removeSCenergy) {
+    totalEt -= (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta()));
+  }
 
   for (auto pf = candidatesView->begin(); pf != candidatesView->end(); ++pf) {
     if ( pf->particleId() != pfId )   continue;
@@ -41,7 +45,7 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
     double dR2 = dEta*dEta + dPhi*dPhi;
     double pfPt = pf->pt();
 
-    if (removeFootprint) {
+    if (footprintRemoval == pfIsoCalculator::removePFcand) {
       // remove the photon itself and associated PF candidates
       if ( pf->superClusterRef() == photon.superCluster() ) {
         continue;
@@ -72,11 +76,15 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
 
 double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
                                       double r1, double r2, double threshold,
-                                      double jWidth, bool removeFootprint, std::vector<reco::PFCandidateRef> particlesInIsoMap)
+                                      double jWidth, int footprintRemoval, std::vector<reco::PFCandidateRef> particlesInIsoMap)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
   double totalEt = 0;
+
+  if (footprintRemoval == pfIsoCalculator::removeSCenergy) {
+    totalEt -= (photon.superCluster()->rawEnergy() / std::cosh(photon.superCluster()->eta()));
+  }
 
   for (auto pf = candidatesView->begin(); pf != candidatesView->end(); ++pf) {
     if ( pf->particleId() != pfId )   continue;
@@ -87,7 +95,7 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
     if (dEta > r1) continue;
     if (dEta < jWidth)  continue;
 
-    if (removeFootprint) {
+    if (footprintRemoval == pfIsoCalculator::removePFcand) {
       // remove the photon itself and associated PF candidates
       if ( pf->superClusterRef() == photon.superCluster() ) {
         continue;
@@ -140,7 +148,7 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
   areaStrip -= areaInnerCone;
   areaCone -= areaInnerCone;
 
-  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth, removeFootprint, particlesInIsoMap) - totalEt * (areaCone / areaStrip);
+  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth, footprintRemoval, particlesInIsoMap) - totalEt * (areaCone / areaStrip);
   return subEt;
 }
 

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
@@ -18,8 +18,8 @@ class pfIsoCalculator
     template <class T>
     bool isInFootprint(const T& footprint, const edm::Ptr<reco::Candidate>& candidate);
 
-    double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
-    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
+    double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, const std::vector<reco::PFCandidateRef>& particlesInIsoMap = {});
+    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, const std::vector<reco::PFCandidateRef>& particlesInIsoMap = {});
 
     double getPfIso(const reco::GsfElectron& ele, int pfId, double r1=0.4, double r2=0.00, double threshold=0);
 

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
@@ -15,8 +15,11 @@ class pfIsoCalculator
   public:
     pfIsoCalculator(const edm::Event &iEvent, const edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandidates, const math::XYZPoint& pv);
 
-    double getPfIso(const reco::Photon& photon,  int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0);
-    double getPfIsoSubUE(const reco::Photon& photon,  int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0);
+    template <class T>
+    bool isInFootprint(const T& footprint, const edm::Ptr<reco::Candidate>& candidate);
+
+    double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, bool removeFootprint = false, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
+    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, bool removeFootprint = false, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
 
     double getPfIso(const reco::GsfElectron& ele, int pfId, double r1=0.4, double r2=0.00, double threshold=0);
 

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
@@ -18,10 +18,16 @@ class pfIsoCalculator
     template <class T>
     bool isInFootprint(const T& footprint, const edm::Ptr<reco::Candidate>& candidate);
 
-    double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, bool removeFootprint = false, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
-    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, bool removeFootprint = false, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
+    double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
+    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, std::vector<reco::PFCandidateRef> particlesInIsoMap = {});
 
     double getPfIso(const reco::GsfElectron& ele, int pfId, double r1=0.4, double r2=0.00, double threshold=0);
+
+    enum footprintOptions {
+      noRemoval=0,
+      removePFcand,       // remove PF candidates in the isolation map
+      removeSCenergy,     // remove SC raw transverse energy
+    };
 
   private:
     edm::Handle<edm::View<reco::PFCandidate> > candidatesView;


### PR DESCRIPTION
Update PF isolation calculation for photons :
1) Remove PF footprints when calculating the isolation for GED photons. PF footprints are read from "particleBasedIsolation" object.
2) add PF pho isolation variables where PF footprints are not removed, instead energy of photon SC is subtracted.

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

@bi-ran 
