### PR TITLE
Add HF coincidence filter to data cfg

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -186,4 +186,6 @@ if addCandidateTagging:
 process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
 process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
+process.load('HeavyIonsAnalysis.EventAnalysis.hffilter_cfi')
+process.pphfCoincFilter2Th4 = cms.Path(process.phfCoincFilter2Th4)
 process.pAna = cms.EndPath(process.skimanalysis)

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HFFilter.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HFFilter.cc
@@ -1,0 +1,71 @@
+// system include files
+#include <memory>
+#include <vector>
+#include <map>
+#include <set>
+
+// user include files
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "DataFormats/HeavyIonEvent/interface/HFFilterInfo.h" //this line is needed to access the HF Filters
+
+class HFFilter : public edm::EDFilter {
+public:
+  explicit HFFilter(const edm::ParameterSet &);
+  ~HFFilter() override;
+
+private:
+  bool filter(edm::Event &, const edm::EventSetup &) override;
+
+  edm::EDGetTokenT<reco::HFFilterInfo> HFfilters_;
+  bool applyfilter_;
+  int threshold_;
+  int minnumtowers_;
+  int numMinHFTowers;
+
+};
+
+
+using namespace edm;
+using namespace std;
+
+HFFilter::HFFilter(const edm::ParameterSet& iConfig) {
+  HFfilters_ = consumes<reco::HFFilterInfo>(iConfig.getParameter<edm::InputTag>("HFfilters"));
+  //  applyfilter_ = iConfig.getParameter<bool>("applyfilter");
+  threshold_ = iConfig.getParameter<int>("threshold");
+  minnumtowers_ = iConfig.getParameter<int>("minnumtowers");
+}
+
+HFFilter::~HFFilter() {}
+
+bool HFFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+  bool accepted = false;
+
+  numMinHFTowers = 0;
+
+  edm::Handle<reco::HFFilterInfo> HFfilter;
+  iEvent.getByToken(HFfilters_, HFfilter);
+
+  if(threshold_ == 2){numMinHFTowers = HFfilter->numMinHFTowers2;}
+  if(threshold_ == 3){numMinHFTowers = HFfilter->numMinHFTowers3;}
+  if(threshold_ == 4){numMinHFTowers = HFfilter->numMinHFTowers4;}
+  if(threshold_ == 5){numMinHFTowers = HFfilter->numMinHFTowers5;}
+
+  if(numMinHFTowers >= minnumtowers_) accepted = true;
+
+  return accepted;
+
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HFFilter);

--- a/HeavyIonsAnalysis/EventAnalysis/python/hffilter_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hffilter_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+phfCoincFilter2Th4  = cms.EDFilter('HFFilter',
+   HFfilters      = cms.InputTag("hiHFfilters","hiHFfilters","PAT"),
+   threshold      = cms.int32(4),
+   minnumtowers  = cms.int32(2)
+)


### PR DESCRIPTION
Describe the Pull-Request:

Adds to the possibility to apply the standard HF coincidence cut to the output tree: skimanalysis/HltTree

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[x] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
