### PR TITLE
Fixed flavor matching for b-jet to use signal event only

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/bTaggers_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/bTaggers_cff.py
@@ -154,7 +154,7 @@ class bTaggers:
 
         self.patJetFlavourIdLegacy = cms.Sequence( self.PatJetPartonAssociationLegacy * self.PatJetFlavourAssociationLegacy)
 
-        self.PatJetPartons = patJetPartons.clone()
+        self.PatJetPartons = patJetPartons.clone(particles = cms.InputTag("hiSignalGenParticles"))
         self.PatJetFlavourAssociation = patJetFlavourAssociation.clone(
             jets = cms.InputTag(jetname+"Jets"),
             rParam = rParam,


### PR DESCRIPTION
Describe the Pull-Request:

The flavor matching used for b-jets was including partons from the underlying hydjet event.
With this fix it uses only the signal event. 

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
