### PR TITLE
always use default jecs

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -69,10 +69,8 @@ private:
 
   edm::InputTag   jetTagLabel_;
   edm::EDGetTokenT<std::vector<reco::Vertex> >       vtxTag_;
-  edm::EDGetTokenT<reco::JetView>                    jetTag_;
-  edm::EDGetTokenT<pat::JetCollection>               jetTagPat_;
-  edm::EDGetTokenT<reco::JetView>                    matchTag_;
-  edm::EDGetTokenT<pat::JetCollection>               matchTagPat_;
+  edm::EDGetTokenT<pat::JetCollection>               jetTag_;
+  edm::EDGetTokenT<pat::JetCollection>               matchTag_;
   edm::EDGetTokenT<reco::PFCandidateCollection>      pfCandidateLabel_;
   edm::EDGetTokenT<reco::TrackCollection>            trackTag_;
   edm::EDGetTokenT<reco::GenParticleCollection>      genParticleSrc_;
@@ -100,8 +98,7 @@ private:
   bool verbose_;
   bool doMatch_;
   bool useVtx_;
-  bool useJEC_;
-  bool usePat_;
+  bool useRawPt_;
   bool doTower;
   bool isMC_;
   bool useHepMC_;
@@ -114,7 +111,6 @@ private:
   bool doLifeTimeTagging_;
   bool doLifeTimeTaggingExtras_;
   bool saveBfragments_;
-  bool skipCorrections_;
   bool doExtraCTagging_;
 
   bool doHiJetID_;

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -15,6 +15,7 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     vtxTag = cms.InputTag("hiSelectedVertex"),
     doTower = cms.untracked.bool(False),
     towersSrc = cms.InputTag("towerMaker"),
+    useRawPt = cms.untracked.bool(False),
     useHepMC = cms.untracked.bool(False),
     useQuality = cms.untracked.bool(True),
     doLifeTimeTagging = cms.untracked.bool(False),

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -96,8 +96,11 @@ do
 
                                 if [ $reco == "HI" ] && [ $sub == "Pu" ]; then
                                     corrname=$(echo ${algo} | sed 's/\(.*\)/\U\1/')${sub}${radius}${object}${corrlabel}
-                                else
-                                    corrname=$(echo ${algo} | sed 's/\(.*\)/\U\1/')${radius}${object}${corrlabel}
+				# to be updated with new JECs
+				elif [ $object == "Calo" ]; then
+				    corrname="AK4Calo"
+				else
+				    corrname="AK${radius}${object}"
                                 fi
 
                                 if [ $groom != "NONE" ]; then

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -59,9 +59,6 @@ process.GlobalTag.toGet.extend([
         ),
     ])
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_PbPb5020
-process = overrideJEC_PbPb5020(process)
-
 process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
 process.centralityBin.Centrality = cms.InputTag("hiCentrality")
 process.centralityBin.centralityVariable = cms.string("HFtowers")
@@ -82,20 +79,6 @@ process.TFileService = cms.Service("TFileService",
 #############################
 # jet reco sequence
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pponAA_data_cff')
-# replace above with this one for JEC:
-# process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_JEC_cff')
-
-# temporary
-process.akPu4Calocorr.payload = "AK4Calo"
-process.akPu4PFcorr.payload = "AK4PF"
-process.akCs4PFcorr.payload = "AK4PF"
-process.akFlowPuCs4PFcorr.payload = "AK4PF"
-process.akPu3Calocorr.payload = "AK4Calo"
-process.akPu3PFcorr.payload = "AK3PF"
-process.akCs3PFcorr.payload = "AK3PF"
-process.akFlowPuCs3PFcorr.payload = "AK3PF"
-process.akPu3PFJets.jetPtMin = 1
-process.akPu4PFJets.jetPtMin = 1
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
@@ -60,9 +60,6 @@ process.GlobalTag.toGet.extend([
         ),
     ])
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_PbPb5020
-process = overrideJEC_PbPb5020(process)
-
 process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
 process.centralityBin.Centrality = cms.InputTag("hiCentrality")
 process.centralityBin.centralityVariable = cms.string("HFtowers")
