### PR TITLE
Add flow subtracted jets for miniAOD forests

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
@@ -151,29 +151,48 @@ process.forest = cms.Path(
 #customisation
 
 addR3Jets = False
+addR3FlowJets = False
 addR4Jets = True
+addR4FlowJets = True
 
-if addR3Jets or addR4Jets :
+if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
-        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF')
+        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF')
         process.forest += process.extraJetsData * process.jetsR3 * process.akCs3PFJetAnalyzer
 
+    if addR3FlowJets :
+        process.jetsR3flow = cms.Sequence()
+        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
+        process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow')
+        process.forest += process.extraFlowJetsData * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer 
+
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
         process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
         process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
+ 
+    if addR4FlowJets :
+        process.jetsR4flow = cms.Sequence()
+        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
+        process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
+        process.forest += process.extraFlowJetsData * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
 # this is only for non-reclustered jets
 addCandidateTagging = False

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
@@ -135,29 +135,48 @@ process.forest = cms.Path(
 #customisation
 
 addR3Jets = False
+addR3FlowJets = False
 addR4Jets = True
+addR4FlowJets = True
 
-if addR3Jets or addR4Jets :
+if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
-        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF', genjetTag = "ak3GenJetsNoNu")      
         process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
+    if addR3FlowJets :
+        process.jetsR3flow = cms.Sequence()
+        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
+        process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow', genjetTag = "ak3GenJetsNoNu")
+        process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
+
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
         process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
         process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
+
+    if addR4FlowJets :
+        process.jetsR4flow = cms.Sequence()
+        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
+        process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
+        process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
 
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -131,29 +131,48 @@ process.forest = cms.Path(
 #customisation
 
 addR3Jets = False
-addR4Jets = False
+addR3FlowJets = False
+addR4Jets = True
+addR4FlowJets = True
 
-if addR3Jets or addR4Jets :
+if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
-        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF')
+        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF', genjetTag = "ak3GenJetsNoNu")      
         process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
+    if addR3FlowJets :
+        process.jetsR3flow = cms.Sequence()
+        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
+        process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow', genjetTag = "ak3GenJetsNoNu")      
+        process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
+
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF')
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
         process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
         process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
+
+    if addR4FlowJets :
+        process.jetsR4flow = cms.Sequence()
+        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
+        process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
+        process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
 
 

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_data_cff.py
@@ -11,3 +11,4 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
     )
 
+akFlowPuCs4PFJetAnalyzer = akCs4PFJetAnalyzer.clone()

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
@@ -15,3 +15,4 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
     )
 
+akFlowPuCs4PFJetAnalyzer = akCs4PFJetAnalyzer.clone()

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -15,7 +15,7 @@ def addToSequence(label, module, process, sequence):
     setattr(process, label, module)
     sequence += getattr(process, label)
 
-def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'):
+def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None', doFlow = False):
 
     if radius < 0:
        radiustag = get_radius(tag)
@@ -24,7 +24,7 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
        radiustag = get_radius(tag)
 
     addToSequence( tag+'Jets',
-                   akCs4PFJets.clone(rParam = radius, src = 'packedPFCandidates', useModulatedRho = False),
+                   akCs4PFJets.clone(rParam = radius, src = 'packedPFCandidates', useModulatedRho = doFlow),
                    process, sequence)
 
     if JECTag == 'None':

--- a/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
@@ -1,8 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJets_cff import PackedPFTowers, hiPuRho, hiSignalGenParticles, allPartons
+from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJets_cff import PackedPFTowers, hiPuRho, hiSignalGenParticles, allPartons, hiFJRhoFlowModulation, ak4PFJetsForFlow
 hiSignalGenParticles.src = "prunedGenParticles"
-hiPuRho.src = 'PackedPFTowers' 
-extraJetsData = cms.Sequence(PackedPFTowers + hiPuRho)
-extraJetsMC = cms.Sequence(PackedPFTowers + hiPuRho + hiSignalGenParticles + allPartons)
+hiPuRho.src = 'PackedPFTowers'
 
+# Configuration for flow subtracted jets
+ak4PFJetsForFlow.src = "PackedPFTowers" # Use packed towers as a source if jetty areas are excluded in flow estimate
+hiFJRhoFlowModulation.jetTag = "ak4PFJetsForFlow"  # Jet collection used for jetty region exclusion
+
+# Create extra jet sequences
+extraJetsData = cms.Sequence(PackedPFTowers + hiPuRho)
+extraFlowJetsData = cms.Sequence(PackedPFTowers + hiPuRho + ak4PFJetsForFlow + hiFJRhoFlowModulation)
+extraJetsMC = cms.Sequence(PackedPFTowers + hiPuRho + hiSignalGenParticles + allPartons)
+extraFlowJetsMC = cms.Sequence(PackedPFTowers + hiPuRho + hiSignalGenParticles + allPartons + ak4PFJetsForFlow + hiFJRhoFlowModulation)

--- a/RecoHI/HiJetAlgos/plugins/HiFJRhoFlowModulationProducer.cc
+++ b/RecoHI/HiJetAlgos/plugins/HiFJRhoFlowModulationProducer.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -17,15 +18,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h"
 #include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"
 #include "DataFormats/JetReco/interface/JetCollection.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "RecoHI/HiEvtPlaneAlgos/interface/HiEvtPlaneList.h"
 
 #include "TF1.h"
+#include "TF2.h"
 #include "TH1.h"
 #include "TMath.h"
+#include "Math/ProbFuncMathCore.h"
 #include "TMinuitMinimizer.h"
 
 #include <algorithm>
@@ -36,9 +38,50 @@
 #include <vector>
 
 namespace {
-  double lineFunction(double* x, double* par) { return par[0]; }
+
   double flowFunction(double* x, double* par) {
-    return par[0] * (1. + 2. * (par[1] * std::cos(2. * (x[0] - par[2])) + par[3] * std::cos(3. * (x[0] - par[4]))));
+    int nFlow = par[0]; // Number of fitted flow components is defined in the first parameter
+    double firstFittedVn = par[1]; // The first fitted flow component is defined in the second parameter
+
+    // Add each component separately to the total fit value
+    double flowModulation = par[2];
+    for(int iFlow = 0; iFlow < nFlow; iFlow++){
+      flowModulation += par[2] * 2.0 * par[2*iFlow+3] * std::cos( (iFlow+firstFittedVn) * (x[0] - par[2*iFlow+4]) );
+    }
+    return flowModulation;
+  }
+
+  double weightFunction(double* x, double* par){
+    // If the particle flow candidate is farther than 0.4 from the jet axis, no need for weighting due to area where no particle flow candidates can be found
+    if(x[0]*x[0] > 0.16) return 0;
+
+    // If the particle flow candidate is closer than 0.4 in phi from the jet axis, then there is part of phi acceptance from which no particle flow candidates can be found. Calculate the half of the size of that strip in eta
+    double exclusionArea = TMath::Sqrt(0.16-x[0]*x[0]);
+  
+    // Particle flow caldidates are only considered until eta = par[0]. We should not exclude any area beyond that. Check that the exclusion are does not go beyond that
+
+    // First, check cases where the jet is found outside of the particle flow candidate acceptance in eta
+    if(TMath::Abs(x[1]) > par[0]){
+    
+      // Check if the whole exclusion area is outside of the acceptance. If this is the case, we should not add anything to the weight for this particle flow candidate.
+      if(TMath::Abs(x[1]) - exclusionArea > par[0]) return 0;
+
+      // Now we know that part of the exclusion area will be inside of the acceptance. Check how big this is.
+      exclusionArea = par[0] - (TMath::Abs(x[1]) - exclusionArea);
+
+    } else {
+      // In the next case, the jet is found inside of the particle flow candidate acceptance. In this case, we need to check if some of the exclusion area goes outside of the acceptance. If is does, we need to exclude that from the exclusion area
+      if(TMath::Abs(x[1]) + exclusionArea > par[0]){
+        exclusionArea += par[0] - TMath::Abs(x[1]);
+      } else {
+        // If not, the the exclusion area is two times half of the nominal exclusion area    
+        exclusionArea *= 2;
+      }
+    
+    }
+
+    // Normalize the exclusion area to the total acceptance. This number should be added to the total weight for the particle flow candidate
+    return (2*par[0]) / (2*par[0] - exclusionArea) - 1;
   }
 };  // namespace
 
@@ -48,40 +91,79 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
+  void beginStream(edm::StreamID) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
+  const int minPfCandidatesPerEvent_;
   const bool doEvtPlane_;
   const bool doFreePlaneFit_;
   const bool doJettyExclusion_;
   const int evtPlaneLevel_;
+  const double pfCandidateEtaCut_;
+  const double pfCandidateMinPtCut_;
+  const double pfCandidateMaxPtCut_;
+  int firstFittedVn_;
+  int lastFittedVn_;
   const edm::EDGetTokenT<reco::JetView> jetToken_;
-  const edm::EDGetTokenT<reco::PFCandidateCollection> pfCandsToken_;
+  const edm::EDGetTokenT<pat::PackedCandidateCollection> pfCandidateToken_;
   const edm::EDGetTokenT<reco::EvtPlaneCollection> evtPlaneToken_;
-  std::unique_ptr<TF1> lineFit_p_;
   std::unique_ptr<TF1> flowFit_p_;
+  std::unique_ptr<TF2> pfWeightFunction_;
+  reco::PFCandidate converter_;
 };
 HiFJRhoFlowModulationProducer::HiFJRhoFlowModulationProducer(const edm::ParameterSet& iConfig)
