### PR TITLE
Added option to do WTA reclustering for jet axis

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -74,6 +74,11 @@ public:
 
 private:
 
+  // for reWTA reclustering-----------------------
+  bool doWTARecluster_ = false;
+  fastjet::JetDefinition WTAjtDef = fastjet::JetDefinition(fastjet::JetAlgorithm::antikt_algorithm, 2, fastjet::WTA_pt_scheme);
+  //--------------------------------------------
+
   int getPFJetMuon(const pat::Jet& pfJet, const reco::PFCandidateCollection *pfCandidateColl);
 
   double getPtRel(const reco::PFCandidate lep, const pat::Jet& jet );
@@ -223,6 +228,13 @@ private:
     float jtpt[MAXJETS];
     float jteta[MAXJETS];
     float jtphi[MAXJETS];
+
+    //reWTA reclusted jet axis
+    float WTAeta[MAXJETS];
+    float WTAphi[MAXJETS];
+    float WTAgeneta[MAXJETS];
+    float WTAgenphi[MAXJETS];
+
     float jty[MAXJETS];
     float jtpu[MAXJETS];
     float jtm[MAXJETS];

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -22,6 +22,7 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     doSubJets = cms.untracked.bool(False),
     doJetConstituents = cms.untracked.bool(False),
     doNewJetVars = cms.untracked.bool(False),
+    doWTARecluster = cms.untracked.bool(False),
     doHiJetID = cms.untracked.bool(True),
     doStandardJetID = cms.untracked.bool(False),
     doSubEvent = cms.untracked.bool(False),

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -94,6 +94,9 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
   doGenSubJets_ = iConfig.getUntrackedParameter<bool>("doGenSubJets", false);
   subjetGenTag_ = consumes<reco::JetView> (iConfig.getUntrackedParameter<InputTag>("subjetGenTag"));
 
+  //reWTA reclustering
+  doWTARecluster_ = iConfig.getUntrackedParameter<bool>("doWTARecluster", false);
+
   if (iConfig.exists("genTau1"))
     tokenGenTau1_          = consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("genTau1"));
   if (iConfig.exists("genTau2"))
@@ -237,6 +240,12 @@ HiInclusiveJetAnalyzer::beginJob() {
   t->Branch("jtpu",jets_.jtpu,"jtpu[nref]/F");
   t->Branch("jtm",jets_.jtm,"jtm[nref]/F");
   t->Branch("jtarea",jets_.jtarea,"jtarea[nref]/F");
+
+  //for reWTA reclustering
+  if(doWTARecluster_){
+    t->Branch("WTAeta",jets_.WTAeta,"WTAeta[nref]/F");
+    t->Branch("WTAphi",jets_.WTAphi,"WTAphi[nref]/F");
+  }
 
   if(doNewJetVars_){
     t->Branch("jtnCands",jets_.jtnCands,"jtnCands[nref]/I");
@@ -690,6 +699,12 @@ HiInclusiveJetAnalyzer::beginJob() {
       t->Branch("genm",jets_.genm,"genm[ngen]/F");
       t->Branch("gendphijt",jets_.gendphijt,"gendphijt[ngen]/F");
       t->Branch("gendrjt",jets_.gendrjt,"gendrjt[ngen]/F");
+
+      //for reWTA reclustering
+      if(doWTARecluster_){
+        t->Branch("WTAgeneta",jets_.WTAgeneta,"WTAgeneta[nref]/F");
+        t->Branch("WTAgenphi",jets_.WTAgenphi,"WTAgenphi[nref]/F");
+      }
 
       if(doNewJetVars_){
 	t->Branch("gennCands",jets_.gennCands,"gennCands[ngen]/I");
@@ -1423,6 +1438,22 @@ HiInclusiveJetAnalyzer::analyze(const Event& iEvent,
       }
     }
 
+    //recluster the jet constituents in reWTA scheme-------------------------
+    if(doWTARecluster_){
+      std::vector<fastjet::PseudoJet> candidates;
+      auto daughters = jet.getJetConstituents();
+      for(auto it = daughters.begin(); it!=daughters.end(); ++it){
+        candidates.push_back(fastjet::PseudoJet((**it).px(), (**it).py(), (**it).pz(), (**it).energy()));
+      }
+      auto cs = new fastjet::ClusterSequence(candidates, WTAjtDef);
+      std::vector<fastjet::PseudoJet> wtajt = fastjet::sorted_by_pt(cs->inclusive_jets(0));
+
+      jets_.WTAeta[jets_.nref] = (wtajt.size() > 0) ? wtajt[0].eta() : -999;
+      jets_.WTAphi[jets_.nref] = (wtajt.size() > 0) ? wtajt[0].phi_std() : -999;
+      delete cs;
+    }
+    //------------------------------------------------------------------
+
     //! fill in the new jet varibles
     if(doNewJetVars_)
       fillNewJetVarsRecoJet(jet);
@@ -1824,6 +1855,22 @@ HiInclusiveJetAnalyzer::analyze(const Event& iEvent,
           break;
         }
       }
+
+      //reWTA reclustering----------------------------------
+      if(doWTARecluster_){
+        std::vector<fastjet::PseudoJet> candidates;
+        auto daughters = genjet.getJetConstituents();
+        for(auto it = daughters.begin(); it!=daughters.end(); ++it){
+          candidates.push_back(fastjet::PseudoJet((**it).px(), (**it).py(), (**it).pz(), (**it).energy()));
+        }
+        auto cs = new fastjet::ClusterSequence(candidates, WTAjtDef);
+        std::vector<fastjet::PseudoJet> wtajt = fastjet::sorted_by_pt(cs->inclusive_jets(0));
+
+        jets_.WTAgeneta[jets_.ngen] = (wtajt.size() > 0) ? wtajt[0].eta() : -999;
+        jets_.WTAgenphi[jets_.ngen] =  (wtajt.size() > 0) ? wtajt[0].phi_std() : -999;
+        delete cs;
+      }
+      //-------------------------------------------------
 
       // threshold to reduce size of output in minbias PbPb
       if(genjet_pt>genPtMin_){

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -702,8 +702,8 @@ HiInclusiveJetAnalyzer::beginJob() {
 
       //for reWTA reclustering
       if(doWTARecluster_){
-        t->Branch("WTAgeneta",jets_.WTAgeneta,"WTAgeneta[nref]/F");
-        t->Branch("WTAgenphi",jets_.WTAgenphi,"WTAgenphi[nref]/F");
+        t->Branch("WTAgeneta",jets_.WTAgeneta,"WTAgeneta[ngen]/F");
+        t->Branch("WTAgenphi",jets_.WTAgenphi,"WTAgenphi[ngen]/F");
       }
 
       if(doNewJetVars_){


### PR DESCRIPTION
Added option to do WTA reclustering for the jet axis also for the 2018 data processing branch. The changes are otherwise the same as in my previous commit to CMSSW_7_5_8_patch3, but it seems that I do not have to disable calo jets for tests to work in the newer branch. So as all the tests work even without disabling calo jets, I also include those for WTA axis reclustering if the option is enabled.
