### PR TITLE
Enabling matchedHadron(Parton)Flavor branches in miniAOD forests

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
@@ -155,15 +155,19 @@ addR3FlowJets = False
 addR4Jets = True
 addR4FlowJets = True
 
+# this is only for non-reclustered jets
+addCandidateTagging = False
+
+
 if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
         setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF')
         process.forest += process.extraJetsData * process.jetsR3 * process.akCs3PFJetAnalyzer
 
@@ -171,7 +175,6 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.jetsR3flow = cms.Sequence()
         setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
         process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow')
         process.forest += process.extraFlowJetsData * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer 
 
@@ -180,7 +183,6 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.jetsR4 = cms.Sequence()
         setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
         process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
         process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
@@ -189,13 +191,10 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.jetsR4flow = cms.Sequence()
         setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
         process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
         process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
         process.forest += process.extraFlowJetsData * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
-# this is only for non-reclustered jets
-addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
@@ -121,7 +121,7 @@ process.forest = cms.Path(
     process.HiForestInfo +
     process.hltanalysis +
     #process.hltobject +
-    process.l1object +
+    #process.l1object +
     process.trackSequencePbPb +
     process.particleFlowAnalyser +
     process.hiEvtAnalyzer +
@@ -138,51 +138,53 @@ addR3Jets = False
 addR3FlowJets = False
 addR4Jets = False
 addR4FlowJets = True
+matchJets = True             # Enables q/g and heavy flavor jet identification
+addCandidateTagging = False
 
 if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
-        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
+        jetName = 'akCs3PF'
+        setupHeavyIonJets(jetName, process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False, matchJets = matchJets)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF', genjetTag = "ak3GenJetsNoNu")      
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets")      
         process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
     if addR3FlowJets :
         process.jetsR3flow = cms.Sequence()
-        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
+        jetName = 'akCs3PFFlow'
+        setupHeavyIonJets(jetName, process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True, matchJets = matchJets)
         process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow', genjetTag = "ak3GenJetsNoNu")
+        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets")
         process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
+        jetName = 'akCs0PF'
+        setupHeavyIonJets(jetName, process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False, matchJets = matchJets)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
-        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.akCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
+        process.akCs4PFJetAnalyzer.jetName = jetName
+        process.akCs4PFJetAnalyzer.matchJets = matchJets
+        process.akCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
         process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
 
     if addR4FlowJets :
         process.jetsR4flow = cms.Sequence()
-        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
+        jetName = 'akCs4PFFlow'
+        setupHeavyIonJets(jetName, process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True, matchJets = matchJets)
         process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
-        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
-        process.akFlowPuCs4PFJetAnalyzer.matchJets = True
-        process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingForakCs4PFFlowpatJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetName = jetName
+        process.akFlowPuCs4PFJetAnalyzer.matchJets = matchJets
+        process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
         process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
-
-
-addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_MC.py
@@ -136,7 +136,7 @@ process.forest = cms.Path(
 
 addR3Jets = False
 addR3FlowJets = False
-addR4Jets = True
+addR4Jets = False
 addR4FlowJets = True
 
 if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
@@ -176,6 +176,8 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
         process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
+        process.akFlowPuCs4PFJetAnalyzer.matchJets = True
+        process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingForakCs4PFFlowpatJets'
         process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
 
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -134,49 +134,53 @@ addR3Jets = False
 addR3FlowJets = False
 addR4Jets = True
 addR4FlowJets = True
+matchJets = True             # Enables q/g and heavy flavor jet identification in MC
+addCandidateTagging = False
 
 if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
-        setupHeavyIonJets('akCs3PF', process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False)
+        jetName = 'akCs3PF'
+        setupHeavyIonJets(jetName, process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False, matchJets = matchJets)
         process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFpatJets", jetName = 'akCs3PF', genjetTag = "ak3GenJetsNoNu")      
+        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets")
         process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
     if addR3FlowJets :
         process.jetsR3flow = cms.Sequence()
-        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
+        jetName = 'akCs3PFFlow'
+        setupHeavyIonJets(jetName, process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True, matchJets = matchJets)
         process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow', genjetTag = "ak3GenJetsNoNu")      
+        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets")
         process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
+        jetName = 'akCs0PF'
+        setupHeavyIonJets(jetName, process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False, matchJets = matchJets)
         process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
-        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.akCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
+        process.akCs4PFJetAnalyzer.jetName = jetName
+        process.akCs4PFJetAnalyzer.matchJets = matchJets
+        process.akCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
         process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
 
     if addR4FlowJets :
         process.jetsR4flow = cms.Sequence()
-        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
+        jetName = 'akCs4PFFlow'
+        setupHeavyIonJets(jetName, process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True, matchJets = matchJets)
         process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
-        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
-        process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
+        process.akFlowPuCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
+        process.akFlowPuCs4PFJetAnalyzer.jetName = jetName
+        process.akFlowPuCs4PFJetAnalyzer.matchJets = matchJets
+        process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
+        process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer 
 
-
-
-addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -67,49 +67,30 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                           src = unsubtractedJetTag + 'Jets'),
                        process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJetPartonAssociationLegacy',
-                       patJetPartonAssociationLegacy.clone(jets = unsubtractedJetTag + 'Jets'),
-                       process, sequence)
-
-        addToSequence( unsubtractedJetTag+'patJetFlavourAssociationLegacy',
-                       patJetFlavourAssociationLegacy.clone(srcByReference = unsubtractedJetTag+'patJetPartonAssociationLegacy'),
-                       process, sequence)
-
         addToSequence( unsubtractedJetTag+'patJetPartons',
                        patJetPartons.clone(partonMode = 'Pythia8'),
                        process, sequence)
 
