### PR TITLE
bug fix for flow cs

### DIFF
--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -168,8 +168,8 @@ void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescripti
   desc.add<double>("csRParam",-1.);
   desc.add<double>("csAlpha",2.);
   desc.add<bool> ("useModulatedRho", false);
-  desc.add<double> ("minFlowChi2Prob", false);
-  desc.add<double> ("maxFlowChi2Prob", false);
+  desc.add<double> ("minFlowChi2Prob", 0.05);
+  desc.add<double> ("maxFlowChi2Prob", 0.95);
 
   desc.add<edm::InputTag>("etaMap",edm::InputTag("hiFJRhoProducer","mapEtaEdges") );
   desc.add<edm::InputTag>("rho",edm::InputTag("hiFJRhoProducer","mapToRho") );


### PR DESCRIPTION
This is a bug fix for flow cs algorithm.
Unfortunately the two parameters `minFlowChi2Prob` and `maxFlowChi2Prob` had no default values, that led to skipping the whole flow part. The values assigned are the same used by Chris in his analysis.

@mandrenguyen @FHead
