### PR TITLE
fix 'ak4PFJetsForFlow' collection

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -45,15 +45,18 @@ akPu4PFJets = akPu5PFJets.clone(rParam       = cms.double(0.4), puPtMin = 20)
 akPu6PFJets = akPu5PFJets.clone(rParam       = cms.double(0.6), puPtMin = 30)
 akPu7PFJets = akPu5PFJets.clone(rParam       = cms.double(0.7), puPtMin = 35)
 
-ak4PFJetsForFlow = akPu5PFJets.clone(
-    Ghost_EtaMax = cms.double(5.0),
-    Rho_EtaMax = cms.double(4.4),
-    doRhoFastjet = cms.bool(False),
-    jetPtMin = cms.double(15.0),
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+
+ak4PFJetsForFlow = ak4PFJets.clone(
+    Ghost_EtaMax = 5.0,
+    Rho_EtaMax = 4.4,
+    doRhoFastjet = False,
+    inputEtMin = 0.0,
+    jetPtMin = 15.0,
     nSigmaPU = cms.double(1.0),
-    rParam = cms.double(0.4),
+    rParam = 0.4,
     radiusPU = cms.double(0.5),
-    src = cms.InputTag("pfcandCleaner", "particleFlowCleaned"),
+    src = "hiPFCandCleaner:particleFlowCleaned",
 )
 
 kt4PFJetsForRho = cms.EDProducer(

--- a/RecoHI/HiJetAlgos/python/hiFJRhoFlowModulationProducer_cfi.py
+++ b/RecoHI/HiJetAlgos/python/hiFJRhoFlowModulationProducer_cfi.py
@@ -7,7 +7,7 @@ hiFJRhoFlowModulationProducer = cms.EDProducer(
     doFreePlaneFit = cms.bool(False),
     doEvtPlane = cms.bool(False),
     doFlatTest = cms.bool(False),
-    jetTag = cms.InputTag("ak4PFJets"),
+    jetTag = cms.InputTag("ak4PFJetsForFlow"),
     EvtPlane = cms.InputTag("hiEvtPlane"),
     evtPlaneLevel = cms.int32(0)
     )


### PR DESCRIPTION
fix the parameters for the 'ak4PFJetsForFlow' collection, and set it as the default input for the flow modulation producer, as was originally intended.

this collection is not used with the default options, so it does not change the output. i checked that this module runs properly when enabled after the fix.

thanks @stepobr for checking and pointing this out.

@mandrenguyen 