### PR TITLE
Bug fix in JEC for AK3 jets in MC forest

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -147,7 +147,7 @@ if addR3Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
     setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, 1)
-    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative']
+    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
     process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
         jetTag = "akCs3PFpatJets",
     )


### PR DESCRIPTION
PAT jet demands we have either L3Absolute or L2L3Residual.  Having neither = no JEC applied.  This fixes the bug.

@mandrenguyen @stepobr 
