### PR TITLE
slimming of hi-style gen jets

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -78,6 +78,8 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
     auto mapping = std::make_unique<std::vector<int> >();
     mapping->reserve(src->size());
 
+    int32_t count = 0;
+
     unsigned nl = 0; // number of loose jets
     for (View<reco::GenJet>::const_iterator it = src->begin(), ed = src->end(); it != ed; ++it) {
 
@@ -96,7 +98,7 @@ pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSet
         out->push_back(*it);
         reco::GenJet & jet = out->back();
 
-        mapping->push_back(it-src->begin());
+        mapping->push_back(count++);
 
 
         if (clearDaughters_) {

--- a/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersHeavyIons/heavyIonJets_cff.py
@@ -29,6 +29,12 @@ signalGenJetsTask = cms.Task(
     signalPartons,
     )
 
+from RecoHI.HiJetAlgos.jetFlavourPlaceholder_cfi import jetFlavourPlaceholder
+
+slimmedGenJetsFlavourPlaceholder = jetFlavourPlaceholder.clone(
+    jets = 'ak4HiGenJets',
+    )
+
 from RecoHI.HiJetAlgos.HiRecoPFJets_cff import PFTowers, pfNoPileUpJMEHI, ak4PFJetsForFlow
 from RecoHI.HiJetAlgos.hiPFCandCleaner_cfi import hiPFCandCleaner
 from RecoHI.HiJetAlgos.hiFJRhoFlowModulationProducer_cfi import hiFJRhoFlowModulationProducer
@@ -50,4 +56,5 @@ recoJetsHIpostAODTask = cms.Task(
     allPartons,
     cleanedGenJetsTask,
     signalGenJetsTask,
+    slimmedGenJetsFlavourPlaceholder,
     )

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -158,7 +158,6 @@ _pp_on_AA_2018_extraCommands = [
 
 _pp_on_AA_2018_extraCommandsGEN = [
     'keep *_heavyIon_*_*',
-    'keep recoBasicJets_*HiGenJets_*_*',
 ]
 
 from Configuration.Eras.Modifier_pp_on_AA_2018_cff import pp_on_AA_2018

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -540,6 +540,8 @@ def miniAOD_customizeHeavyIon(process, data):
 
     if data is False:
         pp_on_AA_2018.toModify(process.slimmedGenJets, src = 'ak4HiGenJets')
+        pp_on_AA_2018.toModify(process.slimmedGenJetsFlavourPlaceholder, jets = 'ak4HiGenJets')
+        pp_on_AA_2018.toModify(process.slimmedGenJetsFlavourInfos, genJets = 'ak4HiGenJets', genJetFlavourInfos = 'slimmedGenJetsFlavourPlaceholder')
         pp_on_AA_2018.toModify(process.slimmedGenJetsAK8, cut = 'pt>9999', nLoose = 0)
         pp_on_AA_2018.toModify(process.slimmedGenJetsAK8SoftDropSubJets, cut = 'pt>9999', nLoose = 0)
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -538,6 +538,11 @@ def miniAOD_customizeHeavyIon(process, data):
 
     pp_on_AA_2018.toModify(process.slimmedJetsAK8PFPuppiSoftDropPacked, jetSrc = 'patJetsAK8Puppi', subjetSrc = 'patJetsAK8Puppi')
 
+    if data is False:
+        pp_on_AA_2018.toModify(process.slimmedGenJets, src = 'ak4HiGenJets')
+        pp_on_AA_2018.toModify(process.slimmedGenJetsAK8, cut = 'pt>9999', nLoose = 0)
+        pp_on_AA_2018.toModify(process.slimmedGenJetsAK8SoftDropSubJets, cut = 'pt>9999', nLoose = 0)
+
     pp_on_AA_2018.toModify(process, func = lambda proc: removeL1FastJetJECs(proc))
     pp_on_AA_2018.toModify(process, func = lambda proc:
 	aliasFlowPuCsJets(proc, 'akFlowPuCs4PF'))

--- a/RecoHI/HiJetAlgos/plugins/JetFlavourPlaceholder.cc
+++ b/RecoHI/HiJetAlgos/plugins/JetFlavourPlaceholder.cc
@@ -1,0 +1,84 @@
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
+#include "SimDataFormats/JetMatching/interface/JetFlavourInfo.h"
+#include "SimDataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// class declaration
+//
+
+class JetFlavourPlaceholder : public edm::stream::EDProducer<> {
+public:
+  explicit JetFlavourPlaceholder(edm::ParameterSet const&);
+  ~JetFlavourPlaceholder() override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<edm::View<reco::Jet>> jetsToken_;
+};
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+JetFlavourPlaceholder::JetFlavourPlaceholder(const edm::ParameterSet& iConfig)
+    : jetsToken_(consumes<edm::View<reco::Jet>>(iConfig.getParameter<edm::InputTag>("jets"))) {
+  // register your products
+  produces<reco::JetFlavourInfoMatchingCollection>();
+}
+
+JetFlavourPlaceholder::~JetFlavourPlaceholder() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+}
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void JetFlavourPlaceholder::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<edm::View<reco::Jet>> jets;
+  iEvent.getByToken(jetsToken_, jets);
+
+  auto jetFlavourInfos = std::make_unique<reco::JetFlavourInfoMatchingCollection>(reco::JetRefBaseProd(jets));
+
+  for (size_t i = 0; i < jets->size(); ++i) {
+    (*jetFlavourInfos)[jets->refAt(i)] = reco::JetFlavourInfo();
+  }
+
+  iEvent.put(std::move(jetFlavourInfos));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void JetFlavourPlaceholder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(JetFlavourPlaceholder);

--- a/RecoHI/HiJetAlgos/python/jetFlavourPlaceholder_cfi.py
+++ b/RecoHI/HiJetAlgos/python/jetFlavourPlaceholder_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+jetFlavourPlaceholder = cms.EDProducer(
+    'JetFlavourPlaceholder',
+    jets = cms.InputTag('ak4HiGenJets'),
+    )

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.cc
@@ -39,7 +39,6 @@ SubEventGenJetProducer::SubEventGenJetProducer(edm::ParameterSet const& conf):
    ignoreHydro_ = conf.getUntrackedParameter<bool>("ignoreHydro", true);
 
    if (signalOnly_) ignoreHydro_ = false;
-   produces<reco::BasicJetCollection>();
   // the subjet collections are set through the config file in the "jetCollInstanceName" field.
 
    input_cand_token_ = consumes<reco::CandidateView>(src_);
@@ -108,8 +107,7 @@ void SubEventGenJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& i
 
    ////////////////
 
-   auto jets = std::make_unique<std::vector<GenJet>>();
-   subJets_ = jets.get();
+   jets_ = std::make_unique<std::vector<GenJet>>();
 
    LogDebug("VirtualJetProducer") << "Inputted towers\n";
 
@@ -126,7 +124,7 @@ void SubEventGenJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& i
    //Finalize
    LogDebug("SubEventJetProducer") << "Wrote jets\n";
 
-   iEvent.put(std::move(jets));  
+   iEvent.put(std::move(jets_));
    return;
 }
 
@@ -166,7 +164,7 @@ void SubEventGenJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup 
     jet.setJetArea (jetArea);
     jet.setPileup (pu);
     
-    subJets_->push_back(jet);
+    jets_->push_back(jet);
    }   
 }
 

