### PR TITLE
Implementation for fractional prescale in HLT

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_AOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_AOD_run3_MC.py
@@ -10,7 +10,7 @@ process = cms.Process('HiForest', Run3_pp_on_PbPb)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 122X, mc")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 125X, mc")
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
@@ -11,7 +11,7 @@ process = cms.Process('HiForest', Run2_2018_pp_on_AA,run2_miniAOD_pp_on_AA_103X)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 122X, data")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 125X, data")
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
@@ -11,7 +11,7 @@ process = cms.Process('HiForest', Run2_2018_pp_on_AA,run2_miniAOD_pp_on_AA_103X)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 122X, mc")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 125X, mc")
 
 ###############################################################################
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -10,7 +10,7 @@ process = cms.Process('HiForest', Run3_pp_on_PbPb)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 122X, mc")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 125X, mc")
 
 ###############################################################################
 
@@ -123,7 +123,6 @@ process.forest = cms.Path(
     process.hiEvtAnalyzer +
     process.HiGenParticleAna +
     process.correctedElectrons +
-    process.akCs4PFJetAnalyzer +
     process.ggHiNtuplizer +
     process.unpackedMuons +
     process.muonAnalyzer


### PR DESCRIPTION
Currently the forest_CMSSW_12_5_0 does not compile if cmsrel is done from version CMSSW_12_5_0. The reason for this is that integer prescales for HLT have been deprecated. This pull request solves this problem by reading the fractional prescale instead of an integer. The prescale value is saved to the forest as two integer numbers, the numerator and the denominator.

There is also a small update to the foresting configurations. The jet sequence was in wrong order in forest_miniAOD_run3_MC.py and it crashed if the jets were included. This is solved by fixing the order in which the jet tasks are included in the sequence. Also in the info string, the version number is updated to 125X.