### PR TITLE
Add option to recluster jets to miniAOD forest

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -3,7 +3,9 @@
 # Type: data
 
 import FWCore.ParameterSet.Config as cms
-process = cms.Process('HiForest')
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
+process = cms.Process('HiForest', Run2_2018_pp_on_AA,run2_miniAOD_pp_on_AA_103X)
 
 ###############################################################################
 
@@ -132,6 +134,21 @@ process.forest = cms.Path(
     )
 
 #customisation
+
+addR3Jets = False
+
+if addR3Jets :
+    process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
+    from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
+    
+    process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
+        jetTag = "akCs3PFpatJets",
+    )
+    
+    process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
+
+
 
 
 addCandidateTagging = True

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -1,15 +1,17 @@
 ### HiForest Configuration
 # Input: miniAOD
-# Type: mc
+# Type: data
 
 import FWCore.ParameterSet.Config as cms
-process = cms.Process('HiForest')
+from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
+from Configuration.ProcessModifiers.run2_miniAOD_pp_on_AA_103X_cff import run2_miniAOD_pp_on_AA_103X
+process = cms.Process('HiForest', Run2_2018_pp_on_AA,run2_miniAOD_pp_on_AA_103X)
 
 ###############################################################################
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, mc")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, data")
 
 # import subprocess, os
 # version = subprocess.check_output(
@@ -24,9 +26,11 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, mc")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        "/store/relval/CMSSW_11_2_0/RelValPyquen_DiJet_pt80to120_2760GeV_2021/MINIAODSIM/PU_112X_mcRun3_2021_realistic_HI_v13-v1/10000/192f6a7f-b549-49e2-b353-fde88b9b78ce.root"
-        ),
-    )
+        "file:/afs/cern.ch/work/m/mnguyen/public/devel/forest/CMSSW_11_2_0_pre9/src/HeavyIonsAnalysis/Configuration/test/step2_PAT.root"
+    ), 
+)
+#input file produced from:
+#"file:/afs/cern.ch/work/r/rbi/public/forest/HIHardProbes_HIRun2018A-PromptReco-v2_AOD.root"
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
@@ -44,67 +48,106 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic_hi', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data_promptlike_hi', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
+
+centralityTag = "CentralityTable_HFtowers200_DataPbPb_periHYDJETshape_run2v1031x02_offline"
+process.HiForestInfo.info.append(centralityTag)
+
+print('\n')
+print('\033[31m~*~ CENTRALITY TABLE FOR 2018 PBPB DATA ~*~\033[0m')
+print('\033[36m~*~ TAG: ' + centralityTag + ' ~*~\033[0m')
+print('\n')
 process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 process.GlobalTag.toGet.extend([
-    cms.PSet(record = cms.string("BTagTrackProbability3DRcd"),
-             tag = cms.string("JPcalib_MC103X_2018PbPb_v4"),                                                                                                                                      connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")
-             
-         )
-])
+    cms.PSet(
+        record = cms.string("HeavyIonRcd"),
+        tag = cms.string(centralityTag),
+        label = cms.untracked.string("HFtowers"),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+        ),
+    ])
 
+process.GlobalTag.toGet.extend([
+    cms.PSet(
+        record = cms.string("BTagTrackProbability3DRcd"),
+        tag = cms.string("JPcalib_Data103X_2018PbPb_v1"),
+        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
+        )
+    ])
 
 ###############################################################################
 
 # root output
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string("HiForestMiniAOD.root")
-)
+    fileName = cms.string("HiForestMiniAOD.root"))
 
 # # edm output for debugging purposes
 # process.output = cms.OutputModule(
 #     "PoolOutputModule",
 #     fileName = cms.untracked.string('HiForestEDM.root'),
-#     outputCommands = cms.untracked.vstring('keep *',)
+#     outputCommands = cms.untracked.vstring(
+#         'keep *',
+#         )
 #     )
+
 # process.output_path = cms.EndPath(process.output)
 
 ###############################################################################
 
-
 # event analysis
 # process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
-# process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
-process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_mc_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi')
+#process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.skimanalysis_cfi')
+#process.load('HeavyIonsAnalysis.EventAnalysis.hltobject_cfi')
+#process.load('HeavyIonsAnalysis.EventAnalysis.l1object_cfi')
+
+#from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_mc
+#process.hltobject.triggerNames = trigger_list_mc
+
+# process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
 ################################
 # electrons, photons, muons
 process.load('HeavyIonsAnalysis.EGMAnalysis.ggHiNtuplizer_cfi')
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ################################
-# jets
-process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_mc_cff')
+# jet reco sequence
+process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_data_cff')
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
-
-process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
-process.load("HeavyIonsAnalysis.MuonAnalysis.hltMuTree_cfi")
+###############################################################################
 
 
+
+###############################################################################
 # main forest sequence
 process.forest = cms.Path(
-    process.HiForestInfo +
+    process.HiForestInfo + 
     # process.hltanalysis +
     process.trackSequencePbPb +
     # process.particleFlowAnalyser +
     process.hiEvtAnalyzer +
     process.ggHiNtuplizer +
-    process.akCs4PFJetAnalyzer +
-    process.unpackedMuons +
-    process.hltMuTree
+    process.akCs4PFJetAnalyzer
     )
