### PR TITLE
PF isolation variables which exclude the cone, backport to 94X

### DIFF
--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -482,6 +482,23 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    std::vector<float> pfcIso5pTgt3p0subUE_;
    // remove if deemed useless - END
 
+   // photon pf isolation UE-subtracted and cone excluded
+   std::vector<float> pfcIso2subUEec_;
+   std::vector<float> pfcIso3subUEec_;
+   std::vector<float> pfcIso4subUEec_;
+
+   std::vector<float> pfpIso2subUEec_;
+   std::vector<float> pfpIso3subUEec_;
+   std::vector<float> pfpIso4subUEec_;
+
+   std::vector<float> pfnIso2subUEec_;
+   std::vector<float> pfnIso3subUEec_;
+   std::vector<float> pfnIso4subUEec_;
+
+   std::vector<float> pfcIso2pTgt2p0subUEec_;
+   std::vector<float> pfcIso3pTgt2p0subUEec_;
+   std::vector<float> pfcIso4pTgt2p0subUEec_;
+
    // reco::Muon
    Int_t          nMu_;
    std::vector<float>  muPt_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -493,6 +493,23 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps) :
       tree_->Branch("pfcIso3pTgt3p0subUE",&pfcIso3pTgt3p0subUE_);
       tree_->Branch("pfcIso4pTgt3p0subUE",&pfcIso4pTgt3p0subUE_);
       tree_->Branch("pfcIso5pTgt3p0subUE",&pfcIso5pTgt3p0subUE_);
+
+      // photon pf isolation UE-subtracted and cone excluded
+      tree_->Branch("pfcIso2subUEec",&pfcIso2subUEec_);
+      tree_->Branch("pfcIso3subUEec",&pfcIso3subUEec_);
+      tree_->Branch("pfcIso4subUEec",&pfcIso4subUEec_);
+
+      tree_->Branch("pfpIso2subUEec",&pfpIso2subUEec_);
+      tree_->Branch("pfpIso3subUEec",&pfpIso3subUEec_);
+      tree_->Branch("pfpIso4subUEec",&pfpIso4subUEec_);
+
+      tree_->Branch("pfnIso2subUEec",&pfnIso2subUEec_);
+      tree_->Branch("pfnIso3subUEec",&pfnIso3subUEec_);
+      tree_->Branch("pfnIso4subUEec",&pfnIso4subUEec_);
+
+      tree_->Branch("pfcIso2pTgt2p0subUEec",&pfcIso2pTgt2p0subUEec_);
+      tree_->Branch("pfcIso3pTgt2p0subUEec",&pfcIso3pTgt2p0subUEec_);
+      tree_->Branch("pfcIso4pTgt2p0subUEec",&pfcIso4pTgt2p0subUEec_);
     }
   }
 
@@ -934,6 +951,22 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
       pfcIso3pTgt3p0subUE_.clear();
       pfcIso4pTgt3p0subUE_.clear();
       pfcIso5pTgt3p0subUE_.clear();
+
+      pfcIso2subUEec_.clear();
+      pfcIso3subUEec_.clear();
+      pfcIso4subUEec_.clear();
+
+      pfpIso2subUEec_.clear();
+      pfpIso3subUEec_.clear();
+      pfpIso4subUEec_.clear();
+
+      pfnIso2subUEec_.clear();
+      pfnIso3subUEec_.clear();
+      pfnIso4subUEec_.clear();
+
+      pfcIso2pTgt2p0subUEec_.clear();
+      pfcIso3pTgt2p0subUEec_.clear();
+      pfcIso4pTgt2p0subUEec_.clear();
     }
   }
 
@@ -1819,6 +1852,22 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       pfcIso3pTgt3p0subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 3.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
       pfcIso4pTgt3p0subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 3.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
       pfcIso5pTgt3p0subUE_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.5, 0.0, 3.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap));
+
+      pfcIso2subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfcIso3subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfcIso4subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+
+      pfpIso2subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfpIso3subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfpIso4subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::gamma, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+
+      pfnIso2subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.2, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfnIso3subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.3, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfnIso4subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h0, 0.4, 0.0, 0.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+
+      pfcIso2pTgt2p0subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.2, 0.0, 2.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfcIso3pTgt2p0subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.3, 0.0, 2.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
+      pfcIso4pTgt2p0subUEec_.push_back( pfIso.getPfIsoSubUE(*pho, reco::PFCandidate::h, 0.4, 0.0, 2.0, 0, pfIsoCalculator::removePFcand, particlesInIsoMap, true));
     }
 
     //////////////////////////////////// MC matching ////////////////////////////////////

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.cc
@@ -76,7 +76,7 @@ double pfIsoCalculator::getPfIso(const reco::Photon& photon, int pfId,
 
 double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
                                       double r1, double r2, double threshold,
-                                      double jWidth, int footprintRemoval, const std::vector<reco::PFCandidateRef>& particlesInIsoMap)
+                                      double jWidth, int footprintRemoval, const std::vector<reco::PFCandidateRef>& particlesInIsoMap, bool excludeCone)
 {
   double photonEta = photon.eta();
   double photonPhi = photon.phi();
@@ -148,8 +148,15 @@ double pfIsoCalculator::getPfIsoSubUE(const reco::Photon& photon, int pfId,
   areaStrip -= areaInnerCone;
   areaCone -= areaInnerCone;
 
-  double subEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth, footprintRemoval, particlesInIsoMap) - totalEt * (areaCone / areaStrip);
-  return subEt;
+  double coneEt = getPfIso(photon, pfId, r1, r2, threshold, jWidth, footprintRemoval, particlesInIsoMap);
+  double ueEt = totalEt;
+  double ueArea = areaStrip;
+  if (excludeCone) {
+    ueEt = totalEt - coneEt;
+    ueArea = areaStrip - areaCone;
+  }
+
+  return coneEt - ueEt * (areaCone / ueArea);
 }
 
 double pfIsoCalculator::getPfIso(const reco::GsfElectron& ele, int pfId,

--- a/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/src/pfIsoCalculator.h
@@ -19,7 +19,7 @@ class pfIsoCalculator
     bool isInFootprint(const T& footprint, const edm::Ptr<reco::Candidate>& candidate);
 
     double getPfIso(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, const std::vector<reco::PFCandidateRef>& particlesInIsoMap = {});
-    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, const std::vector<reco::PFCandidateRef>& particlesInIsoMap = {});
+    double getPfIsoSubUE(const reco::Photon& photon, int pfId, double r1=0.4, double r2=0.00, double threshold=0, double jWidth=0.0, int footprintRemoval = 0, const std::vector<reco::PFCandidateRef>& particlesInIsoMap = {}, bool excludeCone = false);
 
     double getPfIso(const reco::GsfElectron& ele, int pfId, double r1=0.4, double r2=0.00, double threshold=0);
 


### PR DESCRIPTION
add PF isolation variables where energy inside the isolation cone is excluded from UE estimation
backport of https://github.com/CmsHI/cmssw/pull/259

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

@bi-ran 