-    : doEvtPlane_(iConfig.getParameter<bool>("doEvtPlane")),
+    : minPfCandidatesPerEvent_(iConfig.getParameter<int>("minPfCandidatesPerEvent")),
+      doEvtPlane_(iConfig.getParameter<bool>("doEvtPlane")),
       doFreePlaneFit_(iConfig.getParameter<bool>("doFreePlaneFit")),
       doJettyExclusion_(iConfig.getParameter<bool>("doJettyExclusion")),
       evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")),
+      pfCandidateEtaCut_(iConfig.getParameter<double>("pfCandidateEtaCut")),
+      pfCandidateMinPtCut_(iConfig.getParameter<double>("pfCandidateMinPtCut")),
+      pfCandidateMaxPtCut_(iConfig.getParameter<double>("pfCandidateMaxPtCut")),
+      firstFittedVn_(iConfig.getParameter<int>("firstFittedVn")),
+      lastFittedVn_(iConfig.getParameter<int>("lastFittedVn")),
       jetToken_(doJettyExclusion_ ? consumes<reco::JetView>(iConfig.getParameter<edm::InputTag>("jetTag"))
                                   : edm::EDGetTokenT<reco::JetView>()),
-      pfCandsToken_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandSource"))),
+      pfCandidateToken_(consumes<pat::PackedCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandSource"))),
       evtPlaneToken_(consumes<reco::EvtPlaneCollection>(iConfig.getParameter<edm::InputTag>("EvtPlane"))) {
   produces<std::vector<double>>("rhoFlowFitParams");
+
+  // Converter to get PF candidate ID from packed candidates
+  converter_ = reco::PFCandidate();
+
+  // Sanity check for the fitted flow component input
+  if(firstFittedVn_ < 1) firstFittedVn_ = 2;
+  if(lastFittedVn_ < 1) lastFittedVn_ = 2;
+  if(firstFittedVn_ > lastFittedVn_){
+    int flipper = lastFittedVn_;
+    lastFittedVn_ = firstFittedVn_;
+    firstFittedVn_ = flipper;
+  }
+
+  // Calculate the number of flow components
+  const int nFlow = lastFittedVn_ - firstFittedVn_ + 1;
+
+  // Define all fit and weight functions
   TMinuitMinimizer::UseStaticMinuit(false);
-  lineFit_p_ = std::make_unique<TF1>("lineFit", lineFunction, -TMath::Pi(), TMath::Pi());
-  flowFit_p_ = std::make_unique<TF1>("flowFit", flowFunction, -TMath::Pi(), TMath::Pi());
+  flowFit_p_ = std::make_unique<TF1>("flowFit", flowFunction, -TMath::Pi(), TMath::Pi(), nFlow*2+3);
+  flowFit_p_->FixParameter(0, nFlow); // The first parameter defines the number of fitted flow components
+  flowFit_p_->FixParameter(1, firstFittedVn_); // The second parameter defines the first fitted flow component
+  pfWeightFunction_ = std::make_unique<TF2>("weightFunction", weightFunction, 0, TMath::Pi(), -5, 5, 1);
+  pfWeightFunction_->SetParameter(0,pfCandidateEtaCut_); // Set the allowed eta range for particle flow candidates
+
+
 }
 
 // ------------ method called to produce the data  ------------
 void HiFJRhoFlowModulationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  int nPhiBins = 10;
-  auto const& pfCands = iEvent.get(pfCandsToken_);
+  
+  // Get the particle flow candidate collection
+  auto const& pfCands = iEvent.get(pfCandidateToken_);
+
+  // If we are reading the event plane information for the forest, find the event planes
   static constexpr int kMaxEvtPlane = 29;
   std::array<float, kMaxEvtPlane> hiEvtPlane;
-
   if (doEvtPlane_) {
     auto const& evtPlanes = iEvent.get(evtPlaneToken_);
     assert(evtPlanes.size() == hi::NumEPNames);
@@ -90,128 +172,189 @@ void HiFJRhoFlowModulationProducer::produce(edm::Event& iEvent, const edm::Event
     });
   }
 