@@ -83,45 +80,6 @@ process.TFileService = cms.Service("TFileService",
 #############################
 # jet reco sequence
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pponAA_JEC_cff')
-
-# temporary (all 4 because its the only correction that loads
-process.ak1Calocorr.payload = "AK4Calo"
-process.akPu1Calocorr.payload = "AK4Calo"
-process.ak1PFcorr.payload = "AK4PF"
-process.akPu1PFcorr.payload = "AK4PF"
-process.akCs1PFcorr.payload = "AK4PF"
-
-process.ak2Calocorr.payload = "AK4Calo"
-process.akPu2Calocorr.payload = "AK4Calo"
-process.ak2PFcorr.payload = "AK4PF"
-process.akPu2PFcorr.payload = "AK4PF"
-process.akCs2PFcorr.payload = "AK4PF"
-
-process.ak3Calocorr.payload = "AK4Calo"
-process.akPu3Calocorr.payload = "AK4Calo"
-process.ak3PFcorr.payload = "AK4PF"
-process.akPu3PFcorr.payload = "AK4PF"
-process.akCs3PFcorr.payload = "AK4PF"
-
-process.ak4Calocorr.payload = "AK4Calo"
-process.akPu4Calocorr.payload = "AK4Calo"
-process.ak4PFcorr.payload = "AK4PF"
-process.akPu4PFcorr.payload = "AK4PF"
-process.akCs4PFcorr.payload = "AK4PF"
-process.akPu4PFJets.jetPtMin = 1
-
-process.ak5Calocorr.payload = "AK4Calo"
-process.akPu5Calocorr.payload = "AK4Calo"
-process.ak5PFcorr.payload = "AK4PF"
-process.akPu5PFcorr.payload = "AK4PF"
-process.akCs5PFcorr.payload = "AK4PF"
-
-process.ak6Calocorr.payload = "AK4Calo"
-process.akPu6Calocorr.payload = "AK4Calo"
-process.ak6PFcorr.payload = "AK4PF"
-process.akPu6PFcorr.payload = "AK4PF"
-process.akCs6PFcorr.payload = "AK4PF"
-
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
@@ -60,9 +60,6 @@ process.GlobalTag.toGet.extend([
         ),
     ])
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_PbPb5020
-process = overrideJEC_PbPb5020(process)
-
 process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
 process.centralityBin.Centrality = cms.InputTag("hiCentrality")
 process.centralityBin.centralityVariable = cms.string("HFtowers")
@@ -83,20 +80,6 @@ process.TFileService = cms.Service("TFileService",
 #############################
 # jet reco sequence
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pponAA_MB_cff')
-# replace above with this one for JEC:
-# process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_JEC_cff')
-
-# temporary
-process.akPu4Calocorr.payload = "AK4Calo"
-process.akPu4PFcorr.payload = "AK4PF"
-process.akCs4PFcorr.payload = "AK4PF"
-process.akFlowPuCs4PFcorr.payload = "AK4PF"
-process.akPu3Calocorr.payload = "AK4Calo"
-process.akPu3PFcorr.payload = "AK3PF"
-process.akCs3PFcorr.payload = "AK3PF"
-process.akFlowPuCs3PFcorr.payload = "AK3PF"
-process.akPu3PFJets.jetPtMin = 1
-process.akPu4PFJets.jetPtMin = 1
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -60,9 +60,6 @@ process.GlobalTag.toGet.extend([
         ),
     ])
 
-from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_PbPb5020
-process = overrideJEC_PbPb5020(process)
-
 process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
 process.centralityBin.Centrality = cms.InputTag("hiCentrality")
 process.centralityBin.centralityVariable = cms.string("HFtowers")
@@ -83,23 +80,6 @@ process.TFileService = cms.Service("TFileService",
 #############################
 # jet reco sequence
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pponAA_MIX_cff')
-# replace above with this one for JEC:
-# process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_JEC_cff')
-
-# temporary
-process.akPu4Calocorr.payload = "AK4Calo"
-process.akPu4PFcorr.payload = "AK4PF"
-process.akCs4PFcorr.payload = "AK4PF"
-process.ak4PFcorr.payload = "AK4PF"
-process.akFlowPuCs4PFcorr.payload = "AK4PF"
-process.akPu3Calocorr.payload = "AK4Calo"
-process.akPu3PFcorr.payload = "AK3PF"
-process.akCs3PFcorr.payload = "AK3PF"
-process.ak3PFcorr.payload = "AK3PF"
-process.akFlowPuCs3PFcorr.payload = "AK3PF"
-process.akPu3PFJets.jetPtMin = 1
-process.akPu4PFJets.jetPtMin = 1
-
 
 process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")


### PR DESCRIPTION
use default jecs when generating configs, to avoid problems with reusing old jecs.
add option "useRawPt", which, if set to true, cuts on rawpt instead of corrected pt.

remove "useJEC" and "usePAT" options, and use the patjet collection instead of loading it twice as different types.

checked that there are no changes to the output

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@FHead @stepobr 