### PR TITLE
Fix typo such that new flavor matching is available for Cs jets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -189,7 +189,7 @@ do
                                     echo "${fulltag}patJetsWithBtagging.userData.userInts.src += ['${fulltag}Jets:droppedBranches']" >> $jetseqfile
                                 fi
 
-                                if [[ $sub =~ "Cs" ]] && [[ $sub =~ "FlowPuCs" ]] && [ $sample == "mc" ] && [ $reco == "pp" ]; then
+                                if [[ $sub =~ "Cs" ]] || [[ $sub =~ "FlowPuCs" ]] && [ $sample == "mc" ] && [ $reco == "pp" ]; then
 				    echo -e "\n" >> $jetseqfile
                                     echo "${fulltag}JetAnalyzer.matchJets = cms.untracked.bool(True)" >> $jetseqfile				    
                                     echo "${fulltag}JetAnalyzer.matchTag = cms.untracked.InputTag(\"ak"${radius}$"PFpatJetsWithBtagging\")" >> $jetseqfile


### PR DESCRIPTION
Describe the Pull-Request:

The new flavor matching for Cs jets wasn't being activated in the default scripts due to a typo

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