+
+#customisation
+
+addR3Jets = False
+
+if addR3Jets :
+    process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
+    from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
+    
+    process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
+        jetTag = "akCs3PFpatJets",
+    )
+    
+    process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
+
 
 
 
@@ -136,9 +179,6 @@ if addCandidateTagging:
 
     process.akCs4PFJetAnalyzer.addDeepCSV = True
 
-#customisation
-#process.akCs4PFJetAnalyzer.doLifeTimeTagging = False
-
 #########################
 # Event Selection -> add the needed filters here
 #########################
@@ -147,5 +187,3 @@ process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
 process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
 process.pAna = cms.EndPath(process.skimanalysis)
-
-

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -1,6 +1,6 @@
 ### HiForest Configuration
 # Input: miniAOD
-# Type: data
+# Type: mc
 
 import FWCore.ParameterSet.Config as cms
 from Configuration.Eras.Era_Run2_2018_pp_on_AA_cff import Run2_2018_pp_on_AA
@@ -11,7 +11,7 @@ process = cms.Process('HiForest', Run2_2018_pp_on_AA,run2_miniAOD_pp_on_AA_103X)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, data")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, mc")
 
 # import subprocess, os
 # version = subprocess.check_output(
@@ -26,11 +26,9 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 112X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        "file:/afs/cern.ch/work/m/mnguyen/public/devel/forest/CMSSW_11_2_0_pre9/src/HeavyIonsAnalysis/Configuration/test/step2_PAT.root"
+        'file:/afs/cern.ch/work/m/mnguyen/public/integration/CMSSW_11_2_4_patch4/src/step3_inMINIAODSIM.root'
     ), 
 )
-#input file produced from:
-#"file:/afs/cern.ch/work/r/rbi/public/forest/HIHardProbes_HIRun2018A-PromptReco-v2_AOD.root"
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
@@ -48,33 +46,16 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data_promptlike_hi', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2018_realistic_hi', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
-
-centralityTag = "CentralityTable_HFtowers200_DataPbPb_periHYDJETshape_run2v1031x02_offline"
-process.HiForestInfo.info.append(centralityTag)
-
-print('\n')
-print('\033[31m~*~ CENTRALITY TABLE FOR 2018 PBPB DATA ~*~\033[0m')
-print('\033[36m~*~ TAG: ' + centralityTag + ' ~*~\033[0m')
-print('\n')
 process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 process.GlobalTag.toGet.extend([
-    cms.PSet(
-        record = cms.string("HeavyIonRcd"),
-        tag = cms.string(centralityTag),
-        label = cms.untracked.string("HFtowers"),
-        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-        ),
-    ])
+    cms.PSet(record = cms.string("BTagTrackProbability3DRcd"),
+             tag = cms.string("JPcalib_MC103X_2018PbPb_v4"), 
+             connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS")             
+         )
+])
 
-process.GlobalTag.toGet.extend([
-    cms.PSet(
-        record = cms.string("BTagTrackProbability3DRcd"),
-        tag = cms.string("JPcalib_Data103X_2018PbPb_v1"),
-        connect = cms.string("frontier://FrontierProd/CMS_CONDITIONS"),
-        )
-    ])
 
 ###############################################################################
 
@@ -97,7 +78,7 @@ process.TFileService = cms.Service("TFileService",
 
 # event analysis
 # process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
-process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_mc_cfi')
 #process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.skimanalysis_cfi')
 #process.load('HeavyIonsAnalysis.EventAnalysis.hltobject_cfi')
@@ -113,10 +94,14 @@ process.load('HeavyIonsAnalysis.EGMAnalysis.ggHiNtuplizer_cfi')
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ################################
 # jet reco sequence
-process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_data_cff')
+process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_mc_cff')
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
+#muons
+process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
+process.load("HeavyIonsAnalysis.MuonAnalysis.hltMuTree_cfi")
+
 ###############################################################################
 
 
@@ -130,7 +115,9 @@ process.forest = cms.Path(
     # process.particleFlowAnalyser +
     process.hiEvtAnalyzer +
     process.ggHiNtuplizer +
-    process.akCs4PFJetAnalyzer
+    process.akCs4PFJetAnalyzer +
+    process.unpackedMuons +
+    process.hltMuTree
     )
 
 #customisation
@@ -140,13 +127,13 @@ addR3Jets = False
 if addR3Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-    setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
+    setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, 1)
     
     process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
         jetTag = "akCs3PFpatJets",
     )
     
