### PR TITLE
Implement candidate-based b-tagging for reclustered jets

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -154,23 +154,24 @@ if addR3Jets or addR4Jets :
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
-        setupHeavyIonJets('akCs3PF', process.extraJetsData, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
+        process.jetsR3 = cms.Sequence()
+        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
-            jetTag = "akCs3PFpatJets"
-        )
-
-        process.forest += process.extraJetsData * process.akCs3PFJetAnalyzer
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF')
+        process.forest += process.extraJetsData * process.jetsR3 * process.akCs3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCs0PF', process.extraJetsData, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
+        process.jetsR4 = cms.Sequence()
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCs0PFpatJets')
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
+        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
 
-        process.forest += process.extraJetsData * process.akCs4PFJetAnalyzer
-
-
+# this is only for non-reclustered jets
 addCandidateTagging = False
 
 if addCandidateTagging:
@@ -197,7 +198,6 @@ if addCandidateTagging:
 
     process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
 
-    process.akCs4PFJetAnalyzer.addDeepCSV = True
 
 #########################
 # Event Selection -> add the needed filters here

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -150,22 +150,22 @@ if addR3Jets or addR4Jets :
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
-        setupHeavyIonJets('akCs3PF', process.extraJetsMC, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        process.jetsR3 = cms.Sequence()
+        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(
-            jetTag = "akCs3PFpatJets", genjetTag = "ak3GenJetsNoNu"
-        )
-
-        process.forest += process.extraJetsMC * process.akCs3PFJetAnalyzer
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF', genjetTag = "ak3GenJetsNoNu")      
+        process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
-        setupHeavyIonJets('akCs0PF', process.extraJetsMC, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        process.jetsR4 = cms.Sequence()
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs4PFJetAnalyzer.jetTag = cms.InputTag('akCs0PFpatJets')
-
-        process.forest += process.extraJetsMC * process.akCs4PFJetAnalyzer
-
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
+        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
 
 
 
@@ -195,7 +195,6 @@ if addCandidateTagging:
 
     process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
 
-    process.akCs4PFJetAnalyzer.addDeepCSV = True
 
 #########################
 # Event Selection -> add the needed filters here

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -91,8 +91,8 @@ private:
 
   bool doSubEvent_;
   double genPtMin_;
-  bool doLifeTimeTagging_;
-  bool addDeepCSV_;
+  bool doLegacyBtagging_;
+  bool doCandidateBtagging_;
 
   bool doHiJetID_;
   bool doStandardJetID_;
@@ -119,6 +119,7 @@ private:
   std::string simpleSVHighPurBJetTags_;
   std::string combinedSVV2BJetTags_;
   std::string deepCSVJetTags_;
+  std::string pfJPJetTags_;
 
   static const int MAXJETS = 1000;
   static const int MAXTRACKS = 5000;
@@ -257,6 +258,7 @@ private:
 
     float discr_csvV2[MAXJETS]={0};
     float discr_deepCSV[MAXJETS]={0};
+    float discr_pfJP[MAXJETS]={0};
     float discr_muByIp3[MAXJETS]={0};
     float discr_muByPt[MAXJETS]={0};
     float discr_prob[MAXJETS]={0};

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_data_cff.py
@@ -7,7 +7,6 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     rParam = 0.4,
     fillGenJets = False,
     isMC = False,
-    bTagJetName = cms.untracked.string("akCs4PF"),
     jetName = cms.untracked.string("akCs4PF"),
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
     )

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
@@ -11,7 +11,6 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     genParticles = cms.untracked.InputTag("prunedGenParticles"),
     eventInfoTag = cms.InputTag("generator"),
     jetName = cms.untracked.string("akCs4PF"),
-    bTagJetName = cms.untracked.string("akCs4PF"),
     genPtMin = cms.untracked.double(5),
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
     )

--- a/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
@@ -15,6 +15,10 @@ from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import pfSecondaryVe
 #inclusiveCandidateVertexFinder.tracks= "packedPFCandidates"
 #candidateVertexArbitrator.tracks = "packedPFCandidates"
 #candidateVertexArbitrator.primaryVertices = "offlineSlimmedPrimaryVerticesRecovery"
