### PR TITLE
Add a flag to disable HF filters for ppRef

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
@@ -83,6 +83,7 @@ process.hiEvtAnalyzer.doEvtPlane = cms.bool(False)
 process.hiEvtAnalyzer.doEvtPlaneFlat = cms.bool(False)
 process.hiEvtAnalyzer.doMC = cms.bool(True) # general MC info
 process.hiEvtAnalyzer.doHiMC = cms.bool(False) # HI specific MC info
+process.hiEvtAnalyzer.doHFfilters = cms.bool(False) # Disable HF filters for ppRef
 
 process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.hltobject_cfi')

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -70,6 +70,7 @@ private:
 
   bool doMC_;
   bool doHiMC_;
+  bool doHFfilters_;
   bool useHepMC_;
   bool doVertex_;
 
@@ -157,6 +158,7 @@ HiEvtAnalyzer::HiEvtAnalyzer(const edm::ParameterSet& iConfig)
       doCentrality_(iConfig.getParameter<bool>("doCentrality")),
       doMC_(iConfig.getParameter<bool>("doMC")),
       doHiMC_(iConfig.getParameter<bool>("doHiMC")),
+      doHFfilters_(iConfig.getParameter<bool>("doHFfilters")),
       useHepMC_(iConfig.getParameter<bool>("useHepMC")),
       doVertex_(iConfig.getParameter<bool>("doVertex")),
       evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")) {}
@@ -334,8 +336,8 @@ void HiEvtAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     vz = vertex->begin()->z();
   }
 
-  // No HF filter info for ppref
-  if(doHiMC_){
+  // Option to disable HF filters for ppref
+  if(doHFfilters_){
     edm::Handle<reco::HFFilterInfo> HFfilter;
     iEvent.getByToken(HFfilters_, HFfilter);
 

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
@@ -15,5 +15,6 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doMC             = cms.bool(False),
    doHiMC           = cms.bool(False),
    useHepMC         = cms.bool(False),
+   doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0)
 )

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
@@ -15,6 +15,7 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doMC             = cms.bool(True),
    doHiMC           = cms.bool(True),
    useHepMC         = cms.bool(False),
+   doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0)
 )
 


### PR DESCRIPTION
I noticed that I accidentally disabled filling HFfilters for all configurations that are not HiMC in my previous pull request. This is not the intended behavior, these should only be disabled for ppRef. To fix this, I added a flag to HiEvtAnalyzer to fill the filters, configuration to keep the flag True by default, and switch it to False in the ppRef forest configuration.
