### PR TITLE
Flavor match by ghosting for Cs Jets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -415,6 +415,8 @@ private:
     float matchedRawPt[MAXJETS];
     float matchedR[MAXJETS];
     float matchedPu[MAXJETS];
+    int matchedHadronFlavor[MAXJETS];
+    int matchedPartonFlavor[MAXJETS];
 
     float discr_csvV1[MAXJETS];
     float discr_csvV2[MAXJETS];

--- a/HeavyIonsAnalysis/JetAnalysis/python/bTaggers_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/bTaggers_cff.py
@@ -160,7 +160,8 @@ class bTaggers:
             rParam = rParam,
             bHadrons = cms.InputTag(jetname+"PatJetPartons","bHadrons"),
             cHadrons = cms.InputTag(jetname+"PatJetPartons","cHadrons"),
-            partons = cms.InputTag(jetname+"PatJetPartons","partons")
+            leptons = cms.InputTag(jetname+"PatJetPartons","leptons"),
+            partons = cms.InputTag(jetname+"PatJetPartons","physicsPartons")
             )
 
         self.PatJetFlavourId               = cms.Sequence(self.PatJetPartons*self.PatJetFlavourAssociation)

--- a/HeavyIonsAnalysis/JetAnalysis/python/fullJetSequence_pponAA_MIX_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/fullJetSequence_pponAA_MIX_cff.py
@@ -6,10 +6,12 @@ from HeavyIonsAnalysis.JetAnalysis.rerecoJets_cff import *
 from HeavyIonsAnalysis.JetAnalysis.rerecoTracks_cff import *
 
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu3CaloJetSequence_pponPbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.ak3PFJetSequence_pponPbPb_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu3PFJetSequence_pponPbPb_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akCs3PFJetSequence_pponPbPb_mc_cff import *
 
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu4CaloJetSequence_pponPbPb_mc_cff import *
+from HeavyIonsAnalysis.JetAnalysis.jets.ak4PFJetSequence_pponPbPb_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akPu4PFJetSequence_pponPbPb_mc_cff import *
 from HeavyIonsAnalysis.JetAnalysis.jets.akCs4PFJetSequence_pponPbPb_mc_cff import *
 
@@ -50,18 +52,22 @@ jetSequence = cms.Sequence(
     highPurityTracks +
 
     akPu3CaloJets +
+    ak3PFJets +
     akPu3PFJets +
     akCs3PFJets +
 
     akPu4CaloJets +
+    ak4PFJets +
     akPu4PFJets +
     akCs4PFJets +
 
     akPu3CaloJetSequence +
+    ak3PFJetSequence + 
     akPu3PFJetSequence +
     akCs3PFJetSequence +
 
     akPu4CaloJetSequence +
+    ak4PFJetSequence + 
     akPu4PFJetSequence +
     akCs4PFJetSequence
 )

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -110,35 +110,69 @@ do
                                 fulltag=${algo}${subt}${groomt}${radius}${object}
                                 jetseqfile=${fulltag}JetSequence_${reco}on${system}_${sample}_cff.py
 
