### PR TITLE
JECs from DB for forest configuration (PbPb 2018)

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
@@ -831,6 +831,165 @@ def overrideJEC_pp5020(process):
     if hasattr(process, 'HiForest'):
         process.HiForest.inputLines.extend([process.jec.toGet[6].tag.configValue()]) #pick the ak4PF one to record
     return process
+def overrideJEC_DATA_PbPb5020_2018(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_MC_PbPb5020_2018(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_DATA_pp5020_2017(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_MC_pp5020_2017(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
 
 def overrideJEC_PbPb5020(process):
     process.load("CondCore.CondDB.CondDB_cfi")

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -63,7 +63,7 @@ do
                                 domatch="False"
                                 match=""
                                 eventinfotag="generator"
-                                jetcorrlevels="\'L2Relative\',\'L3Absolute\'"
+                                jetcorrlevels="\'L2Relative\'"
                                 corrlabel="_offline"
 
                                 if [ $reco == "HI" ]; then
@@ -79,10 +79,13 @@ do
                                     doTower="False"
                                 fi
 
-                                if [ $system == "pp" ] && [ $sample == "data" ] \
-                                    && [ $object == "PF" ] && [ $sub == "NONE" ] \
-                                    && [ $radius == 4 ]; then
-                                    jetcorrlevels="\'L2Relative\',\'L3Absolute\',\'L2L3Residual\'"
+                                if ([ $system == "pp" ] || [ $system == "PbPb" ]) \
+                                    && [ $object == "PF" ]; then
+                                    if [ $sample = "data" ]; then
+                                        jetcorrlevels="\'L2Relative\',\'L2L3Residual\'"
+                                    else
+                                        jetcorrlevels="\'L2Relative\'"
+                                    fi
                                 fi
 
                                 if [ $sample != "data" ]; then
@@ -98,7 +101,7 @@ do
                                     corrname=$(echo ${algo} | sed 's/\(.*\)/\U\1/')${sub}${radius}${object}${corrlabel}
 				# to be updated with new JECs
 				elif [ $object == "Calo" ]; then
-				    corrname="AK4Calo"
+				    corrname="AK4PF"
 				else
 				    corrname="AK${radius}${object}"
                                 fi

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -84,6 +84,9 @@ process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
 
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_DATA_PbPb5020_2018
+process = overrideJEC_DATA_PbPb5020_2018(process)
+
 ###############################################################################
 
 ############################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_JEC_103X.py
@@ -85,6 +85,8 @@ process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
 
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_MC_PbPb5020_2018
+process = overrideJEC_MC_PbPb5020_2018(process)
 ###############################################################################
 
 #############################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MB_103X.py
@@ -85,6 +85,8 @@ process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
 
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_MC_PbPb5020_2018
+process = overrideJEC_MC_PbPb5020_2018(process)
 ###############################################################################
 
 #############################

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -85,6 +85,9 @@ process.load('HeavyIonsAnalysis.JetAnalysis.hiFJRhoAnalyzer_cff')
 process.load("HeavyIonsAnalysis.JetAnalysis.pfcandAnalyzer_cfi")
 process.pfcandAnalyzer.doTrackMatching  = cms.bool(True)
 
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_MC_PbPb5020_2018
+process = overrideJEC_MC_PbPb5020_2018(process)
+
 ###############################################################################
 
 #############################

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -162,9 +162,9 @@ JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, cons
   //For PAT jets undo previous jet energy corrections
   const Jet* patjet = dynamic_cast<Jet const *>( &*jet );
   if( patjet ){
-    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy());
+    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy()); corrector->setJetPhi(patjet->correctedP4(0).phi());
   } else {
-    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy());
+    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy()); corrector->setJetPhi(jet->phi());
   }
   if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){
     corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction());

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -296,13 +296,13 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       if(std::find(levels.begin(), levels.end(), "L2L3Residual")!=levels.end()){
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
       }
-      else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
+      else if(std::find(levels.begin(), levels.end(), "L2Relative")!=levels.end()){
+	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2Relative"));
       }
       else{
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
 	if(printWarning_){
-	  edm::LogWarning("L3Absolute not found") << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
+	  edm::LogWarning("L2Relative not found") << "L2L3Residual and L2Relative are not part of the jetCorrFactors\n"
 						  << "of module " <<  jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
 						  << " uncorrected."; printWarning_=false;
 	}


### PR DESCRIPTION
Here's my updates to include new JECs to the forest configuration.
Comments to each commit are minimal but give an idea of what was done.
In makeJetSequences.sh I updated only the part of jet algorithms that are supposed to be used with the current JECs. For Calo jets I temporarily put AK4PF as payload.

Modifications in PhysicsTool/PatAlgos is a temporary solution.

I'll do a separate PR for pp2017 JECs

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@FHead @mandrenguyen @bi-ran 