+  // If jetty regions are excluded from the flow fits, read the jet collection
   edm::Handle<reco::JetView> jets;
-  if (doJettyExclusion_)
+  if (doJettyExclusion_){
     iEvent.getByToken(jetToken_, jets);
+  }
 
   int nFill = 0;
 
-  double eventPlane2 = -100;
-  double eventPlane3 = -100;
+  // Initialize arrays for event planes
+  const int nFlow = lastFittedVn_ - firstFittedVn_ + 1; // Number of flow components in the fit to particle flow condidate distribution
+  double eventPlane[nFlow];
+  for(int iFlow = 0; iFlow < nFlow; iFlow++) eventPlane[iFlow] = -100;
 
-  constexpr int nParamVals = 9;
+  // Initialize the output vector with flow fit components
+  const int nParamVals = nFlow*2+4; // v_n and Psi_n for each fitted flow component, plus overall normalization factor, chi^2 and ndf for flow fit, and the first fitted flow component
   auto rhoFlowFitParamsOut = std::make_unique<std::vector<double>>(nParamVals, 1e-6);
 
-  rhoFlowFitParamsOut->at(0) = 0;
-  rhoFlowFitParamsOut->at(1) = 0;
-  rhoFlowFitParamsOut->at(2) = 0;
-  rhoFlowFitParamsOut->at(3) = 0;
-  rhoFlowFitParamsOut->at(4) = 0;
+  // Set the parameters related to flow fit to zero
+  for(int iParameter = 0; iParameter < nFlow*2+1; iParameter++){
+    rhoFlowFitParamsOut->at(iParameter) = 0;
+  }
+  // Set the first fitted flow component to the last index of the output vector
+  rhoFlowFitParamsOut->at(nFlow*2+3) = firstFittedVn_;
 
