### PR TITLE
Fix JES for reclustered jets

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -143,7 +143,7 @@ if addR3Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
     setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
-
+    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative','L2L3Residual']
     process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
         jetTag = "akCs3PFpatJets",
     )

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -139,7 +139,7 @@ if addR3Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
     setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, 1)
-
+    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative']
     process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
         jetTag = "akCs3PFpatJets",
     )

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/BuildFile.xml
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/BuildFile.xml
@@ -8,7 +8,6 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HLTrigger/HLTcore"/>
-<!--<use name="RecoHI/HiCentralityAlgos"/>-->
 <use name="DataFormats/HeavyIonEvent"/>
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="rootcore"/>

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/BuildFile.xml
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="FWCore/PluginManager"/>
 <use name="FWCore/ServiceRegistry"/>
 <use name="HLTrigger/HLTcore"/>
-<use name="RecoHI/HiCentralityAlgos"/>
+<!--<use name="RecoHI/HiCentralityAlgos"/>-->
 <use name="DataFormats/HeavyIonEvent"/>
 <use name="SimGeneral/HepPDTRecord"/>
 <use name="rootcore"/>


### PR DESCRIPTION
In a previous PR I added the possibility to cluster R=0.3 from packedPFCandidates.
The JES for these reclustered jets was not properly configured.
Now they give consistent results with the AOD forest.
Thanks @FHead for spotting the issue

I also removed an unneeded line from a BuildFile that was causing a warning. 
