### PR TITLE
Working version of particle level jetID

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -3,6 +3,9 @@
 # Type: Data
 # Input: AOD
 
+# keep disabled by default until fully commissioned
+cleanJets = False
+
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('HiForest')
 
@@ -27,7 +30,7 @@ process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
         "file:/afs/cern.ch/work/r/rbi/public/forest/HIHardProbes_HIRun2018A-PromptReco-v2_AOD.root"
-        ),
+),
     )
 
 # Number of events we want to process, -1 = all events
@@ -170,6 +173,11 @@ process.pfTowerspp.doHF = False
 #https://twiki.cern.ch/twiki/bin/view/CMS/HITracking2018PbPb#Peripheral%20Vertex%20Recovery
 process.load("RecoVertex.PrimaryVertexProducer.OfflinePrimaryVerticesRecovery_cfi")
 
+# clean bad PF candidates
+if cleanJets:
+    process.load("RecoHI.HiJetAlgos.HiBadParticleFilter_cfi")
+    process.pfBadCandAnalyzer = process.pfcandAnalyzer.clone(pfCandidateLabel = cms.InputTag("filteredParticleFlow","cleaned"))
+    process.pfFilter = cms.Path(process.filteredParticleFlow + process.pfBadCandAnalyzer)
 
 #########################
 # Main analysis list
@@ -260,6 +268,11 @@ process.pAna = cms.EndPath(process.skimanalysis)
 from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
 process = MassReplaceInputTag(process,"offlinePrimaryVertices","offlinePrimaryVerticesRecovery")
 process.offlinePrimaryVerticesRecovery.oldVertexLabel = "offlinePrimaryVertices"
+
+if cleanJets == True:
+    from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
+    process = MassReplaceInputTag(process,"particleFlow","filteredParticleFlow")                                                                                                               
+    process.filteredParticleFlow.PFCandidates  = "particleFlow"
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -3,6 +3,10 @@
 # Type: Embedded Monte Carlo
 # Input: AOD
 
+# keep disabled by default until fully commissioned
+cleanJets = False
+
+
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('HiForest')
 
@@ -175,6 +179,13 @@ process.load('HeavyIonsAnalysis.JetAnalysis.rechitanalyzer_cfi')
 #https://twiki.cern.ch/twiki/bin/view/CMS/HITracking2018PbPb#Peripheral%20Vertex%20Recovery
 process.load("RecoVertex.PrimaryVertexProducer.OfflinePrimaryVerticesRecovery_cfi")
 
+# clean bad PF candidates
+if cleanJets:
+    process.load("RecoHI.HiJetAlgos.HiBadParticleFilter_cfi")
+    process.pfBadCandAnalyzer = process.pfcandAnalyzer.clone(pfCandidateLabel = cms.InputTag("filteredParticleFlow","cleaned"))
+    process.pfFilter = cms.Path(process.filteredParticleFlow + process.pfBadCandAnalyzer)
+
+
 #########################
 # Main analysis list
 #########################
@@ -265,5 +276,12 @@ process.pAna = cms.EndPath(process.skimanalysis)
 from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
 process = MassReplaceInputTag(process,"offlinePrimaryVertices","offlinePrimaryVerticesRecovery")
 process.offlinePrimaryVerticesRecovery.oldVertexLabel = "offlinePrimaryVertices"
+
+if cleanJets == True:
+    from HLTrigger.Configuration.CustomConfigs import MassReplaceInputTag
+    process = MassReplaceInputTag(process,"particleFlow","filteredParticleFlow")                                                                                                               
+    process.filteredParticleFlow.PFCandidates  = "particleFlow"
+
+
 # Customization
 ###############################################################################

--- a/RecoHI/HiJetAlgos/python/HiBadParticleFilter_cfi.py
+++ b/RecoHI/HiJetAlgos/python/HiBadParticleFilter_cfi.py
@@ -3,16 +3,15 @@ import FWCore.ParameterSet.Config as cms
 filteredParticleFlow = cms.EDFilter(
     "HiBadParticleFilter",
     PFCandidates  = cms.InputTag("particleFlow"),   # Collection to test
+    offlinePV  = cms.InputTag("offlinePrimaryVertices"),   
     taggingMode   = cms.bool(False),
+    verbose   = cms.bool(False),
     minMuonTrackRelErr = cms.double(2.0),          # minimum ptError/pt on muon best track
-    minMuonPt     = cms.double(10.0),               # minimum muon pt 
-    minChargedHadronPt = cms.double(10.0),
+    minMuonPt     = cms.double(20.0),               # minimum muon pt 
+    minChargedHadronPt = cms.double(20.0),
     minMuonTrackRelPtErr = cms.double(2.),
-    maxMuonSeededDzSig = cms.double(5.),
-    maxMuonSeededDxySig = cms.double(5.),
-    minCaloCompatibility = cms.double(0.2),
-    minTrackRelPtErrTight = cms.double(0.1),
-    minTrackRelPtErrLoose = cms.double(0.3),
-    minTrackNHitsTight = cms.uint32(10),
-    minTrackNHitsLoose = cms.uint32(7),
+    maxSigLoose = cms.double(100.),
+    maxSigTight = cms.double(10.),
+    minCaloCompatibility = cms.double(0.35),
+    minTrackNHits = cms.uint32(10),
 )


### PR DESCRIPTION
Describe the Pull-Request:

Removed bad PF charged hadrons and muons based on track and muon quality variables. 
On MB events removes 98% of badly reconstructed hadrons and muons, while inducing less an energy scale shift of < 0.5% at high pT in MC.    Adds an additional ntuple of PF candidates, containing only removed particles.  There is also a branch in skimanalyzer/HltTree that indicates when at least one particle is removed.
This code is still disactivated by default. 
To activate in the ppOnAA cfgs, simply set 
cleanJets = True 




Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
