### PR TITLE
JECs from DB for forest configuration (pp 2017)

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/CommonFunctions_cff.py
@@ -748,47 +748,6 @@ def overrideJEC_MC_Pbp5020(process):
         ])
     return process
 
-####
-####
-
-def overrideJEC_pPb8TeV(process):
-    process.GlobalTag.toGet.extend([
-## no PU
-       cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4Calo_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AK4Calo_offline")
-             ),
-        cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4PF_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AK4PF_offline")
-             ),
-        cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4PF_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AK3PF_offline")
-             ),
-	cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4Calo_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AKPu4Calo_offline")
-             ),
-        cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4PF_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AKPu4PF_offline")
-	     ),
-        cms.PSet(record = cms.string("JetCorrectionsRecord"),
-                 tag = cms.string("JetCorrectorParametersCollection_pA_80X_8160GeV_v0_AK4PF_offline"),
-                 connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-                 label = cms.untracked.string("AKPu3PF_offline")
-	     )
-    ])
-    return process
-
-####
-####
 
 def overrideJEC_pp5020(process):
     process.load("CondCore.CondDB.CondDB_cfi")
@@ -871,6 +830,165 @@ def overrideJEC_pp5020(process):
     process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
     if hasattr(process, 'HiForest'):
         process.HiForest.inputLines.extend([process.jec.toGet[6].tag.configValue()]) #pick the ak4PF one to record
+    return process
+def overrideJEC_DATA_PbPb5020_2018(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_DATA_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_MC_PbPb5020_2018(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Autumn18_HI_V6_MC_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_DATA_pp5020_2017(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_DATA_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
+    return process
+
+def overrideJEC_MC_pp5020_2017(process):
+    process.load("CondCore.CondDB.CondDB_cfi")
+    process.jec = cms.ESSource("PoolDBESSource",
+                               DBParameters = cms.PSet(
+                                   messageLevel = cms.untracked.int32(0)
+                               ),
+                               timetype = cms.string('runnumber'),
+                               toGet = cms.VPSet(
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK2PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK2PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK3PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK3PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK4PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK4PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK5PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK5PF")
+                                   ),
+                                   cms.PSet(record = cms.string("JetCorrectionsRecord"),
+                                            tag = cms.string("JetCorrectorParametersCollection_Spring18_ppRef5TeV_V4_MC_AK6PF"),
+                                            connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                                            label = cms.untracked.string("AK6PF")
+                                   ),
+                                )
+                            )
+    process.es_prefer_jec = cms.ESPrefer('PoolDBESSource','jec')
+    if hasattr(process, 'HiForest'):
+        process.HiForest.inputLines.extend([process.jec.toGet[2].tag.configValue()]) #pick the ak4PF one to record
     return process
 
 def overrideJEC_PbPb5020(process):

--- a/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
+++ b/HeavyIonsAnalysis/JetAnalysis/python/jets/makeJetSequences.sh
@@ -33,19 +33,22 @@ do
 			doGenSubJets="False"
 			match=""
 			eventinfotag="generator"
-			jetcorrectionlevels="\'L2Relative\',\'L3Absolute\'"
+			jetcorrectionlevels="\'L2Relative\'"
 			genparticles="genParticles"
 
-			if [ $sample == "data" ] && [ $radius == 4 ] && [ $object == "PF" ]; then
-			    jetcorrectionlevels="\'L2Relative\',\'L3Absolute\',\'L2L3Residual\'"
+			if [ $sample == "data" ]; then
+			    jetcorrectionlevels="\'L2Relative\',\'L2L3Residual\'"
 			fi
 
 			if [ $sample == "mc" ] || [ $sample == "jec" ]; then
 			    ismc="True"
 			fi
 
-			corrname=`echo ${algo} | sed 's/\(.*\)/\U\1/'`${radius}${object}${corrlabel}
-
+			if [ $object == "PF" ]; then
+			    corrname="AK${radius}${object}"
+			else
+			    corrname="AK4PF"
+			fi
 			if [ $groom == "SoftDrop" ] || [ $groom == "Filter" ]; then
 			    doSubJets="True"
 			    if [ $sample == "mc" ] && [ $groom == "SoftDrop" ]; then

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_94X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_DATA_94X.py
@@ -64,11 +64,8 @@ process.TFileService = cms.Service("TFileService",
 #############################
 process.load('HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_data_cff')
 
-# temporary corrections
-for m in vars(process).values():
-    if (isinstance(m, cms.EDProducer)
-            and m._TypedParameterizable__type == 'JetCorrFactorsProducer'):
-        m.payload = "AK4PF"
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_DATA_pp5020_2017
+process = overrideJEC_DATA_pp5020_2017(process)
 
 #####################################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_MC_94X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pp_MC_94X.py
@@ -67,12 +67,8 @@ process.load("HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_mc_cff")
 # Use this version for JEC
 # process.load("HeavyIonsAnalysis.JetAnalysis.fullJetSequence_pp_jec_cff")
 
-# temporary corrections
-for m in vars(process).values():
-    if (isinstance(m, cms.EDProducer)
-            and m._TypedParameterizable__type == 'JetCorrFactorsProducer'):
-        m.payload = "AK4PF"
-
+from HeavyIonsAnalysis.Configuration.CommonFunctions_cff import overrideJEC_MC_pp5020_2017  
+process = overrideJEC_MC_pp5020_2017(process)
 #####################################################################################
 
 ############################

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -296,13 +296,13 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       if(std::find(levels.begin(), levels.end(), "L2L3Residual")!=levels.end()){
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2L3Residual"));
       }
-      else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
-	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
+      else if(std::find(levels.begin(), levels.end(), "L2Relative")!=levels.end()){
+	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2Relative"));
       }
       else{
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
 	if(printWarning_){
-	  edm::LogWarning("L3Absolute not found") << "L2L3Residual and L3Absolute are not part of the jetCorrFactors\n"
+	  edm::LogWarning("L2Relative not found") << "L2L3Residual and L2Relative are not part of the jetCorrFactors\n"
 						  << "of module " <<  jetCorrs[0][jetRef].jecSet() << ". Jets will remain"
 						  << " uncorrected."; printWarning_=false;
 	}


### PR DESCRIPTION
Here's the second attempt for JECs in pp 2017.
Unfortunately I still couldn't get rid of PhysicsTools/PatAlgos, otherwise all the patJetsWithBtagging will remain uncorrected.
I removed my modifications about setting jet phi for corrections.

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@FHead, @bi-ran, @mandrenguyen 