### PR TITLE
option to run deepCSV

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -133,6 +133,35 @@ process.forest = cms.Path(
 
 #customisation
 
+
+addCandidateTagging = False
+
+if addCandidateTagging:
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+    
+    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+    updateJetCollection(
+        process,
+        jetSource = cms.InputTag('slimmedJets'),
+        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+        btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
+        btagPrefix = 'TEST',
+    )
+    
+    process.updatedPatJets.addJetCorrFactors = False
+    process.updatedPatJets.discriminatorSources = cms.VInputTag(
+        cms.InputTag('pfDeepCSVJetTags:probb'),
+        cms.InputTag('pfDeepCSVJetTags:probc'),
+        cms.InputTag('pfDeepCSVJetTags:probudsg'),
+        cms.InputTag('pfDeepCSVJetTags:probbb'),
+    )
+    
+    process.akCs4PFJetAnalyzer.jetTag = "updatedPatJets"
+
+    process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
+
+    process.akCs4PFJetAnalyzer.addDeepCSV = True
+
 #########################
 # Event Selection -> add the needed filters here
 #########################

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -48,12 +48,12 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic_hi'
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 process.GlobalTag.toGet.extend([
-    cms.PSet(
-        record = cms.string("BTagTrackProbability3DRcd"),
-        tag = cms.string("JPcalib_Data103X_2018PbPb_v1"),
-        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-        )
-    ])
+    cms.PSet(record = cms.string("BTagTrackProbability3DRcd"),
+             tag = cms.string("JPcalib_MC103X_2018PbPb_v4"),                                                                                                                                      connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
+             
+         )
+])
+
 
 ###############################################################################
 
@@ -100,6 +100,36 @@ process.forest = cms.Path(
     process.ggHiNtuplizer +
     process.akCs4PFJetAnalyzer
     )
+
+
+
+addCandidateTagging = False
+
+if addCandidateTagging:
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+    
+    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+    updateJetCollection(
+        process,
+        jetSource = cms.InputTag('slimmedJets'),
+        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+        btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
+        btagPrefix = 'TEST',
+    )
+    
+    process.updatedPatJets.addJetCorrFactors = False
+    process.updatedPatJets.discriminatorSources = cms.VInputTag(
+        cms.InputTag('pfDeepCSVJetTags:probb'),
+        cms.InputTag('pfDeepCSVJetTags:probc'),
+        cms.InputTag('pfDeepCSVJetTags:probudsg'),
+        cms.InputTag('pfDeepCSVJetTags:probbb'),
+    )
+    
+    process.akCs4PFJetAnalyzer.jetTag = "updatedPatJets"
+
+    process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
+
+    process.akCs4PFJetAnalyzer.addDeepCSV = True
 
 #customisation
 #process.akCs4PFJetAnalyzer.doLifeTimeTagging = False

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -92,6 +92,7 @@ private:
   bool doSubEvent_;
   double genPtMin_;
   bool doLifeTimeTagging_;
+  bool addDeepCSV_;
 
   bool doHiJetID_;
   bool doStandardJetID_;
@@ -117,6 +118,7 @@ private:
   std::string simpleSVHighEffBJetTags_;
   std::string simpleSVHighPurBJetTags_;
   std::string combinedSVV2BJetTags_;
+  std::string deepCSVJetTags_;
 
   static const int MAXJETS = 1000;
   static const int MAXTRACKS = 5000;
@@ -253,8 +255,8 @@ private:
     int matchedHadronFlavor[MAXJETS]={0};
     int matchedPartonFlavor[MAXJETS]={0};
 
-    float discr_csvV1[MAXJETS]={0};
     float discr_csvV2[MAXJETS]={0};
+    float discr_deepCSV[MAXJETS]={0};
     float discr_muByIp3[MAXJETS]={0};
     float discr_muByPt[MAXJETS]={0};
     float discr_prob[MAXJETS]={0};

--- a/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import pfImpactParameterTagInfos
+pfImpactParameterTagInfos.jets = "slimmedJets"
+pfImpactParameterTagInfos.candidates = "packedPFCandidates"
+pfImpactParameterTagInfos.primaryVertex = "offlineSlimmedPrimaryVerticesRecovery"
+from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import pfSecondaryVertexTagInfos
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateVertexFinder
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexMerger
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexArbitrator
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateSecondaryVertices
+from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import pfInclusiveSecondaryVertexFinderTagInfos
+inclusiveCandidateVertexFinder.primaryVertices  = "offlineSlimmedPrimaryVerticesRecovery"
+inclusiveCandidateVertexFinder.tracks= "packedPFCandidates"
+candidateVertexArbitrator.tracks = "packedPFCandidates"
+candidateVertexArbitrator.primaryVertices = "offlineSlimmedPrimaryVerticesRecovery"
+from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
+from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
+
+
+# this one is needed for training
+from PhysicsTools.PatAlgos.slimming.slimmedSecondaryVertices_cfi import slimmedSecondaryVertices
+
+candidateBtagging = cms.Sequence(
+    pfImpactParameterTagInfos +
+    pfSecondaryVertexTagInfos +
+    inclusiveCandidateVertexFinder +
+    candidateVertexMerger +
+    candidateVertexArbitrator +
+    inclusiveCandidateSecondaryVertices +
+    pfInclusiveSecondaryVertexFinderTagInfos +
+    pfDeepCSVTagInfos + 
+    pfDeepCSVJetTags
+)

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -19,6 +19,7 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     useHepMC = cms.untracked.bool(False),
     useQuality = cms.untracked.bool(True),
     doLifeTimeTagging = cms.untracked.bool(True),
