### PR TITLE
Remove duplicate jet analysis, added in last PR

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_DATA.py
@@ -151,10 +151,9 @@ process.forest = cms.Path(
     process.unpackedMuons +
     process.correctedElectrons +
     process.ggHiNtuplizer +
-    process.akCs4PFJetAnalyzer +
-	  process.zdcdigi +
-	  process.QWzdcreco +
-	  process.zdcanalyzer +
+    process.zdcdigi +
+    process.QWzdcreco +
+    process.zdcanalyzer +
     process.muonAnalyzer
     )
 


### PR DESCRIPTION
When merging the last PR, I accidentally added the jet analyzer back to the main forest path, where it doesn't belong.