-    process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
+    process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
 
 
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -19,7 +19,7 @@ def setupHeavyIonJets(tag, sequence, process, isMC):
     radius = get_radius(tag)
 
     addToSequence( tag+'Jets',
-                   akCs4PFJets.clone(rParam = radius/10, src = 'packedPFCandidates'),
+                   akCs4PFJets.clone(rParam = radius/10, src = 'packedPFCandidates', useModulatedRho = False),
                    process, sequence)
 
     addToSequence( tag+'patJetCorrFactors',

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -1,0 +1,84 @@
+from __future__ import division
+
+from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import *
+from RecoJets.Configuration.RecoGenJets_cff import ak4GenJetsNoNu
+from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import pfImpactParameterTagInfos
+from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import pfSecondaryVertexTagInfos
+from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
+from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
+
+def get_radius(tag):
+    return int(filter(str.isdigit, tag))
+
+def addToSequence(label, module, process, sequence):
+    setattr(process, label, module)
+    sequence += getattr(process, label)
+
+def setupHeavyIonJets(tag, sequence, process, isMC):
+
+    radius = get_radius(tag)
+
+    addToSequence( tag+'Jets',
+                   akCs4PFJets.clone(rParam = radius/10, src = 'packedPFCandidates'),
+                   process, sequence)
+
+    addToSequence( tag+'patJetCorrFactors',
+                   patJetCorrFactors.clone(payload = 'AK'+str(radius)+'PF', src = tag+'Jets'),
+                   process, sequence)
+
+    if isMC :
+        addToSequence( tag+'patJetPartonMatch',
+                       patJetPartonMatch.clone(maxDeltaR = radius/10, matched = 'hiSignalGenParticles', src = tag+'Jets'),
+                       process, sequence)
+        
+        genjetcollection = 'ak'+str(radius)+'GenJetsNoNu'
+        
+        addToSequence( genjetcollection,
+                       ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal'),
+                       process, sequence)
+        
+        addToSequence( tag+'patJetGenJetMatch',
+                       patJetGenJetMatch.clone(maxDeltaR = radius/10, matched = genjetcollection,  src = tag + 'Jets'),
+                       process, sequence)
+        
+        addToSequence( tag+'patJetPartonAssociationLegacy',
+                       patJetPartonAssociationLegacy.clone(jets = tag + 'Jets'),
+                       process, sequence)
+        
+        addToSequence( tag+'patJetFlavourAssociationLegacy',
+                       patJetFlavourAssociationLegacy.clone(srcByReference = tag+'patJetPartonAssociationLegacy'),
+                       process, sequence)
+        
+        addToSequence( tag+'patJetPartons',
+                       patJetPartons.clone(partonMode = 'Pythia8'),
+                       process, sequence)
+        
+    addToSequence( tag+'pfImpactParameterTagInfos',
+                   pfImpactParameterTagInfos.clone(jets = tag +'Jets', candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVerticesRecovery'),
+                   process, sequence)
+    
+    addToSequence( tag+'pfSecondaryVertexTagInfos',
+                   pfSecondaryVertexTagInfos.clone(trackIPTagInfos = tag+'pfImpactParameterTagInfos'),
+                   process, sequence)
+    
+    addToSequence( tag+'pfDeepCSVTagInfos',
+                   pfDeepCSVTagInfos.clone(svTagInfos = tag+'pfSecondaryVertexTagInfos'),
+                   process, sequence)
+
+    addToSequence( tag+'pfDeepCSVJetTags',
+                   pfDeepCSVJetTags.clone(src = tag+'pfDeepCSVTagInfos'),
+                   process, sequence)
+    
+    addToSequence( tag+'patJets',
+                   patJets.clone(
+                       JetFlavourInfoSource = tag+'patJetFlavourAssociation',
+                       JetPartonMapSource = tag+'patJetFlavourAssociationLegacy',
+                       genJetMatch = tag+'patJetGenJetMatch',
+                       genPartonMatch = tag+'patJetPartonMatch',
+                       jetCorrFactorsSource = cms.VInputTag(tag+'patJetCorrFactors'),
+                       jetSource = tag+'Jets',
+                       discriminatorSources = cms.VInputTag(cms.InputTag(tag+'pfDeepCSVJetTags','probb'), cms.InputTag(tag+'pfDeepCSVJetTags','probc'), cms.InputTag(tag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(tag+'pfDeepCSVJetTags','probbb')),
+                       addAssociatedTracks = False,
+                   ),
+                   process, sequence)
+    

--- a/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJets_cff import PFTowers, hiPuRho, hiSignalGenParticles, allPartons
+PFTowers.src = "packedPFCandidates"
+PFTowers.useHF = True
+hiSignalGenParticles.src = "prunedGenParticles"
+
+extraJetsData = cms.Sequence(PFTowers + hiPuRho)
+extraJetsMC = cms.Sequence(PFTowers + hiPuRho + hiSignalGenParticles + allPartons)
+


### PR DESCRIPTION
Now enjoy your favorite jet radii in the miniAOD forest. 
I added an option to the data and MC forest cfgs to cluster R=0.3 Cs jets, and add the corresponding analyzer. 
It's straight-forwards to change to the R value to whatever you want.  
In contrast to jets in the miniAOD, there is no slimming applied.   The slimming has some reco and genJet thresholds, so it strikes me that we should try the reclustering with R=0.4 and check to what extent we get the same results as for the jets in miniAOD.
I also had to modify the PFTower code to accept packedPFCandidates.  I need to propagate that fix into CMSSW, so we don't start accumulating reco changes again. 

@stepobr Can you have a look?

