### PR TITLE
Fix ieta mapping for HF particles

### DIFF
--- a/RecoHI/HiJetAlgos/interface/ParticleTowerProducer.h
+++ b/RecoHI/HiJetAlgos/interface/ParticleTowerProducer.h
@@ -59,7 +59,7 @@ class ParticleTowerProducer : public edm::EDProducer {
   static const double etatow[];
   static const double etacent[];
   double etaedge[42];
-  
+  static constexpr int ietaMax = 42;  
   
  
   

--- a/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
+++ b/RecoHI/HiJetAlgos/src/ParticleTowerProducer.cc
@@ -212,15 +212,15 @@ void ParticleTowerProducer::resetTowers(edm::Event& iEvent,const edm::EventSetup
 int ParticleTowerProducer::eta2ieta(double eta) const {
   // binary search in the array of towers eta edges
 
-  int ieta = 0;
-
-  while(fabs(eta) > etaedge[ieta]){
-    ++ieta;  
+  int ieta = 1;
+  double xeta = fabs(eta);
+  while (xeta > etaedge[ieta] && ieta < ietaMax - 1) {
+    ++ieta;
   }
 
-  if(eta < 0) ieta = -ieta;
+  if (eta < 0)
+    ieta = -ieta;
   return ieta;
-
 }
 
 int ParticleTowerProducer::phi2iphi(double phi, int ieta) const {


### PR DESCRIPTION
Describe the Pull-Request:

In #305 we enabled the PFTower maker for the HF, such that UE subtraction can be run on forward jets, as done in cmssw.
This causes a rare crash, due to a bug in the eta to ieta mapping, that was fixed in cmssw (https://github.com/cms-sw/cmssw/pull/31595), but not in the forest
This PR propagates this fix back to the 10_3_X AOD forest.
No change is expected or central rapidity jets. 

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