--- a/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
+++ b/RecoJets/JetProducers/plugins/SubEventGenJetProducer.h
@@ -10,6 +10,7 @@
 
  ************************************************************/
 
+#include <memory>
 #include <vector>
 #include "RecoJets/JetProducers/plugins/VirtualJetProducer.h"
 #include "DataFormats/JetReco/interface/GenJetCollection.h"
@@ -30,7 +31,7 @@ namespace cms
     
   protected:
    std::vector<std::vector<fastjet::PseudoJet> > subInputs_;
-   std::vector<reco::GenJet>* subJets_;
+   std::unique_ptr<std::vector<reco::GenJet>> jets_;
    std::vector<int> hydroTag_;
    std::vector<int> nSubParticles_;
    bool signalOnly_;


### PR DESCRIPTION
modify the `slimmedJets` collections to use hi-style gen jets as input, and add a very high threshold pt cut to the ak8 gen jets to effectively zero them.

for the `slimmedGenJetsFlavourInfos` collection, i made a simple module to store some dummy flavour information. the existing module reclusters the gen jets using all gen particles instead of using particles only from one sub-event, which leads to mismatches that abort the module.

i also had to fix a bug in PATGenJetSlimmer.cc, where the offset of the original collection was being saved and later used to access the contents of the slimmed collection, causing out-of-bounds errors. this bug doesn't show up with the default settings in pp because the gen jets are sorted by pt, and the selection is 'pt > N', so it is always the first few jets that are selected. the problem shows up for our gen jets because we loop over multiple sub-events and so it's possible that the indices of the selected jets are larger than the final number of selected jets.

the other change is to remove an extra `produces<reco::BasicJetCollection>()` in SubEventGenJetProducer.cc, which was causing an empty `BasicJetCollection` with exactly the same label as the `GenJetCollection` to be produced. this causes problems in later modules because modules that use `edm::View<reco::Jet>` to access jets cannot identify the correct collection to use.

`slimmedGenJets :    11.459 >     0.778 |  -10.681 [ -93.2%]`
`slimmedGenJetsFlavourInfos :     0.972 >     0.088 |   -0.884 [ -91.0%]`
`slimmedGenJetsAK8 :     6.075 >     0.026 |   -6.049 [ -99.6%]`
`slimmedGenJetsAK8SoftDropSubJets :     6.193 >     0.028 |   -6.164 [ -99.5%]`

@mandrenguyen @stepobr 