-  double eventPlane2Cos = 0;
-  double eventPlane2Sin = 0;
+  // Initialize arrays for manual event plane calculation
+  double eventPlaneCos[nFlow] = {0};
+  double eventPlaneSin[nFlow] = {0};
 
-  double eventPlane3Cos = 0;
-  double eventPlane3Sin = 0;
-
+  // Define helper variables for looping over particle flow candidates
   std::vector<bool> pfcuts(pfCands.size(), false);
   int iCand = -1;
-  for (auto const& pfCandidate : pfCands) {
-    iCand++;
-    if (pfCandidate.particleId() != 1 || std::abs(pfCandidate.eta()) > 1.0 || pfCandidate.pt() < .3 ||
-        pfCandidate.pt() > 3.) {
-      continue;
-    }
+  double thisPfCandidateWeight = 0;
+  double deltaPhiJetPf = 0;
+  std::vector<double> pfCandidateWeight(pfCands.size(), 1);
 
+  // Loop over the particle flow candidates
+  for (auto const& pfCandidate : pfCands) {
+    iCand++; // Update the particle flow candidate index
+
+    // Find the PF candidate ID from the packed candidates collection
+    auto particleFlowCandidateID = converter_.translatePdgIdToType(pfCandidate.pdgId());
+
+    // This cut selects particle flow candidates that are charged hadrons. The ID numbers are:
+    // 0 = undefined
+    // 1 = charged hadron
+    // 2 = electron
+    // 3 = muon
+    // 4 = photon
+    // 5 = neutral hadron
+    // 6 = HF tower identified as a hadron
+    // 7 = HF tower identified as an EM particle
+    if(particleFlowCandidateID != 1) continue;
+
+    // Kinematic cuts for particle flow candidate pT and eta
+    if(std::abs(pfCandidate.eta()) > pfCandidateEtaCut_) continue;
+    if(pfCandidate.pt() < pfCandidateMinPtCut_) continue;
+    if(pfCandidate.pt() > pfCandidateMaxPtCut_) continue;
+
+    nFill++;  // Use same nFill criterion with and without jetty region subtraction
+
+    // If the jetty regions are excluded from the fit, find which particle flow candidates are close to jets
+    thisPfCandidateWeight = 1;
     if (doJettyExclusion_) {
       bool isGood = true;
       for (auto const& jet : *jets) {
-        if (deltaR2(jet, pfCandidate) < .16) {
+        if (deltaR2(jet, pfCandidate) < 0.16) {
           isGood = false;
-          break;
+        } else {
+          // If the particle flow candidates are not excluded from the fit, check if there are any jets in the same phi-slice as the particle flow candidate. If this is the case, add a weight for the particle flow candidate taking into account the lost acceptance for underlaying event particle flow candidates.
+          deltaPhiJetPf = TMath::Abs(pfCandidate.phi() - jet.phi());
+          if(deltaPhiJetPf > TMath::Pi()) deltaPhiJetPf = TMath::Pi()*2 - deltaPhiJetPf;
+          thisPfCandidateWeight += pfWeightFunction_->Eval(deltaPhiJetPf, jet.eta()); // Weight currently does not take into account overlapping jets
         }
       }
+      // Do not use this particle flow candidate in the manual event plane calculation
       if (!isGood) {
         continue;
-      }
+      } 
     }
 
-    nFill++;
+    // Update the weight for this particle flow candidate
+    pfCandidateWeight[iCand] = thisPfCandidateWeight;
+
+    // This particle flow candidate passes all the cuts
     pfcuts[iCand] = true;
 
+    // If the event plane is calculated manually, add this particle flow candidate to the calculation
     if (!doEvtPlane_) {
-      eventPlane2Cos += std::cos(2 * pfCandidate.phi());
-      eventPlane2Sin += std::sin(2 * pfCandidate.phi());
-
-      eventPlane3Cos += std::cos(3 * pfCandidate.phi());
-      eventPlane3Sin += std::sin(3 * pfCandidate.phi());
+      for(int iFlow = 0; iFlow < nFlow; iFlow++){
+        eventPlaneCos[iFlow] += std::cos((iFlow+firstFittedVn_) * pfCandidate.phi()) * thisPfCandidateWeight;
+        eventPlaneSin[iFlow] += std::sin((iFlow+firstFittedVn_) * pfCandidate.phi()) * thisPfCandidateWeight;
+      }
     }
   }
 
+  // Determine the event plane angle
   if (!doEvtPlane_) {
-    eventPlane2 = std::atan2(eventPlane2Sin, eventPlane2Cos) / 2.;
-    eventPlane3 = std::atan2(eventPlane3Sin, eventPlane3Cos) / 3.;
+    // Manual calculation for the event plane angle using the particle flow candidates
+    for(int iFlow = 0; iFlow < nFlow; iFlow++){
+      eventPlane[iFlow] = std::atan2(eventPlaneSin[iFlow], eventPlaneCos[iFlow]) / (iFlow+firstFittedVn_);
+    }
   } else {
-    eventPlane2 = hiEvtPlane[hi::HF2];
-    eventPlane3 = hiEvtPlane[hi::HF3];
+    // Read the event plane angle determined from the HF calorimeters from the HiForest
+    // Only v2 and v3 are available in the HiForest. This option should not be used if other flow components are fitted
+    int halfWay = nFlow / 2;
+    for(int iFlow = 0; iFlow < halfWay; iFlow++){
+      eventPlane[iFlow] = hiEvtPlane[hi::HF2];
+    }
+    for(int iFlow = halfWay; iFlow < nFlow; iFlow++){
+      eventPlane[iFlow] = hiEvtPlane[hi::HF3];
+    }
   }
-  int pfcuts_count = 0;
-  if (nFill >= 100 && eventPlane2 > -99) {
-    nPhiBins = std::max(10, nFill / 30);
 
+  // Do the flow fit provided that there are enough particle flow candidates in the event and that the event planes have been determined successfully
+  int pfcuts_count = 0;
+  int nPhiBins = 10;
+  if (nFill >= minPfCandidatesPerEvent_ && eventPlane[0] > -99) {
+
+    // Create a particle flow candidate phi-histogram
+    nPhiBins = std::max(10, nFill / 30);
     std::string name = "phiTestIEta4_" + std::to_string(iEvent.id().event()) + "_h";
-    std::string nameFlat = "phiTestIEta4_Flat_" + std::to_string(iEvent.id().event()) + "_h";
     std::unique_ptr<TH1F> phi_h = std::make_unique<TH1F>(name.data(), "", nPhiBins, -TMath::Pi(), TMath::Pi());
     phi_h->SetDirectory(nullptr);
     for (auto const& pfCandidate : pfCands) {
-      if (pfcuts.at(pfcuts_count))
-        phi_h->Fill(pfCandidate.phi());
+      if (pfcuts.at(pfcuts_count)){ // Only use particle flow candidates that pass all cuts
+        phi_h->Fill(pfCandidate.phi(), pfCandidateWeight.at(pfcuts_count));
+      }
       pfcuts_count++;
     }
-    flowFit_p_->SetParameter(0, 10);
-    flowFit_p_->SetParameter(1, 0);
-    flowFit_p_->SetParameter(2, eventPlane2);
-    flowFit_p_->SetParameter(3, 0);
-    flowFit_p_->SetParameter(4, eventPlane3);
-    if (!doFreePlaneFit_) {
-      flowFit_p_->FixParameter(2, eventPlane2);
-      flowFit_p_->FixParameter(4, eventPlane3);
+
+    // Set initial values for the fit parameters
+    flowFit_p_->SetParameter(2, 10);
+    for(int iFlow = 0; iFlow < nFlow; iFlow++){
+      flowFit_p_->SetParameter(3 + 2*iFlow, 0);
+      flowFit_p_->SetParameter(4 + 2*iFlow, eventPlane[iFlow]);
+      // If we are not allowing the event plane angles to be free parameters in the fit, fix them
+      if (!doFreePlaneFit_) {
+        flowFit_p_->FixParameter(4 + 2*iFlow, eventPlane[iFlow]);
+      }
     }
 
-    lineFit_p_->SetParameter(0, 10);
-
+    // Do the Fourier fit
     phi_h->Fit(flowFit_p_.get(), "Q SERIAL", "", -TMath::Pi(), TMath::Pi());
-    phi_h->Fit(lineFit_p_.get(), "Q SERIAL", "", -TMath::Pi(), TMath::Pi());
-    rhoFlowFitParamsOut->at(0) = flowFit_p_->GetParameter(0);
-    rhoFlowFitParamsOut->at(1) = flowFit_p_->GetParameter(1);
-    rhoFlowFitParamsOut->at(2) = flowFit_p_->GetParameter(2);
-    rhoFlowFitParamsOut->at(3) = flowFit_p_->GetParameter(3);
-    rhoFlowFitParamsOut->at(4) = flowFit_p_->GetParameter(4);
 
-    rhoFlowFitParamsOut->at(5) = flowFit_p_->GetChisquare();
-    rhoFlowFitParamsOut->at(6) = flowFit_p_->GetNDF();
+    // Put the fit parameters to the output vector
+    for(int iParameter = 0; iParameter < nFlow*2+1; iParameter++){
+      rhoFlowFitParamsOut->at(iParameter) = flowFit_p_->GetParameter(iParameter+2);
+    }
 
-    rhoFlowFitParamsOut->at(7) = lineFit_p_->GetChisquare();
-    rhoFlowFitParamsOut->at(8) = lineFit_p_->GetNDF();
+    // Also add chi2 and ndf information to the output vector
+    rhoFlowFitParamsOut->at(nFlow*2+1) = flowFit_p_->GetChisquare();
+    rhoFlowFitParamsOut->at(nFlow*2+2) = flowFit_p_->GetNDF();
 
     phi_h.reset();
     pfcuts.clear();
   }
 
+  // Define the produced output
   iEvent.put(std::move(rhoFlowFitParamsOut), "rhoFlowFitParams");
 }
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void HiFJRhoFlowModulationProducer::beginStream(edm::StreamID) {}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void HiFJRhoFlowModulationProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void HiFJRhoFlowModulationProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
+  desc.add<int>("minPfCandidatesPerEvent", 100);
   desc.add<bool>("doEvtPlane", false);
   desc.add<edm::InputTag>("EvtPlane", edm::InputTag("hiEvtPlane"));
   desc.add<bool>("doJettyExclusion", false);
   desc.add<bool>("doFreePlaneFit", false);
-  desc.add<bool>("doFlatTest", false);
-  desc.add<edm::InputTag>("jetTag", edm::InputTag("ak4PFJets"));
-  desc.add<edm::InputTag>("pfCandSource", edm::InputTag("particleFlow"));
+  desc.add<edm::InputTag>("jetTag", edm::InputTag("ak4PFJetsForFlow"));
+  desc.add<edm::InputTag>("pfCandSource", edm::InputTag("packedPFCandidates"));
   desc.add<int>("evtPlaneLevel", 0);
+  desc.add<double>("pfCandidateEtaCut", 1.0);
+  desc.add<double>("pfCandidateMinPtCut", 0.3);
+  desc.add<double>("pfCandidateMaxPtCut", 3.0);
+  desc.add<int>("firstFittedVn", 2);
+  desc.add<int>("lastFittedVn", 3);
   descriptions.add("hiFJRhoFlowModulationProducer", desc);
 }
 

--- a/RecoJets/JetProducers/plugins/CSJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.cc
@@ -82,7 +82,8 @@ void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSet
   bool maxProb = false;
   if (useModulatedRho_) {
     if (!rhoFlowFitParams->empty()) {
-      double val = ROOT::Math::chisquared_cdf_c(rhoFlowFitParams->at(5), rhoFlowFitParams->at(6));
+      int chi2index = rhoFlowFitParams->size() - 3;
+      double val = ROOT::Math::chisquared_cdf_c(rhoFlowFitParams->at(chi2index), rhoFlowFitParams->at(chi2index+1));
       minProb = val > minFlowChi2Prob_;
       maxProb = val < maxFlowChi2Prob_;
     }
@@ -107,11 +108,7 @@ void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSet
       if (useModulatedRho_) {
         if (!rhoFlowFitParams->empty()) {
           if (minProb && maxProb) {
-            rhoModulationFactor = getModulatedRhoFactor(ghostPhi,
-                                                        rhoFlowFitParams->at(2),
-                                                        rhoFlowFitParams->at(4),
-                                                        rhoFlowFitParams->at(1),
-                                                        rhoFlowFitParams->at(3));
+            rhoModulationFactor = getModulatedRhoFactor(ghostPhi, rhoFlowFitParams);
           }
         }
       }
@@ -153,7 +150,7 @@ void CSJetProducer::runAlgorithm(edm::Event& iEvent, edm::EventSetup const& iSet
 
     //Create subtracted jets
     fastjet::PseudoJet subtracted_jet = join(subtracted_particles);
-    if (subtracted_jet.perp() > 0.)
+    if (subtracted_jet.perp() > jetPtMin_)
       fjJets_.push_back(subtracted_jet);
   }
   fjJets_ = fastjet::sorted_by_pt(fjJets_);
@@ -184,11 +181,16 @@ void CSJetProducer::fillDescriptionsFromCSJetProducer(edm::ParameterSetDescripti
   desc.add<edm::InputTag>("rhoFlowFitParams", {"hiFJRhoFlowModulationProducer", "rhoFlowFitParams"});
 }
 
-double CSJetProducer::getModulatedRhoFactor(
-    const double phi, const double eventPlane2, const double eventPlane3, const double par1, const double par2) {
+double CSJetProducer::getModulatedRhoFactor(const double phi, const edm::Handle<std::vector<double>> flowComponents) {
   // get the rho modulation as function of phi
   // flow modulation fit is done in RecoHI/HiJetAlgos/plugins/HiFJRhoFlowModulationProducer
-  return 1. + 2. * par1 * cos(2. * (phi - eventPlane2)) + par2 * cos(3. * (phi - eventPlane3));
+  int nFlow = (flowComponents->size()-4) / 2;
+  double modulationValue = 1;
+  double firstFlowComponent = flowComponents->at(nFlow*2+3);
+  for(int iFlow = 0; iFlow < nFlow; iFlow++){
+    modulationValue += 2.0 * flowComponents->at(2*iFlow+1) * cos((iFlow+firstFlowComponent) * (phi - flowComponents->at(2*iFlow+2)) );
+  }
+  return modulationValue;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/RecoJets/JetProducers/plugins/CSJetProducer.h
+++ b/RecoJets/JetProducers/plugins/CSJetProducer.h
@@ -34,7 +34,7 @@ namespace cms {
   protected:
     void runAlgorithm(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-    double getModulatedRhoFactor(double phi, double eventPlane2, double eventPlane3, double par1, double par2);
+    double getModulatedRhoFactor(double phi, edm::Handle<std::vector<double>> flowParameters);
 
     double csRParam_;  /// for constituent subtraction : R parameter
     double csAlpha_;   /// for HI constituent subtraction : alpha (power of pt in metric)


### PR DESCRIPTION
This pull request adds the flow subtracted jets to miniAOD forests. What needed to be done to make them work was to change the input sources from AOD naming scheme to miniAOD naming scheme. The pull request also contains improvements and bug fixes for the flow subtracted jets.

Improvements in file HiFJRhoFlowModulationProducer.cc:
  - The code has been rewritten in a way where many hard coded parameters can now be defined in the python configuration
  - Jetty region exclusion method has been improved by giving particle flow candidates outside of the excluded regions weight based on a probability of a background particle flow candidate with the same phi value to be within the excluded region

Bug fixes in CSJetProducer.cc
  - The v3 flow parameter was missing a factor of 2
  - The minimum jet pT cut was not applied correctly

I have tested that cmsRun works with all the included foresting configurations. I did not add the flow jets to forest_miniAOD_run3_DATA.py since the same code there was giving some errors about missing collections. I am not sure if this is a code issue or if it is related to the test file, but it can be solved later.

@mandrenguyen @FHead 
