### PR TITLE
Update the MuonUnpacker and TrackAndVertexUnpacker

### DIFF
--- a/HeavyIonsAnalysis/MuonAnalysis/plugins/BuildFile.xml
+++ b/HeavyIonsAnalysis/MuonAnalysis/plugins/BuildFile.xml
@@ -1,6 +1,3 @@
-<use   name="RecoTracker/TkTrackingRegions"/>
 <use   name="TrackingTools/IPTools"/>
 <use   name="MuonAnalysis/MuonAssociators"/>
-<flags   EDM_PLUGIN="1"/>
-<library   file="*.cc" name="HeavyIonsAnalysisMuonAnalysisPlugins">
-</library>
+<flags EDM_PLUGIN="1"/>

--- a/HeavyIonsAnalysis/MuonAnalysis/plugins/EmbedL1HLTinMuons.cc
+++ b/HeavyIonsAnalysis/MuonAnalysis/plugins/EmbedL1HLTinMuons.cc
@@ -1,0 +1,136 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "Geometry/CommonTopologies/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+
+
+namespace pat {
+
+  class EmbedL1HLTinMuons : public edm::global::EDProducer<> {
+    
+    public:
+    
+      explicit EmbedL1HLTinMuons(const edm::ParameterSet & iConfig):
+          muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+          triggerResultsToken_(consumes<edm::TriggerResults>(iConfig.getParameter<edm::InputTag>("triggerResults"))),
+          triggerObjectsToken_(consumes<pat::TriggerObjectStandAloneCollection>(iConfig.getParameter<edm::InputTag>("triggerObjects"))),
+          geometryToken_(esConsumes())
+      {
+        produces<pat::MuonCollection>();
+      }
+      ~EmbedL1HLTinMuons() override {};
+   
+      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+    
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+    
+    private:
+
+      const edm::EDGetTokenT<pat::MuonCollection> muonToken_;
+      const edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;
+      const edm::EDGetTokenT<pat::TriggerObjectStandAloneCollection> triggerObjectsToken_;
+      const edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geometryToken_;
+
+      std::optional<GlobalPoint> getMuonDirection(const reco::MuonChamberMatch&, const DetId&,
+                                                  const GlobalTrackingGeometry&) const;
+
+      void fillL1TriggerInfo(pat::Muon&, const pat::TriggerObjectStandAloneCollection&,
+                             const edm::TriggerNames&, const GlobalTrackingGeometry&) const;
+
+      void fillHLTriggerInfo(pat::Muon&, const pat::TriggerObjectStandAloneCollection&,
+                             const edm::TriggerNames&) const;
+    
+  };
+  
+}
+
+void pat::EmbedL1HLTinMuons::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  // extract input information
+  const auto& muons = iEvent.get(muonToken_);
+  const auto& triggerObjects = iEvent.get(triggerObjectsToken_);
+  const auto& triggerResults = iEvent.get(triggerResultsToken_);
+  const auto& triggerNames = iEvent.triggerNames(triggerResults);
+  const auto& geometry = iSetup.getHandle(geometryToken_);
+
+  // initialize output muon collection
+  auto output = std::make_unique<pat::MuonCollection>(muons);
+
+  // add trigger information to muons
+  for (auto& muon : *output) {
+    const_cast<TriggerObjectStandAloneCollection&>(muon.triggerObjectMatches()).clear();
+    fillL1TriggerInfo(muon, triggerObjects, triggerNames, *geometry);
+    fillHLTriggerInfo(muon, triggerObjects, triggerNames);
+  }
+
+  iEvent.put(std::move(output));
+}
+
+std::optional<GlobalPoint> pat::EmbedL1HLTinMuons::getMuonDirection(const reco::MuonChamberMatch& chamberMatch, const DetId& chamberId,
+                                                               const GlobalTrackingGeometry& geometry) const {
+  const auto& chamberGeometry = geometry.idToDet(chamberId);
+  if (chamberGeometry) {
+    LocalPoint localPosition(chamberMatch.x, chamberMatch.y, 0);
+    return std::optional<GlobalPoint>(std::in_place, chamberGeometry->toGlobal(localPosition));
+  }
+  return std::optional<GlobalPoint>();
+}
+
+void pat::EmbedL1HLTinMuons::fillL1TriggerInfo(pat::Muon& muon, const pat::TriggerObjectStandAloneCollection& triggerObjects,
+                                          const edm::TriggerNames& triggerNames, const GlobalTrackingGeometry& geometry) const {
+  // L1 trigger object parameters are defined at MB2/ME2. Use the muon
+  // chamber matching information to get the local direction of the
+  // muon trajectory to match the trigger objects
+  std::optional<GlobalPoint> muonPosition;
+  for (const auto& chamberMatch : muon.matches()) {
+    if (chamberMatch.id.subdetId()==MuonSubdetId::DT) {
+      DTChamberId detId(chamberMatch.id.rawId());
+      if (std::abs(detId.station())>3) continue;
+      muonPosition = getMuonDirection(chamberMatch, detId, geometry);
+      if (std::abs(detId.station())==2) break;
+    }
+    else if (chamberMatch.id.subdetId()==MuonSubdetId::CSC) {
+      CSCDetId detId(chamberMatch.id.rawId());
+      if (std::abs(detId.station())>3) continue;
+      muonPosition = getMuonDirection(chamberMatch, detId, geometry);
+      if (std::abs(detId.station())==2) break;
+    }
+  }
+  if (!muonPosition) return;
+
+  // add L1 trigger object to muon
+  for (const auto& triggerObject : triggerObjects) {
+    if (!triggerObject.hasTriggerObjectType(trigger::TriggerL1Mu)) continue;
+    if (std::abs(triggerObject.eta())<0.001) {
+      if (std::abs(deltaPhi(triggerObject.phi(), muonPosition->phi()))>0.1) continue;
+    }
+    else if (deltaR(triggerObject.p4(), *muonPosition)>0.15) continue;
+    muon.addTriggerObjectMatch(triggerObject);
+  }
+}
+
+void pat::EmbedL1HLTinMuons::fillHLTriggerInfo(pat::Muon& muon, const pat::TriggerObjectStandAloneCollection& triggerObjects,
+                                          const edm::TriggerNames& triggerNames) const {
+  // add HLT object to muon
+  for (const auto& triggerObject : triggerObjects) {
+    if (!triggerObject.hasTriggerObjectType(trigger::TriggerMuon)) continue;
+    if (deltaR(triggerObject.p4(), muon)>0.1) continue;
+    muon.addTriggerObjectMatch(triggerObject);
+  }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::EmbedL1HLTinMuons::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muons", edm::InputTag("unpackedMuons"))->setComment("muon input collection");
+  desc.add<edm::InputTag>("triggerResults", edm::InputTag("TriggerResults::HLT"))->setComment("trigger results collection");
+  desc.add<edm::InputTag>("triggerObjects", edm::InputTag("slimmedPatTrigger::PAT"))->setComment("trigger objects collection");
+  descriptions.add("unpackedMuonsWithTrigger", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(EmbedL1HLTinMuons);

--- a/HeavyIonsAnalysis/MuonAnalysis/plugins/EmbedMCinMuons.cc
+++ b/HeavyIonsAnalysis/MuonAnalysis/plugins/EmbedMCinMuons.cc
@@ -1,0 +1,60 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+
+
+namespace pat {
+
+  class EmbedMCinMuons : public edm::global::EDProducer<> {
+    
+    public:
+    
+      explicit EmbedMCinMuons(const edm::ParameterSet & iConfig):
+          muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
+          muonGenMatchToken_(consumes(iConfig.getParameter<edm::InputTag>("matchedGen")))
+      {
+        produces<pat::MuonCollection>();
+      }
+      ~EmbedMCinMuons() override {};
+   
+      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+    
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+    
+    private:
+
+      const edm::EDGetTokenT<pat::MuonCollection> muonToken_;
+      const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > muonGenMatchToken_;
+    
+  };
+  
+}
+
+void pat::EmbedMCinMuons::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  // extract input information
+  const auto& matches = iEvent.get(muonGenMatchToken_);
+  const auto& muons = iEvent.getHandle(muonToken_);
+
+  // initialize output muon collection
+  auto output = std::make_unique<pat::MuonCollection>(*muons);
+
+  // add gen information to muons
+  for (size_t i=0; i<muons->size(); i++) {
+    (*output)[i].setGenParticle(*matches.get(muons.id(), i));
+  }
+
+  iEvent.put(std::move(output));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::EmbedMCinMuons::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("muons", edm::InputTag("unpackedMuons"))->setComment("muon input collection");
+  desc.add<edm::InputTag>("matchedGen", edm::InputTag("muonMatch"))->setComment("matches with gen muons input collection");
+  descriptions.add("unpackedMuonsWithGenMatch", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(EmbedMCinMuons);

--- a/HeavyIonsAnalysis/MuonAnalysis/plugins/MuonUnpacker.cc
+++ b/HeavyIonsAnalysis/MuonAnalysis/plugins/MuonUnpacker.cc
@@ -1,19 +1,10 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/MuonReco/interface/MuonSelectors.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 #include "MuonAnalysis/MuonAssociators/interface/PropagateToMuon.h"
 
@@ -27,11 +18,47 @@ namespace pat {
       explicit MuonUnpacker(const edm::ParameterSet & iConfig):
           muonSelectors_(iConfig.getParameter<std::vector<std::string> >("muonSelectors")),
           muonToken_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("muons"))),
-          trackToken_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+          pc2TrackToken_(consumes<edm::Association<reco::TrackCollection> >(iConfig.getParameter<edm::InputTag>("tracks"))),
           primaryVertexToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
-          beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot")))
+          beamSpotToken_(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"))),
+          trackBuilderToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder"))),
+          candidateMuonIDToken_(getPackedCandidateMap(muonSelectors_)),
+          propToMuon_(getMuonPropagator(iConfig))
       {
-        if (iConfig.getParameter<bool>("propToMuon")) {
+        produces<pat::MuonCollection>();
+      };
+      ~MuonUnpacker() override {};
+
+      void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    private:
+
+      typedef std::map<std::string, std::map<std::string, edm::EDGetTokenT<pat::PackedCandidateRefVector> > > PackedCandidateRefVectorMap;
+
+      const std::vector<std::string> muonSelectors_;
+      const edm::EDGetTokenT<pat::MuonCollection> muonToken_;
+      const edm::EDGetTokenT<edm::Association<reco::TrackCollection> > pc2TrackToken_;
+      const edm::EDGetTokenT<reco::VertexCollection> primaryVertexToken_;
+      const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+      const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> trackBuilderToken_;
+      const PackedCandidateRefVectorMap candidateMuonIDToken_;
+      const std::unique_ptr<PropagateToMuon> propToMuon_;
+
+      PackedCandidateRefVectorMap getPackedCandidateMap(const std::vector<std::string>& v)
+      {
+        PackedCandidateRefVectorMap m;
+        for (const auto& sel: v) {
+          m["packedPFCandidate"][sel] = consumes<pat::PackedCandidateRefVector>(edm::InputTag("packedCandidateMuonID", "pfCandidates"+sel));
+          m["lostTrack"][sel] = consumes<pat::PackedCandidateRefVector>(edm::InputTag("packedCandidateMuonID", "lostTracks"+sel));
+        }
+        return m;
+      };
+
+      PropagateToMuon* getMuonPropagator(const edm::ParameterSet& iConfig)
+      {
+        if (iConfig.getParameter<bool>("addPropToMuonSt")) {
           edm::ParameterSet conf;
           conf.addParameter("useSimpleGeometry", true);
           conf.addParameter("useTrack", std::string("none"));
@@ -39,128 +66,89 @@ namespace pat {
           conf.addParameter("fallbackToME1", true);
           conf.addParameter("useMB2InOverlap", true);
           conf.addParameter("useStation2", true);
-          propToMuon_.reset(new PropagateToMuon(conf));
+          return new PropagateToMuon(conf);
         }
-        for (const auto& sel: muonSelectors_) {
-          candidateMuonIDToken_["packedPFCandidate"][sel] = consumes<pat::PackedCandidateRefVector>(edm::InputTag("packedCandidateMuonID", "pfCandidates"+sel));
-          candidateMuonIDToken_["lostTrack"][sel] = consumes<pat::PackedCandidateRefVector>(edm::InputTag("packedCandidateMuonID", "lostTracks"+sel));
-        }
-        trackChi2Token_["packedPFCandidate"] = consumes<edm::ValueMap<float> >(edm::InputTag("packedPFCandidateTrackChi2"));
-        trackChi2Token_["lostTrack"] = consumes<edm::ValueMap<float> >(edm::InputTag("lostTrackChi2"));
-        produces<pat::MuonCollection>();
-      }
-      ~MuonUnpacker() override {};
+        return nullptr;
+      };
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-
-      void addMuon(pat::Muon&, const pat::PackedCandidate&, const std::string&,
-                   const reco::TrackRef&, const edm::ESHandle<TransientTrackBuilder>&,
-                   const reco::Vertex&, const reco::BeamSpot&, const float& trackChi2, std::map<std::string, bool>);
-
-      static void fillDescriptions(edm::ConfigurationDescriptions&);
-
-    private:
-
-      const std::vector<std::string> muonSelectors_;
-      const edm::EDGetTokenT<pat::MuonCollection> muonToken_;
-      const edm::EDGetTokenT<reco::TrackCollection> trackToken_;
-      const edm::EDGetTokenT<reco::VertexCollection> primaryVertexToken_;
-      const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-      const edm::EDGetTokenT<edm::TriggerResults> triggerResultToken_;
-      std::map<std::string, std::map<std::string, edm::EDGetTokenT<pat::PackedCandidateRefVector> > > candidateMuonIDToken_;
-      std::map<std::string, edm::EDGetTokenT<edm::ValueMap<float> > > trackChi2Token_;
-
-      std::unique_ptr<PropagateToMuon> propToMuon_;
-
+      void addMuon(pat::Muon&, const pat::PackedCandidateRef&, const bool&,
+                   const reco::TrackRef&, const TransientTrackBuilder&,
+                   const reco::Vertex&, const reco::BeamSpot&, std::map<std::string, bool>) const;
 
   };
 
 }
 
 void pat::MuonUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // extract input information
+  const auto& muons = iEvent.get(muonToken_);
+  const auto& pc2Track = iEvent.get(pc2TrackToken_);
+  const auto& primaryVertex = iEvent.get(primaryVertexToken_)[0];
+  const auto& beamSpot = iEvent.get(beamSpotToken_);
+  const auto& trackBuilder = iSetup.getData(trackBuilderToken_);
+
   // extract candidate map
   std::map<std::string, std::map<pat::PackedCandidateRef, std::map<std::string, bool> > > candidateMuonIDs;
   for (const auto& n : candidateMuonIDToken_) {
-    for (const auto& s: n.second) {
-      const auto& coll = iEvent.getHandle(s.second);
-      if (coll.isValid()) {
-        for (const auto& c : *coll) { 
-          candidateMuonIDs[n.first][c][s.first] = true;
-        }
-      }
-    }
+    for (const auto& s: n.second)
+      for (const auto& c : iEvent.get(s.second))
+        candidateMuonIDs[n.first][c][s.first] = true;
   }
 
-  // extract candidate track map
-  typedef std::tuple<float, float, float, char, unsigned short> TUPLE;
-  std::map<TUPLE, reco::TrackRef> candTrackMap;
-  const auto& tracks = iEvent.getHandle(trackToken_);
-  for (size_t i=0; i<tracks->size(); i++) {
-    const auto& trk = reco::TrackRef(tracks, i);
-    const auto& tuple = std::make_tuple(trk->pt(), trk->eta(), trk->phi(), trk->charge(), trk->numberOfValidHits());
-    candTrackMap[tuple] = trk;
+  // initialize output muon collection
+  auto output = std::make_unique<pat::MuonCollection>(muons);
+  // clear trigger info
+  for (auto& muon : *output)
+    const_cast<TriggerObjectStandAloneCollection&>(muon.triggerObjectMatches()).clear();
+
+  // find high-purity muons
+  std::vector<size_t> hpMuonIndexV;
+  for (size_t i=0; i<output->size(); i++) {
+    const auto& muon = output->at(i);
+    if (muon.innerTrack().isNonnull() && muon.innerTrack()->quality(reco::TrackBase::highPurity))
+      hpMuonIndexV.emplace_back(i);
   }
-
-  // extract candidate track chi2 map
-  std::map<std::string, edm::ValueMap<float> > trackChi2Map;
-  for (const auto& n : trackChi2Token_) {
-    const auto& valueMap = iEvent.getHandle(n.second);
-    if (valueMap.isValid()) trackChi2Map.emplace(n.first, *valueMap);
-  }
-
-  // extract primary vertex and beamspot
-  const auto& primaryVertex = iEvent.get(primaryVertexToken_)[0];
-  const auto& beamSpot = iEvent.get(beamSpotToken_);
-
-  // extract the transient track builder
-  edm::ESHandle<TransientTrackBuilder> trackBuilder;
-  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
 
   // extract muons from packedCandidate collections
-  pat::MuonCollection candMuons;
-  const auto& muons = iEvent.get(muonToken_);
   for (const auto& n : candidateMuonIDs) {
+    const bool isLostTrack = (n.first=="lostTrack");
+    // loop over packed candidates
     for (const auto& c : n.second) {
       const auto& cand = c.first;
       const auto& selMap = c.second;
-
-      // extract candidate track
-      if (cand->charge()==0 || !cand->hasTrackDetails()) continue;
-      const auto& trk = cand->pseudoTrack();
-      const auto& tuple = std::make_tuple(trk.pt(), trk.eta(), trk.phi(), trk.charge(), trk.numberOfValidHits());
-      const auto& track = candTrackMap.at(tuple);
+      const auto& track = pc2Track.get(cand.id(), cand.key());
+      const bool isEGamma = (std::abs(cand->pdgId())==11 || cand->pdgId()==22);
 
       // check if candidate is in muon collection
-      bool isIncluded = false;
-      for (const auto& muon : muons) {
-        const auto& mtrk = muon.innerTrack();
-        if (mtrk.isNull() || !mtrk->quality(reco::TrackBase::qualityByName("highPurity"))) continue;
-        if (mtrk->charge()==track->charge() && mtrk->numberOfValidHits()==track->numberOfValidHits() &&
-            std::abs(mtrk->eta()-track->eta())<1E-3 && std::abs(mtrk->phi()-track->phi())<1E-3 && std::abs((mtrk->pt()-track->pt())/mtrk->pt())<1E-2) {
-          isIncluded = true;
-          break;
+      bool isIncluded(false);
+      for (const auto& i : hpMuonIndexV) {
+        const auto& muon = output->at(i);
+        const auto& obj = muon.originalObjectRef();
+        if (obj.id()==cand.id())
+          isIncluded = (obj.key()==cand.key());
+        else if (isLostTrack || obj.isNull()) {
+          const auto& mtrk = muon.innerTrack();
+          if (mtrk->charge()!=track->charge() || std::abs(mtrk->eta()-track->eta())>1E-3) continue;
+          if (isLostTrack || !isEGamma)
+            isIncluded = (mtrk->numberOfValidHits()==track->numberOfValidHits() && std::abs(deltaPhi(mtrk->phi(), track->phi()))<1E-3 && std::abs((mtrk->pt()-track->pt())/mtrk->pt())<1E-2);
+          else
+            isIncluded = (std::abs(mtrk->dz()-track->dz())<2E-2 && std::abs(deltaPhi(mtrk->phi(), track->phi()))<2E-2);
+          // if found, assing candidate reference to muon
+          if (isIncluded)
+            const_cast<reco::CandidatePtr&>(obj) = reco::CandidatePtr(cand.id(), cand.get(), cand.key());
         }
+        if (isIncluded) break;
       }
       if (isIncluded) continue;
 
-      // extract track chi2
-      float trackChi2(-1);
-      if (trackChi2Map[n.first].contains(cand.id())) {
-        trackChi2 = trackChi2Map[n.first][cand];
-      }
-
-      // create and add the muon object
+      // create muon object
       pat::Muon muon;
-      addMuon(muon, *cand, n.first, track, trackBuilder, primaryVertex, beamSpot, trackChi2, selMap);
-      candMuons.push_back(muon);
+      addMuon(muon, cand, !isLostTrack, track, trackBuilder, primaryVertex, beamSpot, selMap);
+      output->emplace_back(muon);
     }
   }
 
-
-  // create output and add extra muons from packedCandidate collections
-  auto output = std::make_unique<pat::MuonCollection>(muons);
-  for (const auto& candMuon : candMuons) { output->push_back(candMuon); }
-  
+  // propagate muon position to 2nd muon station (used for L1 muon matching)
   if (propToMuon_) {
     propToMuon_->init(iSetup);
     for (auto& muon : *output) {
@@ -172,105 +160,90 @@ void pat::MuonUnpacker::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
     }
   }
   
-  // clear trigger data from MiniAOD
-  for (auto& muon : *output) {
-    if (!muon.hasUserInt("candType")) muon.addUserInt("candType", 0);
-    const_cast<TriggerObjectStandAloneCollection*>(&muon.triggerObjectMatches())->clear();
-  }
-
   iEvent.put(std::move(output));
 }
 
-void pat::MuonUnpacker::addMuon(pat::Muon& muon, const pat::PackedCandidate& cand, const std::string& lbl,
-                                const reco::TrackRef& track, const edm::ESHandle<TransientTrackBuilder>& trackBuilder,
-                                const reco::Vertex& primaryVertex, const reco::BeamSpot& beamSpot,
-                                const float& trackChi2, std::map<std::string, bool> selMap) {
+void pat::MuonUnpacker::addMuon(pat::Muon& muon, const pat::PackedCandidateRef& cand, const bool& isPF,
+                                const reco::TrackRef& track, const TransientTrackBuilder& trackBuilder,
+                                const reco::Vertex& primaryVertex, const reco::BeamSpot& beamSpot, std::map<std::string, bool> selMap) const {
   // add basic information
-  muon.setP4(math::PtEtaPhiMLorentzVector(track->pt(), track->eta(), track->phi(), cand.mass()));
-  muon.setCharge(cand.charge());
-  muon.setVertex(cand.vertex());
-  muon.setPdgId(-13 * cand.charge());
+  muon.setP4(math::PtEtaPhiMLorentzVector(track->pt(), track->eta(), track->phi(), 0.105658369));
+  muon.setCharge(track->charge());
+  muon.setVertex(track->vertex());
+  muon.setPdgId(-13 * muon.charge());
+  muon.setStatus(isPF ? 1 : 2);
+
+  // add candidate reference
+  const_cast<reco::CandidatePtr&>(muon.originalObjectRef()) = reco::CandidatePtr(cand.id(), cand.get(), cand.key());
 
   // add track information
   muon.setInnerTrack(track);
   muon.setBestTrack(reco::Muon::InnerTrack);
+  muon.setTunePBestTrack(reco::Muon::InnerTrack);
   muon.embedTrack();
   muon.setNumberOfValidHits(track->numberOfValidHits());
-  const auto& muonTrack = *muon.track();
-  muon.addUserFloat("trackChi2", trackChi2);
+  muon.setNormChi2(track->normalizedChi2());
 
   // add vertex information
-  auto tt = trackBuilder->build(muonTrack);
-  auto result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(muonTrack.px(), muonTrack.py(), muonTrack.pz()), primaryVertex);
-  muon.setDB(result.second.value(), result.second.error(), pat::Muon::PV2D);
-  result = IPTools::signedImpactParameter3D(tt, GlobalVector(muonTrack.px(), muonTrack.py(), muonTrack.pz()), primaryVertex);
-  muon.setDB(result.second.value(), result.second.error(), pat::Muon::PV3D);
-  reco::Vertex beamSpotVertex(beamSpot.position(), beamSpot.rotatedCovariance3D());
-  result = IPTools::signedTransverseImpactParameter(tt, GlobalVector(muonTrack.px(), muonTrack.py(), muonTrack.pz()), beamSpotVertex);
-  muon.setDB(result.second.value(), result.second.error(), pat::Muon::BS2D);
-  result = IPTools::signedImpactParameter3D(tt, GlobalVector(muonTrack.px(), muonTrack.py(), muonTrack.pz()), beamSpotVertex);
-  muon.setDB(result.second.value(), result.second.error(), pat::Muon::BS3D);
-  muon.setDB(muonTrack.dz(primaryVertex.position()), std::hypot(muonTrack.dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
+  muon.setDB(track->dxy(primaryVertex.position()), track->dxyError(primaryVertex.position(), primaryVertex.covariance()), pat::Muon::PV2D);
+  muon.setDB(track->dxy(beamSpot), track->dxyError(beamSpot), pat::Muon::BS2D);
+  muon.setDB(track->dz(primaryVertex.position()), std::hypot(track->dzError(), primaryVertex.zError()), pat::Muon::PVDZ);
+
+  const auto& tt = trackBuilder.build(*track);
+  const auto& resultPV = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), primaryVertex);
+  muon.setDB(resultPV.second.value(), resultPV.second.error(), pat::Muon::PV3D);
+  reco::Vertex vBeamspot(beamSpot.position(), beamSpot.rotatedCovariance3D());
+  const auto& resultBS = IPTools::signedImpactParameter3D(tt, GlobalVector(track->px(), track->py(), track->pz()), vBeamspot);
+  muon.setDB(resultBS.second.value(), resultBS.second.error(), pat::Muon::BS3D);
 
   // determine muon selectors
   bool isTrackerMuon = selMap["AllTrackerMuons"] || selMap["TMOneStationTight"];
-  bool isGlobalMuon = selMap["AllGlobalMuons"] || cand.isGlobalMuon();
-  bool isStandAloneMuon = selMap["AllStandAloneMuons"] || cand.isStandAloneMuon();
-  bool isPFMuon = (lbl=="packedPFCandidate" && std::abs(cand.pdgId())==13);
-  bool isHPMuon = muonTrack.quality(reco::Track::highPurity);
+  bool isGlobalMuon = selMap["AllGlobalMuons"] || cand->isGlobalMuon();
+  bool isStandAloneMuon = selMap["AllStandAloneMuons"] || cand->isStandAloneMuon();
+  bool isPFMuon = isPF && std::abs(cand->pdgId())==13;
+  bool isHPMuon = track->quality(reco::Track::highPurity);
   bool isLooseMuon = isPFMuon || isGlobalMuon || isTrackerMuon;
   bool isTMOneStationTight = selMap["TMOneStationTight"];
   bool isSoftMuon = isTMOneStationTight && isHPMuon &&
-                    muonTrack.hitPattern().trackerLayersWithMeasurement()>5 && muonTrack.hitPattern().pixelLayersWithMeasurement()>0 &&
-                    fabs(muonTrack.dxy(primaryVertex.position()))<0.3 && fabs(muonTrack.dz(primaryVertex.position()))<20.;
+                    track->hitPattern().trackerLayersWithMeasurement()>5 && track->hitPattern().pixelLayersWithMeasurement()>0 &&
+                    std::abs(track->dxy(primaryVertex.position()))<0.3 && std::abs(track->dz(primaryVertex.position()))<20.;
 
   // add muon selectors
-  unsigned int type = 0;
-  unsigned int selectors = 0;
-  std::vector<bool> selVec(muon::TriggerIdLoose+1, false);
-  if (isLooseMuon) {
+  unsigned int selectors(0);
+  if (isLooseMuon)
     selectors |= reco::Muon::CutBasedIdLoose;
-  }
-  if (isSoftMuon) {
+  if (isSoftMuon)
     selectors |= reco::Muon::SoftCutBasedId;
-  }
-  selVec[muon::All] = true;
-  if (isTrackerMuon) {
+  muon.setSelectors(selectors);
+
+  // add muon types
+  unsigned int type(0);
+  if (isTrackerMuon)
     type |= reco::Muon::TrackerMuon;
-    selVec[muon::AllTrackerMuons] = true;
-  }
-  if (isStandAloneMuon) {
+  if (isStandAloneMuon)
     type |= reco::Muon::StandAloneMuon;
-    selVec[muon::AllStandAloneMuons] = true;
-  }
   if (isGlobalMuon) {
-    //type |= reco::Muon::GlobalMuon;
-    selVec[muon::AllGlobalMuons] = true;
+    type |= reco::Muon::GlobalMuon;
+    muon.setGlobalTrack(track);
+    muon.embedCombinedMuon();
   }
   if (isPFMuon) {
     type |= reco::Muon::PFMuon;
-    muon.setPFP4(cand.p4());
-  }
-  if (isTMOneStationTight) {
-    selVec[muon::TMOneStationTight] = true;
+    muon.setPFP4(cand->p4());
+    muon.setPfEcalEnergy(cand->energy()*cand->caloFraction()*(1. - cand->hcalFraction()));
   }
   muon.setType(type);
-  muon.setSelectors(selectors);
-  for (int i=muon::All; i<=muon::TriggerIdLoose; i++) {
-    muon.addUserInt(Form("muonID_%d", i), selVec[i]);
-  }
 
-  // add candidate information
-  unsigned int candType = 0;
-  if (lbl=="packedPFCandidate") {
-    candType = 1;
+  // add TMOneStationTight
+  if (isTMOneStationTight) {
+    reco::MuonSegmentMatch seg;
+    seg.hasZed_ = true; seg.hasPhi_ = true; seg.t0 = 0;
+    seg.mask = (reco::MuonSegmentMatch::BelongsToTrackByDR | reco::MuonSegmentMatch::BestInStationByDR | reco::MuonSegmentMatch::BestInChamberByDR);
+    reco::MuonChamberMatch match({{seg}, {}, {}, {}, {}, 1E9, 1E9, 0, 0, -1, -1, 1E9, 1E9, -1, -1, DTChamberId(0, 1, 0), -1});
+    muon.setMatches({match});
+    if (!muon::isGoodMuon(muon, muon::TMOneStationTight)) throw(cms::Exception("MuonUnpacker") << "Failed to add TMOneStationTight!");
   }
-  else if (lbl=="lostTrack") {
-    candType = 2;
-  }
-  muon.addUserInt("candType", candType);
 }
-  
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void pat::MuonUnpacker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -280,7 +253,7 @@ void pat::MuonUnpacker::fillDescriptions(edm::ConfigurationDescriptions& descrip
   desc.add<edm::InputTag>("primaryVertices", edm::InputTag("unpackedTracksAndVertices"))->setComment("primary vertex input collection");
   desc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"))->setComment("beam spot collection");
   desc.add<std::vector<std::string> >("muonSelectors", {"AllTrackerMuons", "TMOneStationTight"})->setComment("muon selectors");
-  desc.add<bool>("propToMuon", false)->setComment("propagate muon kinematic to muon station");
+  desc.add<bool>("addPropToMuonSt", false)->setComment("add eta/phi propagated to 2nd muon station for L1 matching");
   descriptions.add("unpackedMuons", desc);
 }
 

--- a/HeavyIonsAnalysis/MuonAnalysis/python/muonUnpacker_cfi.py
+++ b/HeavyIonsAnalysis/MuonAnalysis/python/muonUnpacker_cfi.py
@@ -1,2 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-

--- a/HeavyIonsAnalysis/TrackAnalysis/plugins/BuildFile.xml
+++ b/HeavyIonsAnalysis/TrackAnalysis/plugins/BuildFile.xml
@@ -1,0 +1,3 @@
+<use   name="FWCore/Framework"/>
+<use   name="DataFormats/PatCandidates"/>
+<flags EDM_PLUGIN="1"/>

--- a/HeavyIonsAnalysis/TrackAnalysis/plugins/TrackAndVertexUnpacker.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/plugins/TrackAndVertexUnpacker.cc
@@ -1,0 +1,145 @@
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
+
+
+namespace pat {
+
+  class TrackAndVertexUnpacker : public edm::global::EDProducer<> {
+
+    public:
+
+      explicit TrackAndVertexUnpacker(const edm::ParameterSet & iConfig):
+          packedPFCandidateToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+          lostTrackToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("lostTracks"))),
+          packedPFCandidateNormChi2MapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("packedPFCandidateNormChi2Map"))),
+          lostTrackNormChi2MapToken_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("lostTrackNormChi2Map"))),
+          primaryVertexToken_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertices"))),
+          secondaryVertexToken_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("secondaryVertices")))
+      {
+        produces<reco::TrackCollection>();
+        produces<reco::VertexCollection>();
+        produces<reco::VertexCollection>("secondary");
+        produces<edm::Association<reco::TrackCollection> >();
+      };
+      ~TrackAndVertexUnpacker() override {};
+
+      void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override;
+
+      static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+    private:
+
+      const edm::EDGetTokenT<pat::PackedCandidateCollection> packedPFCandidateToken_;
+      const edm::EDGetTokenT<pat::PackedCandidateCollection> lostTrackToken_;
+      const edm::EDGetTokenT<edm::ValueMap<float> > packedPFCandidateNormChi2MapToken_;
+      const edm::EDGetTokenT<edm::ValueMap<float> > lostTrackNormChi2MapToken_;
+      const edm::EDGetTokenT<reco::VertexCollection> primaryVertexToken_;
+      const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> secondaryVertexToken_;
+
+  };
+
+}
+
+void pat::TrackAndVertexUnpacker::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  // extract input information
+  const auto& packedPFCandidates = iEvent.getHandle(packedPFCandidateToken_);
+  const auto& lostTracks = iEvent.getHandle(lostTrackToken_);
+  const auto& packedPFCandidateNormChi2Map = iEvent.get(packedPFCandidateNormChi2MapToken_);
+  const auto& lostTrackNormChi2Map = iEvent.get(lostTrackNormChi2MapToken_);
+  const auto& primaryVertices = iEvent.getHandle(primaryVertexToken_);
+  const auto& secondaryVertices = iEvent.get(secondaryVertexToken_);
+
+  // create output track collection
+  auto outTracks = std::make_unique<reco::TrackCollection>();
+  std::map<bool, std::vector<int> > pcAssoc;
+  std::map<size_t, std::vector<size_t> > pvAssoc;
+  std::map<reco::CandidatePtr, size_t> trackKeys;
+  for (const auto& isPF : {true, false}) {
+    const auto& cands = isPF ? packedPFCandidates : lostTracks;
+    const auto& normChi2Map = isPF ? packedPFCandidateNormChi2Map : lostTrackNormChi2Map;
+    pcAssoc[isPF] = std::vector<int>(cands->size(), -1);
+    for (size_t iC = 0; iC < cands->size(); iC++) {
+      const auto& cand = (*cands)[iC];
+      if (!cand.hasTrackDetails() || cand.charge()==0) continue;
+      const auto& track = cand.pseudoTrack();
+      const auto& normChi2 = normChi2Map.get(cands.id(), iC);
+      const auto  ndof = track.ndof()!=0 ? track.ndof() : 0.1;
+      // create output track
+      outTracks->emplace_back(normChi2 * ndof, ndof, track.referencePoint(), track.momentum(), track.charge(),
+                              track.covariance(), track.algo(), reco::TrackBase::loose,
+                              track.t0(), track.beta(), track.covt0t0(), track.covBetaBeta());
+      auto& outTrack = outTracks->back();
+      outTrack.setQualityMask(track.qualityMask());
+      outTrack.setOriginalAlgorithm(track.originalAlgo());
+      outTrack.setAlgoMask(track.algoMask());
+      outTrack.setNLoops(track.nLoops());
+      outTrack.setStopReason(track.stopReason());
+      const_cast<reco::HitPattern&>(outTrack.hitPattern()) = track.hitPattern();
+      const size_t iT = outTracks->size() - 1;
+      // associate track to primary vertices
+      const auto& pvRef = cand.vertexRef();
+      if (pvRef.id()!=primaryVertices.id())
+        throw(cms::Exception("TrackAndVertexUnpacker") << "Primary vertex collection not associated to packed candidates!");
+      else if (cand.pvAssociationQuality()>=pat::PackedCandidate::UsedInFitLoose)
+        pvAssoc[pvRef.key()].emplace_back(iT);
+      // associate track to candidates
+      reco::CandidatePtr candRef(cands.id(), &cand, iC);
+      trackKeys[candRef] = iT;
+      pcAssoc[isPF][iC] = iT;
+    }
+  }
+  const auto& outTracksHandle = iEvent.put(std::move(outTracks));
+
+  // create output primary vertex collection
+  auto outPrimaryVertices = std::make_unique<reco::VertexCollection>();
+  for (size_t iPV = 0; iPV < primaryVertices->size(); iPV++) {
+    auto vtx = (*primaryVertices)[iPV];
+    for (const auto& iT : pvAssoc[iPV]) {
+      reco::TrackRef trkRef(outTracksHandle, iT);
+      vtx.add(reco::TrackBaseRef(trkRef));
+    }
+    outPrimaryVertices->emplace_back(vtx);
+  }
+  iEvent.put(std::move(outPrimaryVertices));
+
+  // create output secondary vertex collection
+  auto outSecondaryVertices = std::make_unique<reco::VertexCollection>();
+  for (const auto& sv : secondaryVertices) {
+    reco::Vertex vtx(sv.vertex(), sv.vertexCovariance4D(), sv.t(), sv.vertexChi2(), sv.vertexNdof(), sv.numberOfDaughters());
+    for (size_t j = 0; j < sv.numberOfDaughters(); j++) {
+      const auto& dau = sv.daughterPtr(j);
+      reco::TrackRef trkRef(outTracksHandle, trackKeys.at(dau));
+      vtx.add(reco::TrackBaseRef(trkRef));
+    }
+    outSecondaryVertices->emplace_back(vtx);
+  }
+  iEvent.put(std::move(outSecondaryVertices), "secondary");
+
+  // create output association packed candidate -> track
+  auto assoc_pc2track = std::make_unique<edm::Association<reco::TrackCollection> >(outTracksHandle);
+  edm::Association<reco::TrackCollection>::Filler pc2track_filler(*assoc_pc2track);
+  pc2track_filler.insert(packedPFCandidates, pcAssoc[true].begin(), pcAssoc[true].end());
+  pc2track_filler.insert(lostTracks, pcAssoc[false].begin(), pcAssoc[false].end());
+  pc2track_filler.fill();
+  iEvent.put(std::move(assoc_pc2track));
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void pat::TrackAndVertexUnpacker::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("packedPFCandidates", edm::InputTag("packedPFCandidates"))->setComment("packed PF candidates collection");
+  desc.add<edm::InputTag>("lostTracks", edm::InputTag("lostTracks"))->setComment("lost tracks collection");
+  desc.add<edm::InputTag>("packedPFCandidateNormChi2Map", edm::InputTag("packedPFCandidateTrackChi2"))->setComment("packed PF candidates normChi2 map");
+  desc.add<edm::InputTag>("lostTrackNormChi2Map", edm::InputTag("lostTrackChi2"))->setComment("lost tracks normChi2 map");
+  desc.add<edm::InputTag>("primaryVertices", edm::InputTag("offlineSlimmedPrimaryVertices"))->setComment("primary vertex collection");
+  desc.add<edm::InputTag>("secondaryVertices", edm::InputTag("slimmedSecondaryVertices"))->setComment("secondary vertex collection");
+  descriptions.add("unpackedTracksAndVertices", desc);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace pat;
+DEFINE_FWK_MODULE(TrackAndVertexUnpacker);

--- a/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzers_cff.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzers_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi import *
+from HeavyIonsAnalysis.TrackAnalysis.unpackedTracksAndVertices_cfi import *
 from HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzer_cfi import *
 
 PbPbTracks = trackAnalyzer.clone()


### PR DESCRIPTION
Describe the Pull-Request:

This PR fixes improves the matching between muons and packed candidates in the muon unpacker code, and also adds a track & vertex unpacker that includes the normalised chi2 inside the unpacked tracks.

Does the PR pass the test script located at
HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[] Yes
[] No

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@flodamas , @abaty , @CesarBernardes 