### PR TITLE
circleci: fix failing builds for direct commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,12 @@ commands:
                     ssh-keyscan $ip
                 done 2>/dev/null >> ~/.ssh/known_hosts
             - run: |
-                cd $cmssw/src
-                eval `scramv1 runtime -sh`
-                git fetch $CIRCLE_REPOSITORY_URL pull/$CIRCLE_PR_NUMBER/head
-                git merge FETCH_HEAD --no-commit
+                if [ -n "$CIRCLE_PR_NUMBER" ]; then
+                    cd $cmssw/src
+                    eval `scramv1 runtime -sh`
+                    git fetch $CIRCLE_REPOSITORY_URL pull/$CIRCLE_PR_NUMBER/head
+                    git merge FETCH_HEAD --no-commit
+                fi
 
     build-forest:
         steps:


### PR DESCRIPTION
builds for commits fail because they try to merge a (nonexistent) pr. make this step conditional to avoid annoying build failures.

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No