-                                cat templateSequence_bTag_cff.py.txt | sed \
-                                    -e "s/ALGO_/$algo/g" \
-                                    -e "s/SUB_/$subt/g" \
-                                    -e "s/GROOM_/$groomt/g" \
-                                    -e "s/RADIUS_/$radius/g" \
-                                    -e "s/OBJECT_/$object/g" \
-                                    -e "s/SAMPLE_/$sample/g" \
-                                    -e "s/CORRNAME_/$corrname/g" \
-                                    -e "s/MATCHED_/$match/g" \
-                                    -e "s/ISMC/$ismc/g" \
-                                    -e "s/MATCHGENJETS/$matchGenjets/g" \
-                                    -e "s/GENJETS/$genjets/g" \
-                                    -e "s/GENPARTICLES/$genparticles/g" \
-                                    -e "s/PARTONS/$partons/g" \
-                                    -e "s/MATCHPS/$matchpartons/g" \
-                                    -e "s/TRACKS/$tracks/g" \
-                                    -e "s/VERTEX/$vertex/g" \
-                                    -e "s/PARTICLEFLOW/$pflow/g" \
-                                    -e "s/DOMATCH/$domatch/g" \
-                                    -e "s/EVENTINFOTAG/$eventinfotag/g" \
-                                    -e "s/JETCORRECTIONLEVELS/$jetcorrlevels/g" \
-                                    -e "s/DOTOWERS_/$doTower/g" \
-                                    -e "s/DOSUBJETS_/$doSubJets/g" \
-                                    -e "s/DOGENTAUS_/$doGenTaus/g" \
-                                    -e "s/DOGENSUBJETS_/$doGenSubJets/g" \
-                                    -e "s/DOGENSYM_/$doGenSym/g" \
-                                    -e "s/RESOLVEBYDIST_/$resolveByDist/g" \
-                                    -e "s/SYSTEM_/$systemt/g" \
-                                    > $jetseqfile
+				if [ $sub == "Cs" ] || [ $sub == "Pu" ]; then
+                                    cat templateSequence_bTag_LegacyFlavor_cff.py.txt | sed \
+					-e "s/ALGO_/$algo/g" \
+					-e "s/SUB_/$subt/g" \
+					-e "s/GROOM_/$groomt/g" \
+					-e "s/RADIUS_/$radius/g" \
+					-e "s/OBJECT_/$object/g" \
+					-e "s/SAMPLE_/$sample/g" \
+					-e "s/CORRNAME_/$corrname/g" \
+					-e "s/MATCHED_/$match/g" \
+					-e "s/ISMC/$ismc/g" \
+					-e "s/MATCHGENJETS/$matchGenjets/g" \
+					-e "s/GENJETS/$genjets/g" \
+					-e "s/GENPARTICLES/$genparticles/g" \
+					-e "s/PARTONS/$partons/g" \
+					-e "s/MATCHPS/$matchpartons/g" \
+					-e "s/TRACKS/$tracks/g" \
+					-e "s/VERTEX/$vertex/g" \
+					-e "s/PARTICLEFLOW/$pflow/g" \
+					-e "s/DOMATCH/$domatch/g" \
+					-e "s/EVENTINFOTAG/$eventinfotag/g" \
+					-e "s/JETCORRECTIONLEVELS/$jetcorrlevels/g" \
+					-e "s/DOTOWERS_/$doTower/g" \
+					-e "s/DOSUBJETS_/$doSubJets/g" \
+					-e "s/DOGENTAUS_/$doGenTaus/g" \
+					-e "s/DOGENSUBJETS_/$doGenSubJets/g" \
+					-e "s/DOGENSYM_/$doGenSym/g" \
+					-e "s/RESOLVEBYDIST_/$resolveByDist/g" \
+					-e "s/SYSTEM_/$systemt/g" \
+					> $jetseqfile
+				    
+                                else
+                                    cat templateSequence_bTag_cff.py.txt | sed \
+					-e "s/ALGO_/$algo/g" \
+					-e "s/SUB_/$subt/g" \
+					-e "s/GROOM_/$groomt/g" \
+					-e "s/RADIUS_/$radius/g" \
+					-e "s/OBJECT_/$object/g" \
+					-e "s/SAMPLE_/$sample/g" \
+					-e "s/CORRNAME_/$corrname/g" \
+					-e "s/MATCHED_/$match/g" \
+					-e "s/ISMC/$ismc/g" \
+					-e "s/MATCHGENJETS/$matchGenjets/g" \
+					-e "s/GENJETS/$genjets/g" \
+					-e "s/GENPARTICLES/$genparticles/g" \
+					-e "s/PARTONS/$partons/g" \
+					-e "s/MATCHPS/$matchpartons/g" \
+					-e "s/TRACKS/$tracks/g" \
+					-e "s/VERTEX/$vertex/g" \
+					-e "s/PARTICLEFLOW/$pflow/g" \
+					-e "s/DOMATCH/$domatch/g" \
+					-e "s/EVENTINFOTAG/$eventinfotag/g" \
+					-e "s/JETCORRECTIONLEVELS/$jetcorrlevels/g" \
+					-e "s/DOTOWERS_/$doTower/g" \
+					-e "s/DOSUBJETS_/$doSubJets/g" \
+					-e "s/DOGENTAUS_/$doGenTaus/g" \
+					-e "s/DOGENSUBJETS_/$doGenSubJets/g" \
+					-e "s/DOGENSYM_/$doGenSym/g" \
+					-e "s/RESOLVEBYDIST_/$resolveByDist/g" \
+					-e "s/SYSTEM_/$systemt/g" \
+					> $jetseqfile
+                                fi
+
 
                                 if [ $sample == "jec" ]; then
                                     echo "${fulltag}JetAnalyzer.genPtMin = cms.untracked.double(1)" >> $jetseqfile
