### PR TITLE
activate particle cleaner

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_DATA_103X.py
@@ -3,8 +3,7 @@
 # Type: Data
 # Input: AOD
 
-# keep disabled by default until fully commissioned
-cleanJets = False
+cleanJets = True
 
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('HiForest')

--- a/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
+++ b/HeavyIonsAnalysis/JetAnalysis/test/runForestAOD_pponAA_MIX_103X.py
@@ -3,9 +3,7 @@
 # Type: Embedded Monte Carlo
 # Input: AOD
 
-# keep disabled by default until fully commissioned
-cleanJets = False
-
+cleanJets = True
 
 import FWCore.ParameterSet.Config as cms
 process = cms.Process('HiForest')


### PR DESCRIPTION
Describe the Pull-Request:

Cleaning for bad particles was implemented in the forest about a year ago, but has been inactive by default. 
This PR activates it by default. 
The cleaning is appropriate for validation of the miniAOD, as the cleaning has been included in miniAOD. 

I will merged this PR tomorrow unless anyone objects. 
I've been using the cleaning for a while now and haven't found any issue. 
The final performance was presented here:
https://twiki.cern.ch/twiki/pub/CMS/HiHighPt2019/JetReco_MAN_291710.pdf


Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@FHead @stepobr 