### PR TITLE
disable njettiness/flavour id for pp calo jets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -86,10 +86,11 @@ do
 			    sed -i 's/\#SUBJETDUMMY_//g' $jetseqfile
 			fi
 
-			sed -i 's/\#ppDummy_//g' $jetseqfile
-			if [ $sample != "data" ]; then
-			    sed -i 's/\#ppDataDummy_//g' $jetseqfile
-			fi
+                        if [ $object != "Calo" ]; then
+                            sed -i 's/\#DISABLE_PPCALO_//g' $jetseqfile
+			else
+			    sed -i 's/\#ENABLE_PPCALO_//g' $jetseqfile
+                        fi
 			# skip no sub
 			if [ $sample == "jec" ]; then
 			    echo "${fulltag}JetAnalyzer.genPtMin = cms.untracked.double(1)" >> $jetseqfile

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/templateSequence_bTag_cff.py.txt
@@ -200,6 +200,9 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer = inclusiveJetAnalyzer.clone(jetTag = c
                                                              doGenTaus = ISMC
                                                             )
 
+#ENABLE_PPCALO_ALGO_SUB_GROOM_RADIUS_OBJECT_patJetsWithBtagging.getJetMCFlavour = False
+#ENABLE_PPCALO_ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer.doExtendedFlavorTagging = False
+
 ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer.trackSelection = ALGO_SUB_GROOM_RADIUS_OBJECT_SecondaryVertexTagInfos.trackSelection
 ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer.trackPairV0Filter = ALGO_SUB_GROOM_RADIUS_OBJECT_SecondaryVertexTagInfos.vertexCuts.v0Filter
 
@@ -218,14 +221,14 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_JetSequence_mc = cms.Sequence(
                                                   #*
                                                   #ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourIdLegacy  # works for PbPb
                                                   #*
-			                          #ppDummy_ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId  # doesn't work for PbPb yet
-                                                  #ppDummy_*
+                                                  #DISABLE_PPCALO_ALGO_SUB_GROOM_RADIUS_OBJECT_PatJetFlavourId  # doesn't work for PbPb yet
+                                                  #DISABLE_PPCALO_*
                                                   ALGO_SUB_GROOM_RADIUS_OBJECT_JetTracksAssociatorAtVertex
                                                   *
                                                   ALGO_SUB_GROOM_RADIUS_OBJECT_JetBtagging
                                                   *
-                                                  #ppDataDummy_ALGO_SUB_GROOM_RADIUS_OBJECT_Njettiness #No constituents for calo jets in pp. Must be removed for pp calo jets but I'm not sure how to do this transparently (Marta)
-                                                  #ppDataDummy_*
+                                                  #DISABLE_PPCALO_ALGO_SUB_GROOM_RADIUS_OBJECT_Njettiness
+                                                  #DISABLE_PPCALO_*
                                                   ALGO_SUB_GROOM_RADIUS_OBJECT_patJetsWithBtagging
                                                   *
                                                   ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer
@@ -239,8 +242,8 @@ ALGO_SUB_GROOM_RADIUS_OBJECT_JetSequence_data = cms.Sequence(ALGO_SUB_GROOM_RADI
                                                     *
                                                     ALGO_SUB_GROOM_RADIUS_OBJECT_JetBtagging
                                                     *
-                                                    #ppDataDummy_ALGO_SUB_GROOM_RADIUS_OBJECT_Njettiness 
-                                                    #ppDataDummy_*
+                                                    #DISABLE_PPCALO_ALGO_SUB_GROOM_RADIUS_OBJECT_Njettiness
+                                                    #DISABLE_PPCALO_*
                                                     ALGO_SUB_GROOM_RADIUS_OBJECT_patJetsWithBtagging
                                                     *
                                                     ALGO_SUB_GROOM_RADIUS_OBJECT_JetAnalyzer


### PR DESCRIPTION
silence warnings (no calo constituents)

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