-        addToSequence( unsubtractedJetTag+'pfImpactParameterTagInfos',
-                       pfImpactParameterTagInfos.clone(jets = unsubtractedJetTag +'Jets',
-                          candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVerticesRecovery'),
-                       process, sequence)
-
-        addToSequence( unsubtractedJetTag+'pfSecondaryVertexTagInfos',
-                       pfSecondaryVertexTagInfos.clone(trackIPTagInfos = unsubtractedJetTag+'pfImpactParameterTagInfos'),
-                       process, sequence)
-
-        addToSequence( unsubtractedJetTag+'pfDeepCSVTagInfos',
-                       pfDeepCSVTagInfos.clone(svTagInfos = unsubtractedJetTag+'pfSecondaryVertexTagInfos'),
-                       process, sequence)
-
-        addToSequence( unsubtractedJetTag+'pfDeepCSVJetTags',
-                       pfDeepCSVJetTags.clone(src = unsubtractedJetTag+'pfDeepCSVTagInfos'),
-                       process, sequence)
-
-        addToSequence( unsubtractedJetTag+'pfJetProbabilityBJetTags',
-                       pfJetProbabilityBJetTags.clone(tagInfos = [unsubtractedJetTag+'pfImpactParameterTagInfos']),
+        addToSequence( unsubtractedJetTag+'patJetFlavourAssociation',
+                       patJetFlavourAssociation.clone(jets = unsubtractedJetTag+'Jets',
+                           bHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","bHadrons"),
+                           cHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","cHadrons"),
+                           partons = cms.InputTag(unsubtractedJetTag+"patJetPartons","physicsPartons"),
+                           leptons = cms.InputTag(unsubtractedJetTag+"patJetPartons","leptons")),
                        process, sequence)
 
         addToSequence( unsubtractedJetTag+'patJets',
                        patJets.clone(
                            JetFlavourInfoSource = unsubtractedJetTag+'patJetFlavourAssociation',
-                           JetPartonMapSource = unsubtractedJetTag+'patJetFlavourAssociationLegacy',
+                           JetPartonMapSource = unsubtractedJetTag+'patJetFlavourAssociation',
                            genJetMatch = unsubtractedJetTag+'patJetGenJetMatch',
                            genPartonMatch = unsubtractedJetTag+'patJetPartonMatch',
                            jetCorrFactorsSource = cms.VInputTag(unsubtractedJetTag+'patJetCorrFactors'),
                            jetSource = unsubtractedJetTag+'Jets',
-                           discriminatorSources = cms.VInputTag(cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probb'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probc'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probbb'), cms.InputTag(unsubtractedJetTag+'pfJetProbabilityBJetTags')),
+                           addBTagInfo = False,
+                           addDiscriminators = False,
                            addAssociatedTracks = False,
+                           useLegacyJetMCFlavour = False
                        ),
                        process, sequence)
     # And of testing of the implementation for parton flavor identification in MC

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -34,18 +34,98 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                    patJetCorrFactors.clone(payload = JECTag, src = tag+'Jets'),
                    process, sequence)
 
+    # If we want to have parton flavor identification in MC, we need non-CS subtracted jets for which the procedure works
+    # Testing the implementation here
+
     if isMC :
-        addToSequence( tag+'patJetPartonMatch',
-                       patJetPartonMatch.clone(maxDeltaR = radius,
-                          matched = 'hiSignalGenParticles',
-                          src = tag+'Jets'),
-                       process, sequence)
 
         genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
 
         addToSequence( genjetcollection,
                        ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
                        process, sequence)
+
+        unsubtractedJetTag = "ak4PFMatchingFor" + tag
+
+        addToSequence( unsubtractedJetTag+'Jets',
+                       ak4PFJets.clone(rParam = radius, src = 'packedPFCandidates'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetCorrFactors',
+                       patJetCorrFactors.clone(payload = JECTag, src = unsubtractedJetTag+'Jets'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetPartonMatch',
+                       patJetPartonMatch.clone(maxDeltaR = radius,
+                          matched = 'hiSignalGenParticles',
+                          src = unsubtractedJetTag+'Jets'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetGenJetMatch',
+                       patJetGenJetMatch.clone(maxDeltaR = radius,
+                          matched = genjetcollection,
+                          src = unsubtractedJetTag + 'Jets'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetPartonAssociationLegacy',
+                       patJetPartonAssociationLegacy.clone(jets = unsubtractedJetTag + 'Jets'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetFlavourAssociationLegacy',
+                       patJetFlavourAssociationLegacy.clone(srcByReference = unsubtractedJetTag+'patJetPartonAssociationLegacy'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJetPartons',
+                       patJetPartons.clone(partonMode = 'Pythia8'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'pfImpactParameterTagInfos',
+                       pfImpactParameterTagInfos.clone(jets = unsubtractedJetTag +'Jets',
+                          candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVerticesRecovery'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'pfSecondaryVertexTagInfos',
+                       pfSecondaryVertexTagInfos.clone(trackIPTagInfos = unsubtractedJetTag+'pfImpactParameterTagInfos'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'pfDeepCSVTagInfos',
+                       pfDeepCSVTagInfos.clone(svTagInfos = unsubtractedJetTag+'pfSecondaryVertexTagInfos'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'pfDeepCSVJetTags',
+                       pfDeepCSVJetTags.clone(src = unsubtractedJetTag+'pfDeepCSVTagInfos'),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'pfJetProbabilityBJetTags',
+                       pfJetProbabilityBJetTags.clone(tagInfos = [unsubtractedJetTag+'pfImpactParameterTagInfos']),
+                       process, sequence)
+
+        addToSequence( unsubtractedJetTag+'patJets',
+                       patJets.clone(
+                           JetFlavourInfoSource = unsubtractedJetTag+'patJetFlavourAssociation',
+                           JetPartonMapSource = unsubtractedJetTag+'patJetFlavourAssociationLegacy',
+                           genJetMatch = unsubtractedJetTag+'patJetGenJetMatch',
+                           genPartonMatch = unsubtractedJetTag+'patJetPartonMatch',
+                           jetCorrFactorsSource = cms.VInputTag(unsubtractedJetTag+'patJetCorrFactors'),
+                           jetSource = unsubtractedJetTag+'Jets',
+                           discriminatorSources = cms.VInputTag(cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probb'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probc'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(unsubtractedJetTag+'pfDeepCSVJetTags','probbb'), cms.InputTag(unsubtractedJetTag+'pfJetProbabilityBJetTags')),
+                           addAssociatedTracks = False,
+                       ),
+                       process, sequence)
+    # And of testing of the implementation for parton flavor identification in MC
+
+    if isMC :
+        addToSequence( tag+'patJetPartonMatch',
+                       patJetPartonMatch.clone(maxDeltaR = radius,
+                       matched = 'hiSignalGenParticles',
+                       src = tag+'Jets'),
+                       process, sequence)
+
+        #genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
+ 
+        #addToSequence( genjetcollection,
+        #               ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
+        #               process, sequence)
 
         addToSequence( tag+'patJetGenJetMatch',
                        patJetGenJetMatch.clone(maxDeltaR = radius,

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -15,13 +15,13 @@ def addToSequence(label, module, process, sequence):
     setattr(process, label, module)
     sequence += getattr(process, label)
 
-def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None', doFlow = False):
+def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None', doFlow = False, matchJets = False):
 
     if radius < 0:
        radiustag = get_radius(tag)
        radius = radiustag * 0.1
     else:
-       radiustag = get_radius(tag)
+       radiustag = "{:.0f}".format(radius*10)
 
     addToSequence( tag+'Jets',
                    akCs4PFJets.clone(rParam = radius, src = 'packedPFCandidates', useModulatedRho = doFlow),
@@ -34,9 +34,7 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                    patJetCorrFactors.clone(payload = JECTag, src = tag+'Jets'),
                    process, sequence)
 
-    # If we want to have parton flavor identification in MC, we need non-CS subtracted jets for which the procedure works
-    # Testing the implementation here
-
+    # Add Monte Carlo specific collections to the sequence
     if isMC :
 
         genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
@@ -45,68 +43,66 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                        ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
                        process, sequence)
 
-        unsubtractedJetTag = "ak4PFMatchingFor" + tag
+        # To find parton flavor for CS subtracted jets, they need to be matched with unsubtracted jets
+        if matchJets:
 
-        addToSequence( unsubtractedJetTag+'Jets',
-                       ak4PFJets.clone(rParam = radius, src = 'packedPFCandidates'),
-                       process, sequence)
+            unsubtractedJetTag = "ak" + str(radiustag) + "PFMatchingFor" + tag
 
-        addToSequence( unsubtractedJetTag+'patJetCorrFactors',
-                       patJetCorrFactors.clone(payload = JECTag, src = unsubtractedJetTag+'Jets'),
-                       process, sequence)
+            addToSequence( unsubtractedJetTag+'Jets',
+                           ak4PFJets.clone(rParam = radius, src = 'packedPFCandidates'),
+                           process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJetPartonMatch',
-                       patJetPartonMatch.clone(maxDeltaR = radius,
-                          matched = 'hiSignalGenParticles',
-                          src = unsubtractedJetTag+'Jets'),
-                       process, sequence)
+            addToSequence( unsubtractedJetTag+'patJetCorrFactors',
+                           patJetCorrFactors.clone(payload = JECTag, src = unsubtractedJetTag+'Jets'),
+                           process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJetGenJetMatch',
-                       patJetGenJetMatch.clone(maxDeltaR = radius,
-                          matched = genjetcollection,
-                          src = unsubtractedJetTag + 'Jets'),
-                       process, sequence)
+            addToSequence( unsubtractedJetTag+'patJetPartonMatch',
+                           patJetPartonMatch.clone(maxDeltaR = radius,
+                               matched = 'hiSignalGenParticles',
+                               src = unsubtractedJetTag+'Jets'),
+                           process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJetPartons',
-                       patJetPartons.clone(partonMode = 'Pythia8'),
-                       process, sequence)
+            addToSequence( unsubtractedJetTag+'patJetGenJetMatch',
+                           patJetGenJetMatch.clone(maxDeltaR = radius,
+                               matched = genjetcollection,
+                               src = unsubtractedJetTag + 'Jets'),
+                           process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJetFlavourAssociation',
-                       patJetFlavourAssociation.clone(jets = unsubtractedJetTag+'Jets',
-                           bHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","bHadrons"),
-                           cHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","cHadrons"),
-                           partons = cms.InputTag(unsubtractedJetTag+"patJetPartons","physicsPartons"),
-                           leptons = cms.InputTag(unsubtractedJetTag+"patJetPartons","leptons")),
-                       process, sequence)
+            addToSequence( unsubtractedJetTag+'patJetPartons',
+                           patJetPartons.clone(partonMode = 'Pythia8'),
+                           process, sequence)
 
-        addToSequence( unsubtractedJetTag+'patJets',
-                       patJets.clone(
-                           JetFlavourInfoSource = unsubtractedJetTag+'patJetFlavourAssociation',
-                           JetPartonMapSource = unsubtractedJetTag+'patJetFlavourAssociation',
-                           genJetMatch = unsubtractedJetTag+'patJetGenJetMatch',
-                           genPartonMatch = unsubtractedJetTag+'patJetPartonMatch',
-                           jetCorrFactorsSource = cms.VInputTag(unsubtractedJetTag+'patJetCorrFactors'),
-                           jetSource = unsubtractedJetTag+'Jets',
-                           addBTagInfo = False,
-                           addDiscriminators = False,
-                           addAssociatedTracks = False,
-                           useLegacyJetMCFlavour = False
-                       ),
-                       process, sequence)
-    # And of testing of the implementation for parton flavor identification in MC
+            addToSequence( unsubtractedJetTag+'patJetFlavourAssociation',
+                           patJetFlavourAssociation.clone(jets = unsubtractedJetTag+'Jets',
+                               rParam = radius,
+                               bHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","bHadrons"),
+                               cHadrons = cms.InputTag(unsubtractedJetTag+"patJetPartons","cHadrons"),
+                               partons = cms.InputTag(unsubtractedJetTag+"patJetPartons","physicsPartons"),
+                               leptons = cms.InputTag(unsubtractedJetTag+"patJetPartons","leptons")),
+                           process, sequence)
 
-    if isMC :
+            addToSequence( unsubtractedJetTag+'patJets',
+                           patJets.clone(
+                               JetFlavourInfoSource = unsubtractedJetTag+'patJetFlavourAssociation',
+                               JetPartonMapSource = unsubtractedJetTag+'patJetFlavourAssociation',
+                               genJetMatch = unsubtractedJetTag+'patJetGenJetMatch',
+                               genPartonMatch = unsubtractedJetTag+'patJetPartonMatch',
+                               jetCorrFactorsSource = cms.VInputTag(unsubtractedJetTag+'patJetCorrFactors'),
+                               jetSource = unsubtractedJetTag+'Jets',
+                               addBTagInfo = False,
+                               addDiscriminators = False,
+                               addAssociatedTracks = False,
+                               useLegacyJetMCFlavour = False
+                           ),
+                         process, sequence)
+
+        # Configuration for unsubtracted jets ready
+
         addToSequence( tag+'patJetPartonMatch',
                        patJetPartonMatch.clone(maxDeltaR = radius,
                        matched = 'hiSignalGenParticles',
                        src = tag+'Jets'),
                        process, sequence)
-
-        #genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
- 
-        #addToSequence( genjetcollection,
-        #               ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
-        #               process, sequence)
 
         addToSequence( tag+'patJetGenJetMatch',
                        patJetGenJetMatch.clone(maxDeltaR = radius,
@@ -125,6 +121,8 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
         addToSequence( tag+'patJetPartons',
                        patJetPartons.clone(partonMode = 'Pythia8'),
                        process, sequence)
+
+    # Monte Carlo specific collections added
 
     addToSequence( tag+'pfImpactParameterTagInfos',
                    pfImpactParameterTagInfos.clone(jets = tag +'Jets',

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -5,6 +5,7 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     jetTag = cms.InputTag("ak4PFJets"),
     caloJetTag = cms.InputTag("slimmedCaloJets"),
     jetPtMin = cms.double(5.0),
+    matchJets = cms.untracked.bool(False),
     matchTag = cms.untracked.InputTag("akPu4PFpatJets"),
     genjetTag = cms.InputTag("ak4HiGenJets"),
     eventInfoTag = cms.InputTag("generator"),


### PR DESCRIPTION
This pull request enables matchedHadronFlavor and matchedPartonFlavor branches for miniAOD forests.

For constituent subtracted jets, the parton flavor and hadron flavor variables do not work out of the box. The constituent subtracted jets need to be first matched with unsubtracted jets, and then the parton and hadron flavor of the unsubtracted jet is forwarded to constituent subtracted jet. The implementation for this is provided in this pull request.

For the forest configuration files, a boolean flag is added to enable or disable the jet matching and the filling of these branches.

@mandrenguyen @FHead