### PR TITLE
Rho calculation bugfix + reclustering gen jet bugfix - MiniAOD forest

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -154,7 +154,7 @@ if addR3Jets or addR4Jets :
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
-        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
             jetTag = "akCs3PFpatJets"
@@ -164,7 +164,7 @@ if addR3Jets or addR4Jets :
 
     if addR4Jets :
         # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
         process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -154,21 +154,21 @@ if addR3Jets or addR4Jets :
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
-        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
+        setupHeavyIonJets('akCs3PF', process.extraJetsData, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
             jetTag = "akCs3PFpatJets"
         )
 
-        process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
+        process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
+        setupHeavyIonJets('akCsXPF', process.extraJetsData, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
         process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
 
-        process.forest += process.extraJetsMC * process.akCs4PFJetAnalyzer
+        process.forest += process.extraJetsData * process.akCs4PFJetAnalyzer
 
 
 addCandidateTagging = False

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -141,29 +141,37 @@ process.forest = cms.Path(
     process.unpackedMuons +
     process.correctedElectrons +
     process.ggHiNtuplizer +
-    process.akCs4PFJetAnalyzer +
     process.muonAnalyzer
     )
 
 #customisation
 
 addR3Jets = False
+addR4Jets = True
 
-if addR3Jets :
+if addR3Jets or addR4Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-    setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
-    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative','L2L3Residual']
-    process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
-        jetTag = "akCs3PFpatJets",
-    )
 
-    process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
+    if addR3Jets :
+        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
+            jetTag = "akCs3PFpatJets"
+        )
+
+        process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
+
+    if addR4Jets :
+        # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
+        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
+
+        process.forest += process.extraJetsMC * process.akCs4PFJetAnalyzer
 
 
-
-
-addCandidateTagging = True
+addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -163,10 +163,10 @@ if addR3Jets or addR4Jets :
         process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
 
     if addR4Jets :
-        # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCsXPF', process.extraJetsData, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
-        process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
+        # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
+        setupHeavyIonJets('akCs0PF', process.extraJetsData, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
+        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCs0PFpatJets')
 
         process.forest += process.extraJetsData * process.akCs4PFJetAnalyzer
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -159,10 +159,10 @@ if addR3Jets or addR4Jets :
         process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
 
     if addR4Jets :
-        # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
-        process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
+        # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
+        setupHeavyIonJets('akCs0PF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCs0PFpatJets')
 
         process.forest += process.extraJetsMC * process.akCs4PFJetAnalyzer
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -137,29 +137,39 @@ process.forest = cms.Path(
     process.unpackedMuons +
     process.correctedElectrons +
     process.ggHiNtuplizer +
-    process.akCs4PFJetAnalyzer +
     process.muonAnalyzer
     )
 
 #customisation
 
 addR3Jets = False
+addR4Jets = True
 
-if addR3Jets :
+if addR3Jets or addR4Jets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-    setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, 1)
-    process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-    process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
-        jetTag = "akCs3PFpatJets",
-    )
 
-    process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
+    if addR3Jets :
+        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
+            jetTag = "akCs3PFpatJets", genjetTag = "ak3GenJetsNoNu"
+        )
+
+        process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
+
+    if addR4Jets :
+        # Recluster using an alias "X" in order not to get mixed up with the default AK4 collections
+        setupHeavyIonJets('akCsXPF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        process.akCsXPFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCsXPFpatJets')
+
+        process.forest += process.extraJetsMC * process.akCs4PFJetAnalyzer
 
 
 
 
-addCandidateTagging = True
+addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")

--- a/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiPuRhoProducer.cc
@@ -465,7 +465,7 @@ void HiPuRhoProducer::calculateOrphanInput(std::vector<fastjet::PseudoJet>& orph
     for (auto const& im : towermap_) {
       double dr2 = reco::deltaR2(im.eta, im.phi, jet_etaphi.first, jet_etaphi.second);
       if (dr2 < radiusPU_ * radiusPU_ && !excludedTowers[std::pair(im.ieta, im.iphi)] &&
-          (im.ieta - ntowersWithJets_[im.ieta]) > minimumTowersFraction_ * im.ieta) {
+          (geomtowers_[im.ieta] - ntowersWithJets_[im.ieta]) > minimumTowersFraction_ * geomtowers_[im.ieta]) {
         ntowersWithJets_[im.ieta]++;
         excludedTowers[std::pair(im.ieta, im.iphi)] = 1;
       }


### PR DESCRIPTION
Describe the Pull-Request:

1. Rho calculation bug fix: one line change hiPuRhoProducer
2. We also need to recalculate AK4 jets now.  Update to both data and MC configs
3. Added proper gen jets to the clusterJetsFromMiniAOD in the meantime
4. Updated clusterJetsFromMiniAOD to decouple the 'X' in akCsXPF with the radius and also the JEC to use.  If the things are not specified, we guess from the 'X'.  Otherwise use the specified radius and JEC tag.  See below for some examples.  It is backward compatible, old syntax will yield exactly the same result.

Before:
* setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
"3" => R = 0.3, and JEC to use is AK3PF

Now:
* setupHeavyIonJets('akCs3PF', process.extraJetsData, process, 0)
-> radius not set, JEC tag not set, use the old behavior.  R = 0.3 from the "3".  JEC to use is AK3PF from the "3"
* setupHeavyIonJets('akCs9PF', process.extraJetsData, process, isMC = 0, radius = 1.0)
-> radius is set, override the jet radius to use the input 1.0, instead of guessing from the '9'.  JEC to use is AK9PF
* setupHeavyIonJets('akCs9PF', process.extraJetsData, process, isMC = 0, radius = 1.0, JECTag = 'AK4PF')
-> radius is set, override the jet radius to use the input 1.0, instead of guessing from the '9'.  JEC to use is AK4PF (since AK9PF is likely not in the db)


5. @mandrenguyen, please comment on how we proceed with the b-tagging, since the AK4 reclustering probably will break the tagging part.  Do you want to make another PR, or we update it to this one and merge together?



Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@mandrenguyen @stepobr @ttrk

