### PR TITLE
Bug fix for new heavy jet flavor definition

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -184,10 +184,10 @@ do
                                     echo "${fulltag}patJetsWithBtagging.userData.userInts.src += ['${fulltag}Jets:droppedBranches']" >> $jetseqfile
                                 fi
 
-                                if [[ $sub =~ "Cs" ]]; then
+                                if [[ $sub =~ "Cs" ]] && [ $sample == "mc" ] && [ $reco == "pp" ]; then
 				    echo -e "\n" >> $jetseqfile
-                                    echo "${fulltag}JetAnalyzer.doMatch = cms.untracked.bool(True)" >> $jetseqfile				    
-                                    echo "${fulltag}JetAnalyzer.matchTag = cms.untracked.InputTag(\"ak"${radius}$"patJetsWithBtagging\")" >> $jetseqfile
+                                    echo "${fulltag}JetAnalyzer.matchJets = cms.untracked.bool(True)" >> $jetseqfile				    
+                                    echo "${fulltag}JetAnalyzer.matchTag = cms.untracked.InputTag(\"ak"${radius}$"PFpatJetsWithBtagging\")" >> $jetseqfile
                                 fi
                             done
                         done


### PR DESCRIPTION
Describe the Pull-Request:

This is a bug fix for PR #216 
The new flavor definition was actually inactive after that PR so I didn't realize that there was a misnamed parameter.
Fixed on both counts now. 


Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
