### PR TITLE
fix the omission of etaMax

### DIFF
--- a/HeavyIonsAnalysis/TrackAnalysis/src/HiGenAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/HiGenAnalyzer.cc
@@ -326,6 +326,7 @@ HiGenAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       nparticles++;
       if ((*it)->momentum().perp()<ptMin_) continue;
       //	if((*it)->status() == 1){
+      if (fabs((*it)->momentum().eta())>etaMax_) continue;
       Int_t pdg_id = (*it)->pdg_id();
       Float_t eta = (*it)->momentum().eta();
       Float_t phi = (*it)->momentum().phi();
@@ -364,6 +365,7 @@ HiGenAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       const reco::GenParticle& p = (*parts)[i];
       if (stableOnly_ && p.status()!=1) continue;
       if (p.pt()<ptMin_) continue;
+      if (fabs(p.eta())>etaMax_) continue;
       if (chargedOnly_&&p.charge()==0) continue;
       hev_.E.push_back( p.energy());
       hev_.mass.push_back( p.mass());


### PR DESCRIPTION
Somehow etaMax was omitted in gen analyzer of 94X. See the actual usage in 
https://github.com/CmsHI/cmssw/blob/forest_CMSSW_10_3_1/HeavyIonsAnalysis/TrackAnalysis/src/HiGenAnalyzer.cc#L325
and
https://github.com/CmsHI/cmssw/blob/forest_CMSSW_10_3_1/HeavyIonsAnalysis/TrackAnalysis/src/HiGenAnalyzer.cc#L361

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@bi-ran 
