### PR TITLE
local forest changes to physicstools/patalgos

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -162,9 +162,9 @@ JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, cons
   //For PAT jets undo previous jet energy corrections
   const Jet* patjet = dynamic_cast<Jet const *>( &*jet );
   if( patjet ){
-    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy());
+    corrector->setJetEta(patjet->correctedP4(0).eta()); corrector->setJetPt(patjet->correctedP4(0).pt()); corrector->setJetE(patjet->correctedP4(0).energy()); corrector->setJetPhi(patjet->correctedP4(0).phi());
   } else {
-    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy());
+    corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy()); corrector->setJetPhi(jet->phi());
   }
   if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){
     corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction());

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.cc
@@ -299,6 +299,9 @@ void PATJetProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
       else if(std::find(levels.begin(), levels.end(), "L3Absolute")!=levels.end()){
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L3Absolute"));
       }
+      else if(std::find(levels.begin(), levels.end(), "L2Relative")!=levels.end()){
+	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("L2Relative"));
+      }
       else{
 	ajet.initializeJEC(jetCorrs[0][jetRef].jecLevel("Uncorrected"));
 	if(printWarning_){


### PR DESCRIPTION
add SetJetPhi and remove L3Absolute correction level
commit a328ce12ac99f2edc6cc41e55ce72dc62f35dba1

the changes to PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc are in the master branch of cmssw (https://github.com/cms-sw/cmssw/pull/28096), but need to be backported to 103X.

the changes to PhysicsTools/PatAlgos/plugins/PATJetProducer.cc are not in master cmssw, but they look like they might affect pp and might need changes ..

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@mandrenguyen @stepobr @fhead