### PR TITLE
Packed candidate muon id 103 x mini aod

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PackedCandidateMuonSelectorProducer.cc
@@ -1,0 +1,123 @@
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
+
+namespace pat {
+
+  class PackedCandidateMuonSelectorProducer : public edm::stream::EDProducer<> {
+
+    typedef edm::ValueMap<bool> BoolMap;
+
+    public:
+
+      explicit PackedCandidateMuonSelectorProducer(const edm::ParameterSet & iConfig):
+          muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+          candidateToken_(consumes<edm::View<pat::PackedCandidate> >(iConfig.getParameter<edm::InputTag>("candidates"))),
+          muonSelectors_(iConfig.getParameter<std::vector<std::string> >("muonSelectors")),
+          muonIDs_(iConfig.getParameter<std::vector<std::string> >("muonIDs"))
+      {
+        for (const auto& sel : muonSelectors_) {
+          produces<BoolMap>(sel);
+        }
+        for (const auto& sel : muonIDs_) {
+          muonIDMap_[sel].reset(new StringCutObjectSelector<pat::Muon>("passed('"+sel+"')"));
+          produces<BoolMap>(sel);
+        }
+      }
+      ~PackedCandidateMuonSelectorProducer() override {};
+
+      void produce(edm::Event&, const edm::EventSetup&) override;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    private:
+
+      edm::EDGetTokenT<pat::MuonCollection> muonToken_;
+      edm::EDGetTokenT<edm::View<pat::PackedCandidate> > candidateToken_;
+      std::vector<std::string> muonSelectors_;
+      std::vector<std::string> muonIDs_;
+      std::map<std::string, std::unique_ptr<StringCutObjectSelector<pat::Muon> > > muonIDMap_;
+
+  };
+
+}
+
+void pat::PackedCandidateMuonSelectorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<pat::MuonCollection> muons;
+  edm::Handle<edm::View<pat::PackedCandidate> > candidates;
+
+  iEvent.getByToken(muonToken_, muons);
+  iEvent.getByToken(candidateToken_, candidates);
+
+  const auto& nCand = candidates->size();
+
+  std::map<std::string, std::vector<bool> > muonSelMap;
+  for (const auto& sel : muonSelectors_) {
+    muonSelMap[sel] = std::vector<bool>(nCand, false);
+  }
+  for (const auto& sel : muonIDs_) {
+    muonSelMap[sel] = std::vector<bool>(nCand, false);
+  }
+
+  // loop over muons
+  for (const auto& muon : *muons) {
+    // ignore muons without high purity inner track
+    if (muon.innerTrack().isNull() ||
+        !muon.innerTrack()->quality(reco::TrackBase::qualityByName("highPurity"))) continue;
+
+    // find candidate associated to muon
+    const auto& muonTrack = *muon.innerTrack();
+    for (size_t i = 0; i < nCand; i++) {
+      const auto& cand = candidates->refAt(i);
+      // ignore neutral candidates or without track
+      if (cand->charge()==0 || !cand->hasTrackDetails()) continue;
+
+      // check if candidate and muon are compatible
+      const auto& candTrack = cand->pseudoTrack();
+      if (muonTrack.charge()==candTrack.charge() &&
+          muonTrack.numberOfValidHits()==candTrack.numberOfValidHits() &&
+          std::abs(muonTrack.eta()-candTrack.eta())<1E-3 &&
+          std::abs(muonTrack.phi()-candTrack.phi())<1E-3 &&
+          std::abs((muonTrack.pt()-candTrack.pt())/muonTrack.pt())<1E-2) {
+        // fill muon selector map
+        for (const auto& sel : muonSelectors_) {
+          muonSelMap[sel][i] = muon.muonID(sel);
+        }
+        for (const auto& sel : muonIDs_) {
+          muonSelMap[sel][i] = (*muonIDMap_.at(sel))(muon);
+        }
+        break;
+      }
+    }
+  }
+
+  // fill the value maps
+  for (const auto& s : muonSelMap) {
+    std::unique_ptr<BoolMap> valueMap(new BoolMap());
+    BoolMap::Filler filler(*valueMap);
+    filler.insert(candidates, s.second.begin(), s.second.end());
+    filler.fill();
+    iEvent.put(std::move(valueMap), s.first);
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::PackedCandidateMuonSelectorProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muons", edm::InputTag("patMuons"))->setComment("muon input collection");
+  desc.add<edm::InputTag>("candidates", edm::InputTag("packedPFCandidates"))->setComment("packed candidate input collection");
+  desc.add<std::vector<std::string> >("muonSelectors", {})->setComment("muon selectors");
+  desc.add<std::vector<std::string> >("muonIDs", {})->setComment("muon IDs");
+  descriptions.add("packedPFCandidateMuonID", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(PackedCandidateMuonSelectorProducer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -148,6 +148,7 @@ _pp_on_AA_2018_extraCommands = [
     'keep ZDCDataFramesSorted_castorDigis_*_*',
     'keep QIE10DataFrameHcalDataFrameContainer_hcalDigis_ZDC_*',
     'keep CrossingFramePlaybackInfoNew_mix_*_*',
+    'keep booledmValueMap_*MuonID_*_*',
     #'keep *_heavyIon_*_*',
 ]
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -56,3 +56,8 @@ slimmingTask = cms.Task(
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
+
+from PhysicsTools.PatAlgos.packedPFCandidateMuonID_cfi import packedPFCandidateMuonID
+pp_on_AA_2018.toModify(packedPFCandidateMuonID, muonSelectors = cms.vstring(["AllTrackerMuons", "TMOneStationTight"]), muonIDs = cms.vstring(["SoftCutBasedId"]))
+lostTrackMuonID = packedPFCandidateMuonID.clone(candidates = cms.InputTag("lostTracks"))
+pp_on_AA_2018.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateMuonID, lostTrackMuonID))

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -58,6 +58,6 @@ from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 pp_on_AA_2018.toReplaceWith(slimmingTask, slimmingTask.copyAndExclude([slimmedOOTPhotons]))
 
 from PhysicsTools.PatAlgos.packedPFCandidateMuonID_cfi import packedPFCandidateMuonID
-pp_on_AA_2018.toModify(packedPFCandidateMuonID, muonSelectors = cms.vstring(["AllTrackerMuons", "TMOneStationTight"]), muonIDs = cms.vstring(["SoftCutBasedId"]))
+pp_on_AA_2018.toModify(packedPFCandidateMuonID, muonSelectors = cms.vstring(["AllTrackerMuons", "TMOneStationTight"]))
 lostTrackMuonID = packedPFCandidateMuonID.clone(candidates = cms.InputTag("lostTracks"))
 pp_on_AA_2018.toReplaceWith(slimmingTask, cms.Task(slimmingTask.copy(), packedPFCandidateMuonID, lostTrackMuonID))


### PR DESCRIPTION
Describe the Pull-Request:

This PR creates 3 new boolean value maps for the packedPFCandidates and lostTracks collections: one for isTrackerMuon, one for TMOneStationTight  and one for soft ID.
These value maps can be used to determine which packed candidates are tracker muons or pass the TMOneStationTight or Soft ID conditions. 

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[] Yes
[] No

The PR was tested on 12k events of the Double Muon PD (PbPb 2018). The results show that running over both the packedPFCandidates and lostTracks collection allows to find all high purity muons stored in the reco::Muon collection.

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.

@mandrenguyen 
