### PR TITLE
add hi photon isolation to pat::photon userdata

### DIFF
--- a/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
+++ b/RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h
@@ -88,14 +88,14 @@ public:
   using ValueMapsTags = std::unordered_map<std::string,edm::InputTag>;
   struct electron_config {
     edm::InputTag electron_src;
-    edm::EDGetTokenT<edm::View<pat::Electron> > tok_electron_src;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron> > tok_electron_src;
     ValueMapsTags valuemaps;
     ValueMaps tok_valuemaps;    
   };
 
   struct photon_config {
     edm::InputTag photon_src;
-    edm::EDGetTokenT<edm::View<pat::Photon> > tok_photon_src;
+    edm::EDGetTokenT<edm::View<reco::Photon> > tok_photon_src;
     ValueMapsTags valuemaps;
     ValueMaps tok_valuemaps; 
   };
@@ -175,11 +175,11 @@ setEvent(const edm::Event& evt) {
   ele_idx = pho_idx = 0;
 
   if( !e_conf.tok_electron_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Electron> > eles;
+    edm::Handle<edm::View<reco::GsfElectron> > eles;
     evt.getByToken(e_conf.tok_electron_src,eles);
     
     for( unsigned i = 0; i < eles->size(); ++i ) {
-      edm::Ptr<pat::Electron> ptr = eles->ptrAt(i);
+      edm::Ptr<reco::GsfElectron> ptr = eles->ptrAt(i);
       eles_by_oop[i] = ptr;
     }    
   }
@@ -189,11 +189,11 @@ setEvent(const edm::Event& evt) {
   }
 
   if( !ph_conf.tok_photon_src.isUninitialized() ) {
-    edm::Handle<edm::View<pat::Photon> > phos;
+    edm::Handle<edm::View<reco::Photon> > phos;
     evt.getByToken(ph_conf.tok_photon_src,phos);
 
     for( unsigned i = 0; i < phos->size(); ++i ) {
-      edm::Ptr<pat::Photon> ptr = phos->ptrAt(i);
+      edm::Ptr<reco::Photon> ptr = phos->ptrAt(i);
       phos_by_oop[i] = ptr;
     }
   }
@@ -220,14 +220,14 @@ template<typename MapType,typename OutputType>
 void EGExtraInfoModifierFromValueMaps<MapType,OutputType>::
 setConsumes(edm::ConsumesCollector& sumes) {
   //setup electrons
-  if( !(empty_tag == e_conf.electron_src) ) e_conf.tok_electron_src = sumes.consumes<edm::View<pat::Electron> >(e_conf.electron_src);  
+  if( !(empty_tag == e_conf.electron_src) ) e_conf.tok_electron_src = sumes.consumes<edm::View<reco::GsfElectron> >(e_conf.electron_src);
 
   for( auto itr = e_conf.valuemaps.begin(); itr != e_conf.valuemaps.end(); ++itr ) {
     make_consumes(itr->second,e_conf.tok_valuemaps[itr->first],sumes);
   }
   
   // setup photons 
-  if( !(empty_tag == ph_conf.photon_src) ) ph_conf.tok_photon_src = sumes.consumes<edm::View<pat::Photon> >(ph_conf.photon_src);
+  if( !(empty_tag == ph_conf.photon_src) ) ph_conf.tok_photon_src = sumes.consumes<edm::View<reco::Photon> >(ph_conf.photon_src);
   
   for( auto itr = ph_conf.valuemaps.begin(); itr != ph_conf.valuemaps.end(); ++itr ) {
     make_consumes(itr->second,ph_conf.tok_valuemaps[itr->first],sumes);

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromValueMaps.cc
@@ -1,5 +1,7 @@
 #include "RecoEgamma/EgammaTools/interface/EGExtraInfoModifierFromValueMaps.h"
 
+#include "DataFormats/EgammaCandidates/interface/HIPhotonIsolation.h"
+
 using EGExtraInfoModifierFromFloatValueMaps = EGExtraInfoModifierFromValueMaps<float>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
 		  EGExtraInfoModifierFromFloatValueMaps,
@@ -14,6 +16,11 @@ using EGExtraInfoModifierFromBoolValueMaps = EGExtraInfoModifierFromValueMaps<bo
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
 		  EGExtraInfoModifierFromBoolValueMaps,
 		  "EGExtraInfoModifierFromBoolValueMaps");
+
+using EGExtraInfoModifierFromHIPhotonIsolationValueMaps = EGExtraInfoModifierFromValueMaps<reco::HIPhotonIsolation>;
+DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,
+		  EGExtraInfoModifierFromHIPhotonIsolationValueMaps,
+		  "EGExtraInfoModifierFromHIPhotonIsolationValueMaps");
 
 using EGExtraInfoModifierFromBoolToIntValueMaps = EGExtraInfoModifierFromValueMaps<bool,int>;
 DEFINE_EDM_PLUGIN(ModifyObjectValueFactory,

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -113,6 +113,16 @@ egamma8XLegacyEtScaleSysModifier = cms.PSet(
         )
     )
 
+# modifier for photon isolation used in heavy ions
+egammaHIPhotonIsolationModifier = cms.PSet(
+    modifierName = cms.string('EGExtraInfoModifierFromHIPhotonIsolationValueMaps'),
+    electron_config = cms.PSet(),
+    photon_config = cms.PSet(
+        photonSrc = cms.InputTag("gedPhotons"),
+        photonIsolationHI = cms.InputTag("photonIsolationHIProducerppGED")
+        )
+    )
+
 def appendReducedEgammaEnergyScaleAndSmearingModifier(modifiers):
     modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
 
@@ -123,9 +133,15 @@ def appendEgamma8XLegacyAppendableModifiers (modifiers):
     modifiers.append(reducedEgammaEnergyScaleAndSmearingModifier)
     modifiers.append(egamma8XLegacyEtScaleSysModifier)
 
+def appendEgammaHIPhotonIsolationModifier(modifiers):
+    modifiers.append(egammaHIPhotonIsolationModifier)
+
 from Configuration.Eras.Modifier_run2_miniAOD_94XFall17_cff import run2_miniAOD_94XFall17
 run2_miniAOD_94XFall17.toModify(egamma_modifications,appendReducedEgammaEnergyScaleAndSmearingModifier)
    
 from Configuration.Eras.Modifier_run2_miniAOD_80XLegacy_cff import run2_miniAOD_80XLegacy
 run2_miniAOD_80XLegacy.toModify(egamma_modifications,appendEgamma8XLegacyAppendableModifiers)
 run2_miniAOD_80XLegacy.toModify(egamma_modifications,prependEgamma8XObjectUpdateModifier)
+
+from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
+pp_on_AA_2018.toModify(egamma_modifications, appendEgammaHIPhotonIsolationModifier)


### PR DESCRIPTION
add the info from reco::HIPhotonIsolation to the pat object. the changes from pat:: objects to reco:: objects allow both pat and reco collections to be used as the source.

tested that it can be read out from miniaod: https://github.com/bi-ran/cmssw/commit/8aab3a19e7447baca39f400cae7c74e853861af4

any comments?

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR .
@mandrenguyen @ttrk @innakucher