### PR TITLE
Fix array size for gen WTA axis

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -707,8 +707,8 @@ HiInclusiveJetAnalyzer::beginJob() {
       //for reWTA reclustering
       // disable for calo jets
       if(doWTARecluster_ && !(jetName_.find("Calo") != std::string::npos)){
-        t->Branch("WTAgeneta",jets_.WTAgeneta,"WTAgeneta[nref]/F");
-        t->Branch("WTAgenphi",jets_.WTAgenphi,"WTAgenphi[nref]/F");
+        t->Branch("WTAgeneta",jets_.WTAgeneta,"WTAgeneta[ngen]/F");
+        t->Branch("WTAgenphi",jets_.WTAgenphi,"WTAgenphi[ngen]/F");
       }
 
       if(doNewJetVars_){


### PR DESCRIPTION
The generator level WTA clustering had accidentally eta and phi array sizes coming from the number of reco jets (nref). The correct size is given by the number of gen jets (ngen).