+    addDeepCSV = cms.untracked.bool(False),
     doGenTaus = cms.untracked.bool(False),
     doGenSym = cms.untracked.bool(False),
     doSubJets = cms.untracked.bool(False),

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -76,6 +76,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
   useRawPt_ = iConfig.getUntrackedParameter<bool>("useRawPt", true);
 
   doLifeTimeTagging_ = iConfig.getUntrackedParameter<bool>("doLifeTimeTagging", true);
+  addDeepCSV_ = iConfig.getUntrackedParameter<bool>("addDeepCSV", false);
 
   pfCandidateLabel_ =
       consumes<edm::View<pat::PackedCandidate>>(iConfig.getUntrackedParameter<edm::InputTag>("pfCandidateLabel"));
@@ -92,6 +93,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
     simpleSVHighEffBJetTags_ = "simpleSecondaryVertexHighEffBJetTags";
     simpleSVHighPurBJetTags_ = "simpleSecondaryVertexHighPurBJetTags";
     combinedSVV2BJetTags_ = "combinedSecondaryVertexV2BJetTags";
+    deepCSVJetTags_ = "pfDeepCSVJetTags:probb";
   }
 
   doSubEvent_ = false;
@@ -245,9 +247,8 @@ void HiInclusiveJetAnalyzer::beginJob() {
   if (doLifeTimeTagging_) {
     t->Branch("discr_ssvHighEff", jets_.discr_ssvHighEff, "discr_ssvHighEff[nref]/F");
     t->Branch("discr_ssvHighPur", jets_.discr_ssvHighPur, "discr_ssvHighPur[nref]/F");
-
-    t->Branch("discr_csvV1", jets_.discr_csvV1, "discr_csvV1[nref]/F");
     t->Branch("discr_csvV2", jets_.discr_csvV2, "discr_csvV2[nref]/F");
+    if(addDeepCSV_)t->Branch("discr_deepCSV", jets_.discr_deepCSV, "discr_deepCSV[nref]/F");
     t->Branch("discr_muByIp3", jets_.discr_muByIp3, "discr_muByIp3[nref]/F");
     t->Branch("discr_muByPt", jets_.discr_muByPt, "discr_muByPt[nref]/F");
     t->Branch("discr_prob", jets_.discr_prob, "discr_prob[nref]/F");
@@ -389,6 +390,7 @@ void HiInclusiveJetAnalyzer::beginJob() {
   if (doLifeTimeTagging_) {
     /* clear arrays */
     memset(jets_.discr_csvV2, 0, MAXJETS * sizeof(float));
+    if(addDeepCSV_) memset(jets_.discr_deepCSV, 0, MAXJETS * sizeof(float));
     memset(jets_.discr_muByIp3, 0, MAXJETS * sizeof(float));
     memset(jets_.discr_muByPt, 0, MAXJETS * sizeof(float));
     memset(jets_.discr_prob, 0, MAXJETS * sizeof(float));
@@ -486,6 +488,7 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
       jets_.discr_ssvHighEff[jets_.nref] = jet.bDiscriminator(simpleSVHighEffBJetTags_);
       jets_.discr_ssvHighPur[jets_.nref] = jet.bDiscriminator(simpleSVHighPurBJetTags_);
       jets_.discr_csvV2[jets_.nref] = jet.bDiscriminator(combinedSVV2BJetTags_);
+      if(addDeepCSV_)jets_.discr_deepCSV[jets_.nref]=jet.bDiscriminator(deepCSVJetTags_);
       jets_.discr_prob[jets_.nref] = jet.bDiscriminator(jetPBJetTags_);
       jets_.discr_probb[jets_.nref] = jet.bDiscriminator(jetBPBJetTags_);
       jets_.discr_tcHighEff[jets_.nref] = jet.bDiscriminator(trackCHEBJetTags_);


### PR DESCRIPTION
I have added a flag in the forest cfgs called addCandidateTagging, which is set to False by default.
If you enable it, you will run fill the deepCSV discriminator, which uses the default pp training for now.
It needs to run the inclusiveVertexFinder, which is slow.  That's why it's disabled by default. 