### PR TITLE
Including the quality event filters in miniAOD

### DIFF
--- a/HeavyIonsAnalysis/Configuration/python/hfCoincFilter_cff.py
+++ b/HeavyIonsAnalysis/Configuration/python/hfCoincFilter_cff.py
@@ -8,6 +8,11 @@ towersAboveThreshold = cms.EDProducer("CaloTowerCandidateCreator",
     minimumEt = cms.double(0.0),
 )
 
+# make calotowers into candidates with threshold 4
+towersAboveThresholdTh2 = towersAboveThreshold.clone(minimumE=cms.double(2.0))
+towersAboveThresholdTh4 = towersAboveThreshold.clone(minimumE=cms.double(4.0))
+towersAboveThresholdTh5 = towersAboveThreshold.clone(minimumE=cms.double(5.0))
+
 # select HF+ towers above threshold
 hfPosTowers = cms.EDFilter("EtaPtMinCandSelector",
     src = cms.InputTag("towersAboveThreshold"),
@@ -24,6 +29,14 @@ hfNegTowers = cms.EDFilter("EtaPtMinCandSelector",
     etaMax = cms.double(-3.0)
 )
 
+# select HF+/HF- towers above threshold 4 and 5
+hfPosTowersTh2 = hfPosTowers.clone(src=cms.InputTag("towersAboveThresholdTh2"))
+hfNegTowersTh2 = hfNegTowers.clone(src=cms.InputTag("towersAboveThresholdTh2"))
+hfPosTowersTh4 = hfPosTowers.clone(src=cms.InputTag("towersAboveThresholdTh4"))
+hfNegTowersTh4 = hfNegTowers.clone(src=cms.InputTag("towersAboveThresholdTh4"))
+hfPosTowersTh5 = hfPosTowers.clone(src=cms.InputTag("towersAboveThresholdTh5"))
+hfNegTowersTh5 = hfNegTowers.clone(src=cms.InputTag("towersAboveThresholdTh5"))
+
 # require at least one HF+ tower above threshold
 hfPosFilter = cms.EDFilter("CandCountFilter",
     src = cms.InputTag("hfPosTowers"),
@@ -36,23 +49,191 @@ hfNegFilter = cms.EDFilter("CandCountFilter",
     minNumber = cms.uint32(1)
 )
 
+# require at least one HF+/HF- tower above threshold 4
+hfPosFilterTh2 =hfPosFilter.clone(src="hfPosTowersTh2")  
+hfNegFilterTh2 =hfNegFilter.clone(src="hfNegTowersTh2")  
+hfPosFilterTh4 =hfPosFilter.clone(src="hfPosTowersTh4")  
+hfNegFilterTh4 =hfNegFilter.clone(src="hfNegTowersTh4")  
+hfPosFilterTh5 =hfPosFilter.clone(src="hfPosTowersTh5")  
+hfNegFilterTh5 =hfNegFilter.clone(src="hfNegTowersTh5")  
+
 # one HF tower above threshold on each side
-hfCoincFilter = cms.Sequence(
+hfCoincFilterTh3 = cms.Sequence(
     towersAboveThreshold *
     hfPosTowers *
     hfNegTowers *
     hfPosFilter *
     hfNegFilter)
 
+hfCoincFilterTh2 = cms.Sequence(
+    towersAboveThresholdTh2 *
+    hfPosTowersTh2 *
+    hfNegTowersTh2 *
+    hfPosFilterTh2 *
+    hfNegFilterTh2)
 
-# three HF towers above threshold on each side
+hfCoincFilterTh4 = cms.Sequence(
+    towersAboveThresholdTh4 *
+    hfPosTowersTh4 *
+    hfNegTowersTh4 *
+    hfPosFilterTh4 *
+    hfNegFilterTh4)
 
+hfCoincFilterTh5 = cms.Sequence(
+    towersAboveThresholdTh5 *
+    hfPosTowersTh5 *
+    hfNegTowersTh5 *
+    hfPosFilterTh5 *
+    hfNegFilterTh5)
+
+# two HF towers above threshold on each side
+hfPosFilter2 = hfPosFilter.clone(minNumber=cms.uint32(2))
+hfNegFilter2 = hfNegFilter.clone(minNumber=cms.uint32(2))
+hfPosFilter2Th2 = hfPosFilterTh2.clone(minNumber=cms.uint32(2))
+hfNegFilter2Th2 = hfNegFilterTh2.clone(minNumber=cms.uint32(2))
+hfPosFilter2Th4 = hfPosFilterTh4.clone(minNumber=cms.uint32(2))
+hfNegFilter2Th4 = hfNegFilterTh4.clone(minNumber=cms.uint32(2))
+hfPosFilter2Th5 = hfPosFilterTh5.clone(minNumber=cms.uint32(2))
+hfNegFilter2Th5 = hfNegFilterTh5.clone(minNumber=cms.uint32(2))
+
+hfCoincFilter2Th3 = cms.Sequence(
+    towersAboveThreshold *
+    hfPosTowers *
+    hfNegTowers *
+    hfPosFilter2 *
+    hfNegFilter2)
+
+hfCoincFilter2Th2 = cms.Sequence(
+    towersAboveThresholdTh2 *
+    hfPosTowersTh2 *
+    hfNegTowersTh2 *
+    hfPosFilter2Th2 *
+    hfNegFilter2Th2)
+
+hfCoincFilter2Th4 = cms.Sequence(
+    towersAboveThresholdTh4 *
+    hfPosTowersTh4 *
+    hfNegTowersTh4 *
+    hfPosFilter2Th4 *
+    hfNegFilter2Th4)
+
+hfCoincFilter2Th5 = cms.Sequence(
+    towersAboveThresholdTh5 *
+    hfPosTowersTh5 *
+    hfNegTowersTh5 *
+    hfPosFilter2Th5 *
+    hfNegFilter2Th5)
+
+#three HF towers above threshold on each side
 hfPosFilter3 = hfPosFilter.clone(minNumber=cms.uint32(3))
 hfNegFilter3 = hfNegFilter.clone(minNumber=cms.uint32(3))
+hfPosFilter3Th2 = hfPosFilterTh2.clone(minNumber=cms.uint32(3))
+hfNegFilter3Th2 = hfNegFilterTh2.clone(minNumber=cms.uint32(3))
+hfPosFilter3Th4 = hfPosFilterTh4.clone(minNumber=cms.uint32(3))
+hfNegFilter3Th4 = hfNegFilterTh4.clone(minNumber=cms.uint32(3))
+hfPosFilter3Th5 = hfPosFilterTh5.clone(minNumber=cms.uint32(3))
+hfNegFilter3Th5 = hfNegFilterTh5.clone(minNumber=cms.uint32(3))
 
-hfCoincFilter3 = cms.Sequence(
+hfCoincFilter3Th3 = cms.Sequence(
     towersAboveThreshold *
     hfPosTowers *
     hfNegTowers *
     hfPosFilter3 *
     hfNegFilter3)
+
+hfCoincFilter3Th2 = cms.Sequence(
+    towersAboveThresholdTh2 *
+    hfPosTowersTh2 *
+    hfNegTowersTh2 *
+    hfPosFilter3Th2 *
+    hfNegFilter3Th2)
+
+hfCoincFilter3Th4 = cms.Sequence(
+    towersAboveThresholdTh4 *
+    hfPosTowersTh4 *
+    hfNegTowersTh4 *
+    hfPosFilter3Th4 *
+    hfNegFilter3Th4)
+
+hfCoincFilter3Th5 = cms.Sequence(
+    towersAboveThresholdTh5 *
+    hfPosTowersTh5 *
+    hfNegTowersTh5 *
+    hfPosFilter3Th5 *
+    hfNegFilter3Th5)
+
+#four HF towers above threshold on each side
+hfPosFilter4 = hfPosFilter.clone(minNumber=cms.uint32(4))
+hfNegFilter4 = hfNegFilter.clone(minNumber=cms.uint32(4))
+hfPosFilter4Th2 = hfPosFilterTh2.clone(minNumber=cms.uint32(4))
+hfNegFilter4Th2 = hfNegFilterTh2.clone(minNumber=cms.uint32(4))
+hfPosFilter4Th4 = hfPosFilterTh4.clone(minNumber=cms.uint32(4))
+hfNegFilter4Th4 = hfNegFilterTh4.clone(minNumber=cms.uint32(4))
+hfPosFilter4Th5 = hfPosFilterTh5.clone(minNumber=cms.uint32(4))
+hfNegFilter4Th5 = hfNegFilterTh5.clone(minNumber=cms.uint32(4))
+
+hfCoincFilter4Th3 = cms.Sequence(
+    towersAboveThreshold *
+    hfPosTowers *
+    hfNegTowers *
+    hfPosFilter4 *
+    hfNegFilter4)
+
+hfCoincFilter4Th2 = cms.Sequence(
+    towersAboveThresholdTh2 *
+    hfPosTowersTh2 *
+    hfNegTowersTh2 *
+    hfPosFilter4Th2 *
+    hfNegFilter4Th2)
+
+hfCoincFilter4Th4 = cms.Sequence(
+    towersAboveThresholdTh4 *
+    hfPosTowersTh4 *
+    hfNegTowersTh4 *
+    hfPosFilter4Th4 *
+    hfNegFilter4Th4)
+
+hfCoincFilter4Th5 = cms.Sequence(
+    towersAboveThresholdTh5 *
+    hfPosTowersTh5 *
+    hfNegTowersTh5 *
+    hfPosFilter4Th5 *
+    hfNegFilter4Th5)
+
+#five hf towers above threshold on each side
+hfPosFilter5 = hfPosFilter.clone(minNumber=cms.uint32(5))
+hfNegFilter5 = hfNegFilter.clone(minNumber=cms.uint32(5))
+hfPosFilter5Th2 = hfPosFilterTh2.clone(minNumber=cms.uint32(5))
+hfNegFilter5Th2 = hfNegFilterTh2.clone(minNumber=cms.uint32(5))
+hfPosFilter5Th4 = hfPosFilterTh4.clone(minNumber=cms.uint32(5))
+hfNegFilter5Th4 = hfNegFilterTh4.clone(minNumber=cms.uint32(5))
+hfPosFilter5Th5 = hfPosFilterTh5.clone(minNumber=cms.uint32(5))
+hfNegFilter5Th5 = hfNegFilterTh5.clone(minNumber=cms.uint32(5))
+
+hfCoincFilter5Th3 = cms.Sequence(
+    towersAboveThreshold *
+    hfPosTowers *
+    hfNegTowers *
+    hfPosFilter5 *
+    hfNegFilter5)
+
+hfCoincFilter5Th2 = cms.Sequence(
+    towersAboveThresholdTh2 *
+    hfPosTowersTh2 *
+    hfNegTowersTh2 *
+    hfPosFilter5Th2 *
+    hfNegFilter5Th2)
+
+hfCoincFilter5Th4 = cms.Sequence(
+    towersAboveThresholdTh4 *
+    hfPosTowersTh4 *
+    hfNegTowersTh4 *
+    hfPosFilter5Th4 *
+    hfNegFilter5Th4)
+
+hfCoincFilter5Th5 = cms.Sequence(
+    towersAboveThresholdTh5 *
+    hfPosTowersTh5 *
+    hfNegTowersTh5 *
+    hfPosFilter5Th5 *
+    hfNegFilter5Th5)

--- a/HeavyIonsAnalysis/Configuration/test/reMiniAOD_DATA_PAT.py
+++ b/HeavyIonsAnalysis/Configuration/test/reMiniAOD_DATA_PAT.py
@@ -20,6 +20,7 @@ process.load('PhysicsTools.PatAlgos.slimming.metFilterPaths_cff')
 process.load('Configuration.StandardSequences.PAT_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('HeavyIonsAnalysis.Configuration.hfCoincFilter_cff') #add centrality filter cfg file
 
 process.maxEvents = cms.untracked.PSet(
     #input = cms.untracked.int32(100)
@@ -148,11 +149,98 @@ process.Flag_trkPOG_manystripclus53X = cms.Path(~process.manystripclus53X)
 process.Flag_BadPFMuonSummer16Filter = cms.Path(process.BadPFMuonSummer16Filter)
 process.Flag_muonBadTrackFilter = cms.Path(process.muonBadTrackFilter)
 process.Flag_CSCTightHalo2015Filter = cms.Path(process.CSCTightHalo2015Filter)
+#---------------add centrality filters here---------------------
+# make calotowers into candidates
+process.Flag_towersAboveThreshold = cms.Path(process.towersAboveThreshold)
+# make calotowers into candidates with threshold 2, 4 and 5
+process.Flag_towersAboveThresholdTh2 = cms.Path(process.towersAboveThresholdTh2)
+process.Flag_towersAboveThresholdTh4 = cms.Path(process.towersAboveThresholdTh4)
+process.Flag_towersAboveThresholdTh5 = cms.Path(process.towersAboveThresholdTh5)
+# select HF+ towers above threshold
+process.Flag_hfPosTowers = cms.Path(process.hfPosTowers)
+# select HF- towers above threshold
+process.Flag_hfNegTowers = cms.Path(process.hfNegTowers)
+# select HF+/HF- towers above threshold 2, 4 and 5
+process.Flag_hfPosTowersTh2 = cms.Path(process.hfPosTowersTh2)
+process.Flag_hfNegTowersTh2 = cms.Path(process.hfNegTowersTh2)
+process.Flag_hfPosTowersTh4 = cms.Path(process.hfPosTowersTh4)
+process.Flag_hfNegTowersTh4 = cms.Path(process.hfNegTowersTh4)
+process.Flag_hfPosTowersTh5 = cms.Path(process.hfPosTowersTh5)
+process.Flag_hfNegTowersTh5 = cms.Path(process.hfNegTowersTh5)
+# require at least one HF+ tower above threshold
+process.Flag_hfPosFilter = cms.Path(process.hfPosFilter)
+process.Flag_hfNegFilter = cms.Path(process.hfNegFilter)
+# require at least one HF+/HF- tower above threshold 2, 4and 5
+process.Flag_hfPosFilterTh2 = cms.Path(process.hfPosFilterTh2)
+process.Flag_hfNegFilterTh2 = cms.Path(process.hfNegFilterTh2)
+process.Flag_hfPosFilterTh4 = cms.Path(process.hfPosFilterTh4)
+process.Flag_hfNegFilterTh4 = cms.Path(process.hfNegFilterTh4)
+process.Flag_hfPosFilterTh5 = cms.Path(process.hfPosFilterTh5)
+process.Flag_hfNegFilterTh5 = cms.Path(process.hfNegFilterTh5)
+# one HF tower above threshold on each side
+process.Flag_hfCoincFilterTh2 = cms.Path(process.hfCoincFilterTh2)
+process.Flag_hfCoincFilterTh3 = cms.Path(process.hfCoincFilterTh3)
+process.Flag_hfCoincFilterTh4 = cms.Path(process.hfCoincFilterTh4)
+process.Flag_hfCoincFilterTh5 = cms.Path(process.hfCoincFilterTh5)
+# two HF towers above threshold on each side
+process.Flag_hfPosFilter2 = cms.Path(process.hfPosFilter2)
+process.Flag_hfNegFilter2 = cms.Path(process.hfNegFilter2)
+process.Flag_hfPosFilter2Th2 = cms.Path(process.hfPosFilter2Th2)
+process.Flag_hfNegFilter2Th2 = cms.Path(process.hfNegFilter2Th2)
+process.Flag_hfPosFilter2Th4 = cms.Path(process.hfPosFilter2Th4)
+process.Flag_hfNegFilter2Th4 = cms.Path(process.hfNegFilter2Th4)
+process.Flag_hfPosFilter2Th5 = cms.Path(process.hfPosFilter2Th5)
+process.Flag_hfNegFilter2Th5 = cms.Path(process.hfNegFilter2Th5)
+process.Flag_hfCoincFilter2Th2 = cms.Path(process.hfCoincFilter2Th2)
+process.Flag_hfCoincFilter2Th3 = cms.Path(process.hfCoincFilter2Th3)
+process.Flag_hfCoincFilter2Th4 = cms.Path(process.hfCoincFilter2Th4)
+process.Flag_hfCoincFilter2Th5 = cms.Path(process.hfCoincFilter2Th5)
+#three HF towers above threshold on each side
+process.Flag_hfPosFilter3 = cms.Path(process.hfPosFilter3)
+process.Flag_hfNegFilter3 = cms.Path(process.hfNegFilter3)
+process.Flag_hfPosFilter3Th2 = cms.Path(process.hfPosFilter3Th2)
+process.Flag_hfNegFilter3Th2 = cms.Path(process.hfNegFilter3Th2)
+process.Flag_hfPosFilter3Th4 = cms.Path(process.hfPosFilter3Th4)
+process.Flag_hfNegFilter3Th4 = cms.Path(process.hfNegFilter3Th4)
+process.Flag_hfPosFilter3Th5 = cms.Path(process.hfPosFilter3Th5)
+process.Flag_hfNegFilter3Th5 = cms.Path(process.hfNegFilter3Th5)
+process.Flag_hfCoincFilter3Th2 = cms.Path(process.hfCoincFilter3Th2)
+process.Flag_hfCoincFilter3Th3 = cms.Path(process.hfCoincFilter3Th3)
+process.Flag_hfCoincFilter3Th4 = cms.Path(process.hfCoincFilter3Th4)
+process.Flag_hfCoincFilter3Th5 = cms.Path(process.hfCoincFilter3Th5)
+#four HF towers above threshold on each side
+process.Flag_hfPosFilter4 = cms.Path(process.hfPosFilter4)
+process.Flag_hfNegFilter4 = cms.Path(process.hfNegFilter4)
+process.Flag_hfPosFilter4Th2 = cms.Path(process.hfPosFilter4Th2)
+process.Flag_hfNegFilter4Th2 = cms.Path(process.hfNegFilter4Th2)
+process.Flag_hfPosFilter4Th4 = cms.Path(process.hfPosFilter4Th4)
+process.Flag_hfNegFilter4Th4 = cms.Path(process.hfNegFilter4Th4)
+process.Flag_hfPosFilter4Th5 = cms.Path(process.hfPosFilter4Th5)
+process.Flag_hfNegFilter4Th5 = cms.Path(process.hfNegFilter4Th5)
+process.Flag_hfCoincFilter4Th2 = cms.Path(process.hfCoincFilter4Th2)
+process.Flag_hfCoincFilter4Th3 = cms.Path(process.hfCoincFilter4Th3)
+process.Flag_hfCoincFilter4Th4 = cms.Path(process.hfCoincFilter4Th4)
+process.Flag_hfCoincFilter4Th5 = cms.Path(process.hfCoincFilter4Th5)
+#five hf towers above threshold on each side
+process.Flag_hfPosFilter5 = cms.Path(process.hfPosFilter5)
+process.Flag_hfNegFilter5 = cms.Path(process.hfNegFilter5)
+process.Flag_hfPosFilter5Th2 = cms.Path(process.hfPosFilter5Th2)
+process.Flag_hfNegFilter5Th2 = cms.Path(process.hfNegFilter5Th2)
+process.Flag_hfPosFilter5Th4 = cms.Path(process.hfPosFilter5Th4)
+process.Flag_hfNegFilter5Th4 = cms.Path(process.hfNegFilter5Th4)
+process.Flag_hfPosFilter5Th5 = cms.Path(process.hfPosFilter5Th5)
+process.Flag_hfNegFilter5Th5 = cms.Path(process.hfNegFilter5Th5)
+process.Flag_hfCoincFilter5Th2 = cms.Path(process.hfCoincFilter5Th2)
+process.Flag_hfCoincFilter5Th3 = cms.Path(process.hfCoincFilter5Th3)
+process.Flag_hfCoincFilter5Th4 = cms.Path(process.hfCoincFilter5Th4)
+process.Flag_hfCoincFilter5Th5 = cms.Path(process.hfCoincFilter5Th5)
+#---------------------------------------------------------------
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.MINIAODoutput_step = cms.EndPath(process.MINIAODoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilters,process.endjob_step,process.MINIAODoutput_step)
+process.schedule = cms.Schedule(process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilters,process.Flag_towersAboveThreshold,process.Flag_towersAboveThresholdTh2,process.Flag_towersAboveThresholdTh4,process.Flag_towersAboveThresholdTh5,process.Flag_hfPosTowers,process.Flag_hfNegTowers,process.Flag_hfPosTowersTh2,process.Flag_hfNegTowersTh2,process.Flag_hfPosTowersTh4,process.Flag_hfNegTowersTh4,process.Flag_hfPosTowersTh5,process.Flag_hfNegTowersTh5,process.Flag_hfPosFilter,process.Flag_hfNegFilter,process.Flag_hfPosFilterTh2,process.Flag_hfNegFilterTh2,process.Flag_hfPosFilterTh4,process.Flag_hfNegFilterTh4,process.Flag_hfPosFilterTh5,process.Flag_hfNegFilterTh5,process.Flag_hfCoincFilterTh2,process.Flag_hfCoincFilterTh3,process.Flag_hfCoincFilterTh4,process.Flag_hfCoincFilterTh5,process.Flag_hfPosFilter2,process.Flag_hfNegFilter2,process.Flag_hfPosFilter2Th2,process.Flag_hfNegFilter2Th2,process.Flag_hfPosFilter2Th4,process.Flag_hfNegFilter2Th4,process.Flag_hfPosFilter2Th5,process.Flag_hfNegFilter2Th5,process.Flag_hfCoincFilter2Th2,process.Flag_hfCoincFilter2Th3,process.Flag_hfCoincFilter2Th4,process.Flag_hfCoincFilter2Th5,process.Flag_hfPosFilter3,process.Flag_hfNegFilter3,process.Flag_hfPosFilter3Th2,process.Flag_hfNegFilter3Th2,process.Flag_hfPosFilter3Th4,process.Flag_hfNegFilter3Th4,process.Flag_hfPosFilter3Th5,process.Flag_hfNegFilter3Th5,process.Flag_hfCoincFilter3Th2,process.Flag_hfCoincFilter3Th3,process.Flag_hfCoincFilter3Th4,process.Flag_hfCoincFilter3Th5,process.Flag_hfPosFilter4,process.Flag_hfNegFilter4,process.Flag_hfPosFilter4Th2,process.Flag_hfNegFilter4Th2,process.Flag_hfPosFilter4Th4,process.Flag_hfNegFilter4Th4,process.Flag_hfPosFilter4Th5,process.Flag_hfNegFilter4Th5,process.Flag_hfCoincFilter4Th2,process.Flag_hfCoincFilter4Th3,process.Flag_hfCoincFilter4Th4,process.Flag_hfCoincFilter4Th5,process.Flag_hfPosFilter5,process.Flag_hfNegFilter5,process.Flag_hfPosFilter5Th2,process.Flag_hfNegFilter5Th2,process.Flag_hfPosFilter5Th4,process.Flag_hfNegFilter5Th4,process.Flag_hfPosFilter5Th5,process.Flag_hfNegFilter5Th5,process.Flag_hfCoincFilter5Th2,process.Flag_hfCoincFilter5Th3,process.Flag_hfCoincFilter5Th4,process.Flag_hfCoincFilter5Th5,process.endjob_step,process.MINIAODoutput_step)
+
 process.schedule.associate(process.patTask)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)

--- a/HeavyIonsAnalysis/Configuration/test/reMiniAOD_MC_PAT.py
+++ b/HeavyIonsAnalysis/Configuration/test/reMiniAOD_MC_PAT.py
@@ -21,6 +21,9 @@ process.load('PhysicsTools.PatAlgos.slimming.metFilterPaths_cff')
 process.load('Configuration.StandardSequences.PATMC_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('HeavyIonsAnalysis.Configuration.hfCoincFilter_cff') #add centrality filter cfg file
+
+
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
@@ -148,11 +151,98 @@ process.Flag_trkPOG_manystripclus53X = cms.Path(~process.manystripclus53X)
 process.Flag_BadPFMuonSummer16Filter = cms.Path(process.BadPFMuonSummer16Filter)
 process.Flag_muonBadTrackFilter = cms.Path(process.muonBadTrackFilter)
 process.Flag_CSCTightHalo2015Filter = cms.Path(process.CSCTightHalo2015Filter)
+#---------------add centrality filters here---------------------
+# make calotowers into candidates
+process.Flag_towersAboveThreshold = cms.Path(process.towersAboveThreshold)
+# make calotowers into candidates with threshold 2, 4 and 5
+process.Flag_towersAboveThresholdTh2 = cms.Path(process.towersAboveThresholdTh2)
+process.Flag_towersAboveThresholdTh4 = cms.Path(process.towersAboveThresholdTh4)
+process.Flag_towersAboveThresholdTh5 = cms.Path(process.towersAboveThresholdTh5)
+# select HF+ towers above threshold
+process.Flag_hfPosTowers = cms.Path(process.hfPosTowers)
+# select HF- towers above threshold
+process.Flag_hfNegTowers = cms.Path(process.hfNegTowers)
+# select HF+/HF- towers above threshold 2, 4 and 5
+process.Flag_hfPosTowersTh2 = cms.Path(process.hfPosTowersTh2)
+process.Flag_hfNegTowersTh2 = cms.Path(process.hfNegTowersTh2)
+process.Flag_hfPosTowersTh4 = cms.Path(process.hfPosTowersTh4)
+process.Flag_hfNegTowersTh4 = cms.Path(process.hfNegTowersTh4)
+process.Flag_hfPosTowersTh5 = cms.Path(process.hfPosTowersTh5)
+process.Flag_hfNegTowersTh5 = cms.Path(process.hfNegTowersTh5)
+# require at least one HF+ tower above threshold
+process.Flag_hfPosFilter = cms.Path(process.hfPosFilter)
+process.Flag_hfNegFilter = cms.Path(process.hfNegFilter)
+# require at least one HF+/HF- tower above threshold 2, 4and 5
+process.Flag_hfPosFilterTh2 = cms.Path(process.hfPosFilterTh2)
+process.Flag_hfNegFilterTh2 = cms.Path(process.hfNegFilterTh2)
+process.Flag_hfPosFilterTh4 = cms.Path(process.hfPosFilterTh4)
+process.Flag_hfNegFilterTh4 = cms.Path(process.hfNegFilterTh4)
+process.Flag_hfPosFilterTh5 = cms.Path(process.hfPosFilterTh5)
+process.Flag_hfNegFilterTh5 = cms.Path(process.hfNegFilterTh5)
+# one HF tower above threshold on each side
+process.Flag_hfCoincFilterTh2 = cms.Path(process.hfCoincFilterTh2)
+process.Flag_hfCoincFilterTh3 = cms.Path(process.hfCoincFilterTh3)
+process.Flag_hfCoincFilterTh4 = cms.Path(process.hfCoincFilterTh4)
+process.Flag_hfCoincFilterTh5 = cms.Path(process.hfCoincFilterTh5)
+# two HF towers above threshold on each side
+process.Flag_hfPosFilter2 = cms.Path(process.hfPosFilter2)
+process.Flag_hfNegFilter2 = cms.Path(process.hfNegFilter2)
+process.Flag_hfPosFilter2Th2 = cms.Path(process.hfPosFilter2Th2)
+process.Flag_hfNegFilter2Th2 = cms.Path(process.hfNegFilter2Th2)
+process.Flag_hfPosFilter2Th4 = cms.Path(process.hfPosFilter2Th4)
+process.Flag_hfNegFilter2Th4 = cms.Path(process.hfNegFilter2Th4)
+process.Flag_hfPosFilter2Th5 = cms.Path(process.hfPosFilter2Th5)
+process.Flag_hfNegFilter2Th5 = cms.Path(process.hfNegFilter2Th5)
+process.Flag_hfCoincFilter2Th2 = cms.Path(process.hfCoincFilter2Th2)
+process.Flag_hfCoincFilter2Th3 = cms.Path(process.hfCoincFilter2Th3)
+process.Flag_hfCoincFilter2Th4 = cms.Path(process.hfCoincFilter2Th4)
+process.Flag_hfCoincFilter2Th5 = cms.Path(process.hfCoincFilter2Th5)
+#three HF towers above threshold on each side
+process.Flag_hfPosFilter3 = cms.Path(process.hfPosFilter3)
+process.Flag_hfNegFilter3 = cms.Path(process.hfNegFilter3)
+process.Flag_hfPosFilter3Th2 = cms.Path(process.hfPosFilter3Th2)
+process.Flag_hfNegFilter3Th2 = cms.Path(process.hfNegFilter3Th2)
+process.Flag_hfPosFilter3Th4 = cms.Path(process.hfPosFilter3Th4)
+process.Flag_hfNegFilter3Th4 = cms.Path(process.hfNegFilter3Th4)
+process.Flag_hfPosFilter3Th5 = cms.Path(process.hfPosFilter3Th5)
+process.Flag_hfNegFilter3Th5 = cms.Path(process.hfNegFilter3Th5)
+process.Flag_hfCoincFilter3Th2 = cms.Path(process.hfCoincFilter3Th2)
+process.Flag_hfCoincFilter3Th3 = cms.Path(process.hfCoincFilter3Th3)
+process.Flag_hfCoincFilter3Th4 = cms.Path(process.hfCoincFilter3Th4)
+process.Flag_hfCoincFilter3Th5 = cms.Path(process.hfCoincFilter3Th5)
+#four HF towers above threshold on each side
+process.Flag_hfPosFilter4 = cms.Path(process.hfPosFilter4)
+process.Flag_hfNegFilter4 = cms.Path(process.hfNegFilter4)
+process.Flag_hfPosFilter4Th2 = cms.Path(process.hfPosFilter4Th2)
+process.Flag_hfNegFilter4Th2 = cms.Path(process.hfNegFilter4Th2)
+process.Flag_hfPosFilter4Th4 = cms.Path(process.hfPosFilter4Th4)
+process.Flag_hfNegFilter4Th4 = cms.Path(process.hfNegFilter4Th4)
+process.Flag_hfPosFilter4Th5 = cms.Path(process.hfPosFilter4Th5)
+process.Flag_hfNegFilter4Th5 = cms.Path(process.hfNegFilter4Th5)
+process.Flag_hfCoincFilter4Th2 = cms.Path(process.hfCoincFilter4Th2)
+process.Flag_hfCoincFilter4Th3 = cms.Path(process.hfCoincFilter4Th3)
+process.Flag_hfCoincFilter4Th4 = cms.Path(process.hfCoincFilter4Th4)
+process.Flag_hfCoincFilter4Th5 = cms.Path(process.hfCoincFilter4Th5)
+#five hf towers above threshold on each side
+process.Flag_hfPosFilter5 = cms.Path(process.hfPosFilter5)
+process.Flag_hfNegFilter5 = cms.Path(process.hfNegFilter5)
+process.Flag_hfPosFilter5Th2 = cms.Path(process.hfPosFilter5Th2)
+process.Flag_hfNegFilter5Th2 = cms.Path(process.hfNegFilter5Th2)
+process.Flag_hfPosFilter5Th4 = cms.Path(process.hfPosFilter5Th4)
+process.Flag_hfNegFilter5Th4 = cms.Path(process.hfNegFilter5Th4)
+process.Flag_hfPosFilter5Th5 = cms.Path(process.hfPosFilter5Th5)
+process.Flag_hfNegFilter5Th5 = cms.Path(process.hfNegFilter5Th5)
+process.Flag_hfCoincFilter5Th2 = cms.Path(process.hfCoincFilter5Th2)
+process.Flag_hfCoincFilter5Th3 = cms.Path(process.hfCoincFilter5Th3)
+process.Flag_hfCoincFilter5Th4 = cms.Path(process.hfCoincFilter5Th4)
+process.Flag_hfCoincFilter5Th5 = cms.Path(process.hfCoincFilter5Th5)
+#---------------------------------------------------------------
 process.endjob_step = cms.EndPath(process.endOfProcess)
 process.MINIAODSIMoutput_step = cms.EndPath(process.MINIAODSIMoutput)
 
 # Schedule definition
-process.schedule = cms.Schedule(process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilters,process.endjob_step,process.MINIAODSIMoutput_step)
+process.schedule = cms.Schedule(process.Flag_HBHENoiseFilter,process.Flag_HBHENoiseIsoFilter,process.Flag_CSCTightHaloFilter,process.Flag_CSCTightHaloTrkMuUnvetoFilter,process.Flag_CSCTightHalo2015Filter,process.Flag_globalTightHalo2016Filter,process.Flag_globalSuperTightHalo2016Filter,process.Flag_HcalStripHaloFilter,process.Flag_hcalLaserEventFilter,process.Flag_EcalDeadCellTriggerPrimitiveFilter,process.Flag_EcalDeadCellBoundaryEnergyFilter,process.Flag_ecalBadCalibFilter,process.Flag_goodVertices,process.Flag_eeBadScFilter,process.Flag_ecalLaserCorrFilter,process.Flag_trkPOGFilters,process.Flag_chargedHadronTrackResolutionFilter,process.Flag_muonBadTrackFilter,process.Flag_BadChargedCandidateFilter,process.Flag_BadPFMuonFilter,process.Flag_BadChargedCandidateSummer16Filter,process.Flag_BadPFMuonSummer16Filter,process.Flag_trkPOG_manystripclus53X,process.Flag_trkPOG_toomanystripclus53X,process.Flag_trkPOG_logErrorTooManyClusters,process.Flag_METFilters,process.Flag_towersAboveThreshold,process.Flag_towersAboveThresholdTh2,process.Flag_towersAboveThresholdTh4,process.Flag_towersAboveThresholdTh5,process.Flag_hfPosTowers,process.Flag_hfNegTowers,process.Flag_hfPosTowersTh2,process.Flag_hfNegTowersTh2,process.Flag_hfPosTowersTh4,process.Flag_hfNegTowersTh4,process.Flag_hfPosTowersTh5,process.Flag_hfNegTowersTh5,process.Flag_hfPosFilter,process.Flag_hfNegFilter,process.Flag_hfPosFilterTh2,process.Flag_hfNegFilterTh2,process.Flag_hfPosFilterTh4,process.Flag_hfNegFilterTh4,process.Flag_hfPosFilterTh5,process.Flag_hfNegFilterTh5,process.Flag_hfCoincFilterTh2,process.Flag_hfCoincFilterTh3,process.Flag_hfCoincFilterTh4,process.Flag_hfCoincFilterTh5,process.Flag_hfPosFilter2,process.Flag_hfNegFilter2,process.Flag_hfPosFilter2Th2,process.Flag_hfNegFilter2Th2,process.Flag_hfPosFilter2Th4,process.Flag_hfNegFilter2Th4,process.Flag_hfPosFilter2Th5,process.Flag_hfNegFilter2Th5,process.Flag_hfCoincFilter2Th2,process.Flag_hfCoincFilter2Th3,process.Flag_hfCoincFilter2Th4,process.Flag_hfCoincFilter2Th5,process.Flag_hfPosFilter3,process.Flag_hfNegFilter3,process.Flag_hfPosFilter3Th2,process.Flag_hfNegFilter3Th2,process.Flag_hfPosFilter3Th4,process.Flag_hfNegFilter3Th4,process.Flag_hfPosFilter3Th5,process.Flag_hfNegFilter3Th5,process.Flag_hfCoincFilter3Th2,process.Flag_hfCoincFilter3Th3,process.Flag_hfCoincFilter3Th4,process.Flag_hfCoincFilter3Th5,process.Flag_hfPosFilter4,process.Flag_hfNegFilter4,process.Flag_hfPosFilter4Th2,process.Flag_hfNegFilter4Th2,process.Flag_hfPosFilter4Th4,process.Flag_hfNegFilter4Th4,process.Flag_hfPosFilter4Th5,process.Flag_hfNegFilter4Th5,process.Flag_hfCoincFilter4Th2,process.Flag_hfCoincFilter4Th3,process.Flag_hfCoincFilter4Th4,process.Flag_hfCoincFilter4Th5,process.Flag_hfPosFilter5,process.Flag_hfNegFilter5,process.Flag_hfPosFilter5Th2,process.Flag_hfNegFilter5Th2,process.Flag_hfPosFilter5Th4,process.Flag_hfNegFilter5Th4,process.Flag_hfPosFilter5Th5,process.Flag_hfNegFilter5Th5,process.Flag_hfCoincFilter5Th2,process.Flag_hfCoincFilter5Th3,process.Flag_hfCoincFilter5Th4,process.Flag_hfCoincFilter5Th5,process.endjob_step,process.MINIAODSIMoutput_step)
+
 process.schedule.associate(process.patTask)
 from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)


### PR DESCRIPTION
Dear all, 

This PR includes the heavy ion event filters in the miniAOD workflow. 

First, i updated the filters for the newest version which includes 72 filters in total. 
See HeavyIonsAnalysis/Configuration/python/hfCoincFilter_cff.py

In order to store the filter, I've included the filters as "cms.Path". This schema is used for MET filters and this are saved as "triggers" [1]. This was included at HeavyIonsAnalysis/Configuration/test/reMiniAOD_MC_PAT.py for MC and HeavyIonsAnalysis/Configuration/test/reMiniAOD_DATA_PAT.py for data. At the end, this process increases the size of miniAOD in ~11 bytes per event and basically there is no timing difference. 

Tests comparing miniAOD and AOD was made, and the result of the application of the filters are exactly the same in both. For example, using hfCoincFilter2Th4 filter, both AOD and miniAOD has 5723 passed events and 1237 failed events (total events: 6960 for MB sample). Also, the number of tracks removed for both AOD (generalTracks with highPurity and pT > 0.5 GeV) and miniAOD (packedPFcandidates) was exactly the same: 142.
 
You can find details of this studies in the presentation [2].

@mandrenguyen @YeonjuGo @pjwinnetou

Best,

Dener Lemos

[1]
https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2017#ETmiss_filters

[2] https://twiki.cern.ch/twiki/pub/CMS/HiCentrality2020/centrality_filter_in_miniAOD_12_05_2020.pdf 