### PR TITLE
Filter out PF candidates linked to bad tracks

### DIFF
--- a/RecoHI/HiJetAlgos/plugins/HiBadParticleFilter.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiBadParticleFilter.cc
@@ -1,0 +1,195 @@
+// system include files
+#include <memory>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+
+//
+// class declaration
+//
+
+class HiBadParticleFilter : public edm::global::EDFilter<> {
+public:
+  explicit HiBadParticleFilter(const edm::ParameterSet&);
+  ~HiBadParticleFilter() override;
+
+private:
+  bool filter(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override;
+
+  // ----------member data ---------------------------
+
+  edm::EDGetTokenT<edm::View<reco::PFCandidate> >   tokenPFCandidates_;
+  edm::EDGetTokenT<edm::View<reco::Muon> >   tokenMuons_;
+
+  const bool taggingMode_;
+  const double          minMuonPt_;
+  const double          minChargedHadronPt_;
+  const double          minMuonTrackRelPtErr_;
+  const double          maxMuonSeededDzSig_;
+  const double          maxMuonSeededDxySig_;
+  const double          minCaloCompatibility_;
+  const double          minTrackRelPtErrLoose_;
+  const double          minTrackRelPtErrTight_;
+  const unsigned        minTrackNHitsLoose_;
+  const unsigned        minTrackNHitsTight_;
+};
+
+//
+// constructors and destructor
+//
+HiBadParticleFilter::HiBadParticleFilter(const edm::ParameterSet& iConfig)
+  : tokenPFCandidates_ ( consumes<edm::View<reco::PFCandidate> >(iConfig.getParameter<edm::InputTag> ("PFCandidates")  ))
+  , taggingMode_          ( iConfig.getParameter<bool>    ("taggingMode") )
+  , minMuonPt_            ( iConfig.getParameter<double>  ("minMuonPt") )
+  , minChargedHadronPt_   ( iConfig.getParameter<double>  ("minChargedHadronPt") )
+  , minMuonTrackRelPtErr_ ( iConfig.getParameter<double>  ("minMuonTrackRelPtErr") )
+  , maxMuonSeededDzSig_   ( iConfig.getParameter<double>  ("maxMuonSeededDzSig") )
+  , maxMuonSeededDxySig_  ( iConfig.getParameter<double>  ("maxMuonSeededDxySig") )
+  , minCaloCompatibility_ ( iConfig.getParameter<double>  ("minCaloCompatibility") )
+  , minTrackRelPtErrLoose_( iConfig.getParameter<double>  ("minTrackRelPtErrLoose") )
+  , minTrackRelPtErrTight_( iConfig.getParameter<double>  ("minTrackRelPtErrTight") )
+  , minTrackNHitsLoose_   ( iConfig.getParameter<uint>  ("minTrackNHitsLoose") )
+  , minTrackNHitsTight_   ( iConfig.getParameter<uint>  ("minTrackNHitsTight") )
+{
+  produces<bool>();
+  produces<reco::PFCandidateCollection>();
+}
+
+HiBadParticleFilter::~HiBadParticleFilter() { }
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool
+HiBadParticleFilter::filter(edm::StreamID iID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
+{
+  using namespace std;
+  using namespace edm;
+
+  typedef View<reco::PFCandidate> CandidateView;
+  Handle<CandidateView> pfCandidates;
+  iEvent.getByToken(tokenPFCandidates_,pfCandidates);
+
+  auto pOutputCandidateCollection = std::make_unique<reco::PFCandidateCollection>();
+
+
+  bool foundBadCandidate = false;
+
+
+  for(unsigned j=0;j<pfCandidates->size();++j ) {
+    const reco::PFCandidate & pfCandidate = (*pfCandidates)[j];
+    
+
+    if(abs(pfCandidate.particleId()) == 3)     // muon cleaning    
+      {
+	if(pfCandidate.pt() < minMuonPt_) continue;
+	if(!pfCandidate.muonRef()->isGlobalMuon() || !pfCandidate.muonRef()->isTrackerMuon() || !pfCandidate.trackRef().isNonnull())	
+	  {
+	    foundBadCandidate=true;
+	    break;
+	  }
+	reco::TrackRef track = pfCandidate.trackRef();
+
+	if(track->ptError()/track->pt()>minMuonTrackRelPtErr_){
+	  foundBadCandidate=true;
+	  break;	 
+	}
+	
+	if(track->algo()==13 || track->algo()==14){
+	  double dxySig = fabs(track->dxy());
+	  double dxyErr = track->dxyError();
+	  if(dxyErr>0) dxySig/=dxyErr;
+
+	  double dzSig = fabs(track->dz());
+	  double dzErr = track->dzError();
+	  if(dzErr>0) dzSig/=dzErr;
+
+	  if(dxySig > maxMuonSeededDxySig_ || dzSig > maxMuonSeededDzSig_){
+	    foundBadCandidate=true;
+	    break;	 
+	  }	  	 
+	}
+      }
+    else if(abs(pfCandidate.particleId()) == 1)  //charged hadron cleaning
+      {
+	if(pfCandidate.pt() < minChargedHadronPt_) continue;
+	
+	reco::TrackRef track = pfCandidate.trackRef();
+
+	if(track->algo()==13 || track->algo()==14){
+	  double dxySig = fabs(track->dxy());
+	  double dxyErr = track->dxyError();
+	  if(dxyErr>0) dxySig/=dxyErr;
+	  
+	  double dzSig = fabs(track->dz());
+	  double dzErr = track->dzError();
+	  if(dzErr>0) dzSig/=dzErr;
+	  
+	  if(dxySig > maxMuonSeededDxySig_ || dzSig > maxMuonSeededDzSig_){
+	    foundBadCandidate=true;
+	    break;	 
+	  }	  	 
+	  	  	  
+	}
+
+	double caloEnergy = pfCandidate.ecalEnergy() + pfCandidate.hcalEnergy();
+	unsigned nHits = track->numberOfValidHits();
+	double relError =track->ptError()/track->pt();
+
+	
+	if(caloEnergy < track->p()*minCaloCompatibility_) 	// tight selection if calo incompatible
+	  {
+	    if(relError > minTrackRelPtErrTight_  || nHits < minTrackNHitsTight_ ){
+	      foundBadCandidate=true;
+	      break;	 
+	    }	     
+	}
+	else {
+	    if(relError > minTrackRelPtErrLoose_  || nHits< minTrackNHitsLoose_ ){
+	      foundBadCandidate=true;
+	      break;	 
+	    }	 
+	}
+
+      }
+
+    pOutputCandidateCollection->push_back(pfCandidate);
+
+
+  } // end loop over pf candidates
+
+  bool pass = !foundBadCandidate;
+
+  iEvent.put(std::move(pOutputCandidateCollection) );
+
+  iEvent.put( std::unique_ptr<bool>(new bool(pass)) );
+    
+  return taggingMode_ || pass;
+
+
+}
+
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HiBadParticleFilter);

--- a/RecoHI/HiJetAlgos/python/HiBadParticleFilter_cfi.py
+++ b/RecoHI/HiJetAlgos/python/HiBadParticleFilter_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+filteredParticleFlow = cms.EDFilter(
+    "HiBadParticleFilter",
+    PFCandidates  = cms.InputTag("particleFlow"),   # Collection to test
+    taggingMode   = cms.bool(False),
+    minMuonTrackRelErr = cms.double(2.0),          # minimum ptError/pt on muon best track
+    minMuonPt     = cms.double(10.0),               # minimum muon pt 
+    minChargedHadronPt = cms.double(10.0),
+    minMuonTrackRelPtErr = cms.double(2.),
+    maxMuonSeededDzSig = cms.double(5.),
+    maxMuonSeededDxySig = cms.double(5.),
+    minCaloCompatibility = cms.double(0.2),
+    minTrackRelPtErrTight = cms.double(0.1),
+    minTrackRelPtErrLoose = cms.double(0.3),
+    minTrackNHitsTight = cms.uint32(10),
+    minTrackNHitsLoose = cms.uint32(7),
+)


### PR DESCRIPTION
Describe the Pull-Request:

Added a filter to remove PF charged hadrons and muons that are linked to bad tracks.  
The cuts in applied are highly preliminary and still need to be carefully tested.
This filter is not active by default.  

To execute the filter such that bad candidates are excluded from the jet reconstruction add the following to your forest cfg:
process.load("RecoHI.HiJetAlgos.HiBadParticleFilter_cfi")
and add:
process.filteredParticleFlow+
before 
process.jetSequence +

Then at the bottom of your cfg add:
from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
process = MassReplaceInputTag(process,"particleFlow","filteredParticleFlow")
process.filteredParticleFlow.PFCandidates  = "particleFlow"


Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@abaty 