### PR TITLE
restore jet collections/use dummy inputs

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -145,9 +145,7 @@ _pp_on_AA_2018_extraCommands = [
     'keep *_hiFJRhoProducer_*_*',
     'keep *_hiFJRhoFlowModulationProducer_*_*',
     'keep *_hiPuRhoProducer_*_*',
-    'keep patJets_patJetsakFlowPuCs*_*_*',
-    'keep *_patJetsakFlowPuCs*_pfCandidates_*',
-    'keep *_patJetsakFlowPuCs*_tagInfos_*',
+    'keep *_slimmedJets_pfCandidates_*',
     'keep *_zdcreco_*_*',
     'keep ZDCDataFramesSorted_hcalDigis_*_*',
     'keep ZDCDataFramesSorted_castorDigis_*_*',
@@ -156,19 +154,11 @@ _pp_on_AA_2018_extraCommands = [
     'keep booledmValueMap_*MuonID_*_*',
     'keep floatedmValueMap_*TrackChi2_*_*',
     'keep patPackedCandidates_hipixeltracks_*_*',
-    'drop *_slimmedJetsAK8_*_*',
-    'drop *_slimmedJetsAK8PFPuppiSoftDropPacked_SubJets_*',
-    'drop *_slimmedJetsPuppi_*_*',
-    'drop *_slimmedMETsPuppi_*_*',
 ]
 
 _pp_on_AA_2018_extraCommandsGEN = [
     'keep *_heavyIon_*_*',
     'keep recoBasicJets_*HiGenJets_*_*',
-    'drop *_slimmedGenJets__*',
-    'drop *_slimmedGenJetsFlavourInfos_*_*',
-    'drop *_slimmedGenJetsAK8__*',
-    'drop *_slimmedGenJetsAK8SoftDropSubJets__*',
 ]
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -527,12 +527,38 @@ def miniAOD_customizeHeavyIon(process, data):
     from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJetSetup import aliasFlowPuCsJets, removeL1FastJetJECs, removeJECsForMC, addJECsForData
     from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
     pp_on_AA_2018.toModify(process.slimmedJets, src = 'selectedPatJets')
+
+    pp_on_AA_2018.toModify(process.ak8PFJetsPuppi, src = 'pfNoPileUpJMEHI')
+    pp_on_AA_2018.toModify(process.patJetsAK8Puppi, jetSource = 'ak8PFJetsPuppi')
+    pp_on_AA_2018.toModify(process.slimmedJetsAK8, src = 'patJetsAK8Puppi')
+
+    pp_on_AA_2018.toModify(process.ak4PFJetsPuppi, src = 'pfNoPileUpJMEHI')
+    pp_on_AA_2018.toModify(process.patJetsPuppi, jetSource = 'ak4PFJetsPuppi')
+    pp_on_AA_2018.toModify(process.slimmedJetsPuppi, src = 'patJetsPuppi')
+
+    pp_on_AA_2018.toModify(process.slimmedJetsAK8PFPuppiSoftDropPacked, jetSrc = 'patJetsAK8Puppi', subjetSrc = 'patJetsAK8Puppi')
+
     pp_on_AA_2018.toModify(process, func = lambda proc: removeL1FastJetJECs(proc))
     pp_on_AA_2018.toModify(process, func = lambda proc:
 	aliasFlowPuCsJets(proc, 'akFlowPuCs4PF'))
 
     modifyJECs = addJECsForData if data is True else removeJECsForMC
     pp_on_AA_2018.toModify(process, func = lambda proc: modifyJECs(proc))
+
+    pp_on_AA_2018.toModify(process.pfMetPuppi, src = 'pfNoPileUpJMEHI')
+    pp_on_AA_2018.toModify(process.patMETsPuppi, computeMETSignificance = False, metSource = 'pfMetPuppi')
+    pp_on_AA_2018.toModify(process.slimmedMETsPuppi,
+        chsMET = 'patMETsPuppi',
+        rawVariation = 'patMETsPuppi',
+        t01Variation = 'patMETsPuppi',
+        t1SmearedVarsAndUncs = 'patMETsPuppi',
+        t1Uncertainties = 'patMETsPuppi',
+        tXYUncForRaw = 'patMETsPuppi',
+        tXYUncForT01 = 'patMETsPuppi',
+        tXYUncForT01Smear = 'patMETsPuppi',
+        tXYUncForT1 = 'patMETsPuppi',
+        tXYUncForT1Smear = 'patMETsPuppi',
+        trkMET = 'patMETsPuppi')
 
 def miniAOD_customizeAllData(process):
     miniAOD_customizeCommon(process)

--- a/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/boostedHPSPFTaus_cff.py
@@ -36,7 +36,6 @@ from Configuration.Eras.Modifier_pp_on_XeXe_2017_cff import pp_on_XeXe_2017
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018
 for e in [pp_on_XeXe_2017, pp_on_AA_2018]:
     e.toModify(ca8PFJetsCHSprunedForBoostedTaus, inputEtMin = 999999.0)
-    e.toModify(ca8PFJetsCHSprunedForBoostedTaus, src = cms.InputTag("particleFlow"))
 
 boostedTauSeeds = cms.EDProducer("BoostedTauSeedsProducer",
     subjetSrc = cms.InputTag('ca8PFJetsCHSprunedForBoostedTaus', 'subJetsForSeedingBoostedTaus'),


### PR DESCRIPTION
restore the event content, and instead use dummy inputs for fat/puppi jets. the dummy collection 'pfNoPileUpJMEHI' is the same one used in the reco sequence [1]. i also tried to cut out as many modules in these sequences as possible.

i undid the change in RecoTauTag, now that the 'pfNoPileUpJMEHI' collection is available in the pat sequence as well.

the changes to the size of the collections, ran over 100 events of the hard probes file listed on the twiki:

`slimmedMETsPuppi :     0.234 >     0.043 |   -0.191 [ -81.7%]`
`slimmedJetsPuppi :    19.717 >     0.971 |  -18.746 [ -95.1%]`
`slimmedJetsAK8 :     0.025 >     0.025 |    0.000 [   0.0%]`
`slimmedJetsAK8PFPuppiSoftDropPacked:SubJets :     0.029 >     0.029 |    0.000 [   0.0%]`

for some reason the AK8 jets are already negligible in size, but i did not look into this.

@mandrenguyen @stepobr 

1) https://github.com/cms-sw/cmssw/pull/24655