### PR TITLE
get btag info and discriminators from PAT, rather than by hand

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -192,16 +192,16 @@ private:
   std::string			jetIDweightFile_;
 
   std::string bTagJetName_;
-  edm::EDGetTokenT<std::vector<reco::TrackIPTagInfo> > ImpactParameterTagInfos_;
-  edm::EDGetTokenT<reco::JetTagCollection> TrackCountingHighEffBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> TrackCountingHighPurBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> JetProbabilityBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> JetBProbabilityBJetTags_;
-  edm::EDGetTokenT<std::vector<reco::SecondaryVertexTagInfo> > SecondaryVertexTagInfos_;
-  edm::EDGetTokenT<reco::JetTagCollection> SimpleSecondaryVertexHighEffBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> SimpleSecondaryVertexHighPurBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> CombinedSecondaryVertexBJetTags_;
-  edm::EDGetTokenT<reco::JetTagCollection> CombinedSecondaryVertexV2BJetTags_;
+  std::string ipTagInfos_;
+  std::string svTagInfos_;
+  std::string trackCHEBJetTags_;
+  std::string trackCHPBJetTags_;
+  std::string jetPBJetTags_;
+  std::string jetBPBJetTags_;
+  std::string simpleSVHighEffBJetTags_;
+  std::string simpleSVHighPurBJetTags_;
+  std::string combinedSVV1BJetTags_;
+  std::string combinedSVV2BJetTags_;
 
   static const int MAXJETS = 1000;
   static const int MAXTRACKS = 5000;

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
@@ -160,6 +160,7 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_patJetsWithBtagging = patJets.clone(
         cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_TrackCountingHighEffBJetTags"),
         cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_TrackCountingHighPurBJetTags"),
         ),
+    tagInfoSources = cms.VInputTag(cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_ImpactParameterTagInfos"),cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_SecondaryVertexTagInfos")),
     jetIDMap = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_JetID"),
     addBTagInfo = True,
     addTagInfos = True,


### PR DESCRIPTION
#### PR description:

This is a purely technical change. 
The btag discriminators and tag information were added to the inclusive jet analyzer by manually loading the input tags and matching them to the jets.   Now we simply grab the information from the PAT jets.  
The code is cleaner and should run faster. 

#### PR validation:


#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
