### PR TITLE
add key of PF cands in the collection and their vtx info

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
@@ -20,6 +20,7 @@ class TreePFCandEventData
     void Clear();
 
     Int_t nPFpart_;
+    std::vector<unsigned long> pfKey_;   // key for this PF cand, ref https://github.com/cms-sw/cmssw/blob/master/DataFormats/Common/interface/Ptr.h#L163
     std::vector<Int_t> pfId_;
     std::vector<Float_t> pfPt_;
     std::vector<Float_t> pfEnergy_;

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiPFCandAnalyzer.h
@@ -28,6 +28,10 @@ class TreePFCandEventData
     std::vector<Float_t> pfPhi_;
     std::vector<Float_t> pfM_;
 
+    std::vector<Float_t> pfvx_;
+    std::vector<Float_t> pfvy_;
+    std::vector<Float_t> pfvz_;
+
     std::vector<Float_t> pfEcalE_;
     std::vector<Float_t> pfEcalEraw_;
     std::vector<Float_t> pfHcalE_;

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
@@ -84,6 +84,7 @@ HiPFCandAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     int id = pfcand.particleId();
     if (skipCharged_ && (abs(id) == 1 || abs(id) == 3)) continue;
 
+    pfEvt_.pfKey_.push_back( pfcand.sourceCandidatePtr(0).key() );
     pfEvt_.pfId_.push_back( id );
     pfEvt_.pfPt_.push_back( pt );
     pfEvt_.pfEnergy_.push_back( pfcand.energy() );
@@ -195,6 +196,7 @@ void TreePFCandEventData::SetBranches(bool doJets, bool doMC, bool doCaloEnergy,
 {
   // -- particle info --
   tree_->Branch("nPFpart", &nPFpart_, "nPFpart/I");
+  tree_->Branch("pfKey", &pfKey_);
   tree_->Branch("pfId", &pfId_);
   tree_->Branch("pfPt", &pfPt_);
   tree_->Branch("pfEnergy", &pfEnergy_);
@@ -239,6 +241,7 @@ void TreePFCandEventData::SetBranches(bool doJets, bool doMC, bool doCaloEnergy,
 void TreePFCandEventData::Clear()
 {
   nPFpart_ = 0;
+  pfKey_.clear();
   pfId_.clear();
   pfPt_.clear();
   pfEnergy_.clear();

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiPFCandAnalyzer.cc
@@ -91,6 +91,17 @@ HiPFCandAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
     pfEvt_.pfEta_.push_back( pfcand.eta() );
     pfEvt_.pfPhi_.push_back( pfcand.phi() );
     pfEvt_.pfM_.push_back( pfcand.mass() );
+
+    if (id == 1 || id == 3) {
+      pfEvt_.pfvx_.push_back( pfcand.vx() );
+      pfEvt_.pfvy_.push_back( pfcand.vy() );
+      pfEvt_.pfvz_.push_back( pfcand.vz() );
+    }
+    else {
+      pfEvt_.pfvx_.push_back(-999);
+      pfEvt_.pfvy_.push_back(-999);
+      pfEvt_.pfvz_.push_back(-999);
+    }
     
     if (doCaloEnergy_) {
       pfEvt_.pfEcalE_.push_back( pfcand.ecalEnergy() );
@@ -204,6 +215,10 @@ void TreePFCandEventData::SetBranches(bool doJets, bool doMC, bool doCaloEnergy,
   tree_->Branch("pfPhi", &pfPhi_);
   tree_->Branch("pfM", &pfM_);
 
+  tree_->Branch("pfvx", &pfvx_);
+  tree_->Branch("pfvy", &pfvy_);
+  tree_->Branch("pfvz", &pfvz_);
+
   // -- ecal/hcal energy info --
   if (doCaloEnergy) {
     tree_->Branch("pfEcalE", &pfEcalE_);
@@ -248,6 +263,10 @@ void TreePFCandEventData::Clear()
   pfEta_.clear();
   pfPhi_.clear();
   pfM_.clear();
+
+  pfvx_.clear();
+  pfvy_.clear();
+  pfvz_.clear();
 
   pfEcalE_.clear();
   pfEcalEraw_.clear();

--- a/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
+++ b/HeavyIonsAnalysis/PhotonAnalysis/interface/ggHiNtuplizer.h
@@ -528,6 +528,7 @@ class ggHiNtuplizer : public edm::EDAnalyzer {
    // PF candidates associated with a reco::photon
    int nPhoPF_;
    std::vector<int> ppfPhoIdx_;   // index of the reco::photon this PF cand is associated to
+   std::vector<unsigned long> ppfKey_;   // key for this PF cand, ref https://github.com/cms-sw/cmssw/blob/master/DataFormats/Common/interface/Ptr.h#L163
    std::vector<int> ppfId_;
    std::vector<float> ppfPt_;
    std::vector<float> ppfEta_;

--- a/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
+++ b/HeavyIonsAnalysis/PhotonAnalysis/plugins/ggHiNtuplizer.cc
@@ -541,6 +541,7 @@ ggHiNtuplizer::ggHiNtuplizer(const edm::ParameterSet& ps) :
     if (saveAssoPFcands_) {
       tree_->Branch("nPhoPF", &nPhoPF_);
       tree_->Branch("ppfPhoIdx",&ppfPhoIdx_);
+      tree_->Branch("ppfKey",&ppfKey_);
       tree_->Branch("ppfId",&ppfId_);
       tree_->Branch("ppfPt",&ppfPt_);
       tree_->Branch("ppfEta",&ppfEta_);
@@ -1002,6 +1003,7 @@ void ggHiNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
     if (saveAssoPFcands_) {
       nPhoPF_ = 0;
       ppfPhoIdx_.clear();
+      ppfKey_.clear();
       ppfId_.clear();
       ppfPt_.clear();
       ppfEta_.clear();
@@ -1954,6 +1956,7 @@ void ggHiNtuplizer::fillPhotons(const edm::Event& e, const edm::EventSetup& es, 
       for (auto& it : particlesInIsoMap) {
         nPhoPF_++;
         ppfPhoIdx_.push_back(nPho_);
+        ppfKey_.push_back(it.key());
         ppfId_.push_back((int)(it->particleId()));
         ppfPt_.push_back((it->pt()));
         ppfEta_.push_back((it->eta()));


### PR DESCRIPTION
Key and vtx of PF candidate is needed when calculating photon iso in ntuple level

HeavyIonsAnalysis/JetAnalysis/test/runtest.sh
[X] Yes
[] No

@mandrenguyen @FHead
