### PR TITLE
set useHF = True for PFTowers

### DIFF
--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -7,7 +7,7 @@ from RecoHI.HiJetAlgos.HiPFJetParameters_cff import *
 #pseudo towers for noise suppression background subtraction
 PFTowers = cms.EDProducer("ParticleTowerProducer",
                           src = cms.InputTag("particleFlow"),
-                          useHF = cms.bool(False)
+                          useHF = cms.bool(True)
                           )
 
 #dummy sequence to speed-up reconstruction in pp_on_AA era


### PR DESCRIPTION
Set useHF = True for PFTowers. This is already True in 11_2_X and it's better to have the same setting in 10_3_X. This eliminates an excess in jets in the forward region, due to the fact that if set to `False` `HiPuRhoProducer` doesn't subtract anything in that region. 

@mandrenguyen @FHead