### PR TITLE
fix jet axis being sometimes inverted

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_94X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_94X.py
@@ -48,9 +48,6 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '94X_dataRun2_ReReco_EOY17_v6', '')
 process.HiForest.GlobalTagLabel = process.GlobalTag.globaltag
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_pp5020
-process = overrideJEC_pp5020(process)
-
 #####################################################################################
 # Define tree output
 #####################################################################################
@@ -66,6 +63,12 @@ process.TFileService = cms.Service("TFileService",
 # Jets
 #############################
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_data_cff')
+
+# temporary corrections
+for m in vars(process).values():
+    if (isinstance(m, cms.EDProducer)
+            and m._TypedParameterizable__type == 'JetCorrFactorsProducer'):
+        m.payload = "AK4PF"
 
 #####################################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_MC_94X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_MC_94X.py
@@ -48,9 +48,6 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '94X_mc2017_realistic_forppRef5TeV', '')
 process.HiForest.GlobalTagLabel = process.GlobalTag.globaltag
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_pp5020
-process = overrideJEC_pp5020(process)
-
 #####################################################################################
 # Define tree output
 #####################################################################################
@@ -69,6 +66,12 @@ process.load("HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_mc_cff")
 
 # Use this version for JEC
 # process.load("HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_jec_cff")
+
+# temporary corrections
+for m in vars(process).values():
+    if (isinstance(m, cms.EDProducer)
+            and m._TypedParameterizable__type == 'JetCorrFactorsProducer'):
+        m.payload = "AK4PF"
 
 #####################################################################################
 


### PR DESCRIPTION
use placeholder corrections instead of 2015 pp jet corrections. fixes issue with jet axis sometimes being inverted after applying corrections:

```
root [1] Events->Scan("recoPFJets_ak4PFJets__RECO.obj.eta():recoPFJets_ak4PFJets__RECO.obj.phi()")
***********************************************
*    Row   * Instance * recoPFJet * recoPFJet *
***********************************************
*        0 *        0 * 0.4140011 * 2.2872598 *
*        0 *        1 * -3.492249 * 2.7201185 *
*        0 *        2 * 1.9699994 * 1.9183710 *
***********************************************
```
```
root [2] Events->Scan("patJets_ak4PFpatJetsWithBtagging__HiForest.obj.eta():patJets_ak4PFpatJetsWithBtagging__HiForest.obj.phi()")
***********************************************
*    Row   * Instance * patJets_a * patJets_a *
***********************************************
*        0 *        0 * 3.4922499 * -0.421474 *
*        0 *        1 * -0.414001 * -0.854332 *
*        0 *        2 * -1.969999 * -1.223221 *
***********************************************
```

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@FHead @stepobr 