+from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
+from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import  *
+from RecoBTag.ImpactParameter.pfJetProbabilityBJetTags_cfi import pfJetProbabilityBJetTags
 from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
 from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
 pfDeepCSVTagInfos.svTagInfos = "pfSecondaryVertexTagInfos"
@@ -27,6 +31,7 @@ candidateBtagging = cms.Sequence(
     #candidateVertexArbitrator +
     #inclusiveCandidateSecondaryVertices +
     #pfInclusiveSecondaryVertexFinderTagInfos +
+    pfJetProbabilityBJetTags +
     pfDeepCSVTagInfos + 
     pfDeepCSVJetTags
 )

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -4,6 +4,7 @@ from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import *
 from RecoJets.Configuration.RecoGenJets_cff import ak4GenJetsNoNu
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import pfImpactParameterTagInfos
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import pfSecondaryVertexTagInfos
+from RecoBTag.ImpactParameter.pfJetProbabilityBJetTags_cfi import pfJetProbabilityBJetTags
 from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
 from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
 
@@ -81,6 +82,10 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                    pfDeepCSVJetTags.clone(src = tag+'pfDeepCSVTagInfos'),
                    process, sequence)
 
+    addToSequence( tag+'pfJetProbabilityBJetTags',
+                   pfJetProbabilityBJetTags.clone(tagInfos = [tag+'pfImpactParameterTagInfos']),
+                   process, sequence)
+
     addToSequence( tag+'patJets',
                    patJets.clone(
                        JetFlavourInfoSource = tag+'patJetFlavourAssociation',
@@ -89,7 +94,7 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                        genPartonMatch = tag+'patJetPartonMatch',
                        jetCorrFactorsSource = cms.VInputTag(tag+'patJetCorrFactors'),
                        jetSource = tag+'Jets',
-                       discriminatorSources = cms.VInputTag(cms.InputTag(tag+'pfDeepCSVJetTags','probb'), cms.InputTag(tag+'pfDeepCSVJetTags','probc'), cms.InputTag(tag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(tag+'pfDeepCSVJetTags','probbb')),
+                       discriminatorSources = cms.VInputTag(cms.InputTag(tag+'pfDeepCSVJetTags','probb'), cms.InputTag(tag+'pfDeepCSVJetTags','probc'), cms.InputTag(tag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(tag+'pfDeepCSVJetTags','probbb'), cms.InputTag(tag+'pfJetProbabilityBJetTags')),
                        addAssociatedTracks = False,
                    ),
                    process, sequence)

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -18,8 +18,6 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     useRawPt = cms.untracked.bool(False),
     useHepMC = cms.untracked.bool(False),
     useQuality = cms.untracked.bool(True),
-    doLifeTimeTagging = cms.untracked.bool(True),
-    addDeepCSV = cms.untracked.bool(False),
     doGenTaus = cms.untracked.bool(False),
     doGenSym = cms.untracked.bool(False),
     doSubJets = cms.untracked.bool(False),
@@ -28,4 +26,6 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     doHiJetID = cms.untracked.bool(False),
     doStandardJetID = cms.untracked.bool(False),
     doSubEvent = cms.untracked.bool(False),
+    doLegacyBtagging = cms.untracked.bool(False),
+    doCandidateBtagging = cms.untracked.bool(True),
     )


### PR DESCRIPTION
Due to the jet reco bug identified by @FHead we are obliged to recluster our jets when using the current version of HI miniAOD.
Unfortunately, this means that the "legacy" track-based b-tagging is unavailable. 
For the reclustered jets, I have instead enabled two candidate-based taggers, deepCSV and the candidate version of Jet Probability.
Dedicated heavy-ion calibrations are not yet available or deepCSV, but out-of-the-box it already performs comparably to (calibrated) csvV2, which is our main legacy tagger.
Jet probability has the same calibrations applied for the track-based and candidate-based versions, and gives nearly identical performance.  