@@ -148,6 +182,12 @@ do
                                 if [[ $groom =~ "SoftDrop" ]]; then
                                     echo "${fulltag}patJetsWithBtagging.userData.userFloats.src += ['${fulltag}Jets:sym']" >> $jetseqfile
                                     echo "${fulltag}patJetsWithBtagging.userData.userInts.src += ['${fulltag}Jets:droppedBranches']" >> $jetseqfile
+                                fi
+
+                                if [[ $sub =~ "Cs" ]]; then
+				    echo -e "\n" >> $jetseqfile
+                                    echo "${fulltag}JetAnalyzer.doMatch = cms.untracked.bool(True)" >> $jetseqfile				    
+                                    echo "${fulltag}JetAnalyzer.matchTag = cms.untracked.InputTag(\"ak"${radius}$"patJetsWithBtagging\")" >> $jetseqfile
                                 fi
                             done
                         done

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_LegacyFlavor_cff.py.txt
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_LegacyFlavor_cff.py.txt
@@ -49,6 +49,7 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger = bTaggers(
     0.RADIUS_)
 
 # create objects locally since they dont load properly otherwise
+ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociationLegacy = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PatJetFlavourAssociationLegacy
 ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartons = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PatJetPartons
 ALGO_SUB_GROOM_RADIUS_OBJECT_JetTracksAssociatorAtVertex = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.JetTracksAssociatorAtVertex
 ALGO_SUB_GROOM_RADIUS_OBJECT_JetTracksAssociatorAtVertex.tracks = cms.InputTag("highPurityTracks")
@@ -61,6 +62,8 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_SoftPFMuonByPtBJetTags = ALGO_SUB_GROOM_RADIUS_OBJE
 ALGO_SUB_GROOM_RADIUS_OBJECT_SoftPFMuonByIP3dBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.SoftPFMuonByIP3dBJetTags
 ALGO_SUB_GROOM_RADIUS_OBJECT_TrackCountingHighEffBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.TrackCountingHighEffBJetTags
 ALGO_SUB_GROOM_RADIUS_OBJECT_TrackCountingHighPurBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.TrackCountingHighPurBJetTags
+ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartonAssociationLegacy = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PatJetPartonAssociationLegacy
+ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartonAssociationLegacy.partons = "MATCHPS"
 
 ALGO_SUB_GROOM_RADIUS_OBJECT_ImpactParameterTagInfos = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.ImpactParameterTagInfos
 ALGO_SUB_GROOM_RADIUS_OBJECT_ImpactParameterTagInfos.primaryVertex = cms.InputTag("VERTEX")
@@ -87,8 +90,10 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_SoftPFMuonByIP3dBJetTags = ALGO_SUB_GROOM_RADIUS_OB
 ALGO_SUB_GROOM_RADIUS_OBJECT_SoftPFMuonByPtBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.SoftPFMuonByPtBJetTags
 ALGO_SUB_GROOM_RADIUS_OBJECT_NegativeSoftPFMuonByPtBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.NegativeSoftPFMuonByPtBJetTags
 ALGO_SUB_GROOM_RADIUS_OBJECT_PositiveSoftPFMuonByPtBJetTags = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PositiveSoftPFMuonByPtBJetTags
-ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PatJetFlavourAssociation
-ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId = cms.Sequence(ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartons*ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation)
+ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourIdLegacy = cms.Sequence(ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartonAssociationLegacy*ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociationLegacy)
+# Not working with our PU sub, but keep it here for reference
+# ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation = ALGO_SUB_GROOM_RADIUS_OBJECT_bTagger.PatJetFlavourAssociation
+# ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId = cms.Sequence(ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetPartons*ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation)
 
 ALGO_SUB_GROOM_RADIUS_OBJECT_JetBtaggingIP = cms.Sequence(
     ALGO_SUB_GROOM_RADIUS_OBJECT_ImpactParameterTagInfos *
@@ -139,10 +144,10 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_patJetsWithBtagging = patJets.clone(
     genJetMatch            = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_match"),
     genPartonMatch         = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_parton"),
     jetCorrFactorsSource   = cms.VInputTag(cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_corr")),
-    JetPartonMapSource     = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation"),
+    JetPartonMapSource     = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociationLegacy"),
     JetFlavourInfoSource   = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourAssociation"),
     trackAssociationSource = cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_JetTracksAssociatorAtVertex"),
-    useLegacyJetMCFlavour  = False,
+    useLegacyJetMCFlavour  = True,
     discriminatorSources   = cms.VInputTag(
         cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_SimpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("ALGO_SUB_GROOM_RADIUS_OBJECT_SimpleSecondaryVertexHighPurBJetTags"),
@@ -228,7 +233,9 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_JetSequence_mc = cms.Sequence(
     # *
     # ALGO_SUB_GROOM_RADIUS_OBJECT_JetID
     *
-     ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId 
+    ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourIdLegacy
+    # *
+    # ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId # Use legacy algo till PU implemented
     *
     ALGO_SUB_GROOM_RADIUS_OBJECT_JetTracksAssociatorAtVertex
     *

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -436,6 +436,10 @@ HiInclusiveJetAnalyzer::beginJob() {
     t->Branch("matchedRawPt", jets_.matchedRawPt,"matchedRawPt[nref]/F");
     t->Branch("matchedPu", jets_.matchedPu,"matchedPu[nref]/F");
     t->Branch("matchedR", jets_.matchedR,"matchedR[nref]/F");
+    if(isMC_){
+      t->Branch("matchedHadronFlavor", jets_.matchedHadronFlavor,"matchedHadronFlavor[nref]/I");
+      t->Branch("matchedPartonFlavor", jets_.matchedPartonFlavor,"matchedPartonFlavor[nref]/I");
+    }
   }
 
   // b-jet discriminators
@@ -1316,6 +1320,10 @@ HiInclusiveJetAnalyzer::analyze(const Event& iEvent,
 	    const pat::Jet& mpatjet = (*patmatchedjets)[imatch];
 	    jets_.matchedRawPt[jets_.nref] = mpatjet.correctedJet("Uncorrected").pt();
 	    jets_.matchedPu[jets_.nref] = mpatjet.pileup();
+	    if(isMC_){
+	      jets_.matchedHadronFlavor[jets_.nref] = mpatjet.hadronFlavour();
+	      jets_.matchedPartonFlavor[jets_.nref] = mpatjet.partonFlavour();
+	    }
 	  }
 	  jets_.matchedR[jets_.nref] = dr;
 	  drMin = dr;

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -90,6 +90,7 @@ process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pponAA_MIX_cff')
 process.akPu4Calocorr.payload = "AK4Calo"
 process.akPu4PFcorr.payload = "AK4PF"
 process.akCs4PFcorr.payload = "AK4PF"
+process.ak4PFcorr.payload = "AK4PF"
 process.akPu4PFJets.jetPtMin = 1
 
 


### PR DESCRIPTION
Since quite a while the flavor of heavy flavor jets no longer assigned by a delta R matching at the parton level, but rather by ghosting the heavy flavor hadron and reclustering the jet. 
This poses a challenge for UE-subtracted jets, which are not trivial to recluster. 
This PR implements a work around to achieve this in the MC workflow.
The unsubtracted jets are now run (e.g., ak4 for akCs4) and their flavor is assigned using the new method.  
Cs jets are matched to the unsubtracted collection in the jet analyzer and the flavor is taken from the unsubtracted jet.  The legacy flavor is still also available.  

In a future PR I may try and make the unsubtracted jets run faster by removing certain features such as b-tagging, which are presumably not needed. 



Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
