### PR TITLE
Fixed a bug in handling of ESGetToken<> tokens

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/src/RecHitTreeProducer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/RecHitTreeProducer.cc
@@ -214,6 +214,8 @@ private:
   edm::EDGetTokenT<std::vector<double>> jetRhoSrc_;
   edm::EDGetTokenT<std::vector<double>> jetSigmaSrc_;
 
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
+
   bool useJets_;
   bool doBasicClusters_;
   bool doTowers_;
@@ -244,7 +246,9 @@ constexpr double cone2 = 0.5 * 0.5;
 //
 // constructors and destructor
 //
-RecHitTreeProducer::RecHitTreeProducer(const edm::ParameterSet& iConfig) {
+RecHitTreeProducer::RecHitTreeProducer(const edm::ParameterSet& iConfig):
+  hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>())
+{
   //now do what ever initialization is needed
   doEbyEonly_ = iConfig.getParameter<bool>("doEbyEonly");
 
@@ -689,8 +693,7 @@ RecHitTreeProducer::analyze(const edm::Event& ev, const edm::EventSetup& iSetup)
     edm::Handle<ZDCDigiCollection> zdcdigis;
     ev.getByToken(zdcDigiSrc_,zdcdigis);
 
-    edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken;
-    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken); 
+    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken_); 
 
     int nhits = 0;
     for (auto const& rh : *zdcdigis)  {

--- a/HeavyIonsAnalysis/MuonAnalysis/interface/HLTMuTree.h
+++ b/HeavyIonsAnalysis/MuonAnalysis/interface/HLTMuTree.h
@@ -90,6 +90,8 @@ private:
   edm::InputTag MuCandTag2;
   edm::InputTag MuCandTag3;
 
+  edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken_;
+
   Bool_t doReco;
   Bool_t doGen;
   Bool_t doHLT;

--- a/HeavyIonsAnalysis/MuonAnalysis/src/HLTMuTree.cc
+++ b/HeavyIonsAnalysis/MuonAnalysis/src/HLTMuTree.cc
@@ -31,7 +31,9 @@ using namespace HepMC;
 //
 // constructors and destructor
 //
-HLTMuTree::HLTMuTree(const edm::ParameterSet& iConfig) {
+HLTMuTree::HLTMuTree(const edm::ParameterSet& iConfig):
+  transientTrackToken_(esConsumes(edm::ESInputTag("", "TransientTrackBuilder")))
+{
   //now do what ever initialization is needed
   //tagRecoMu = iConfig.getParameter<edm::InputTag>("muons");
   tagRecoMu = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>("muons"));
@@ -326,8 +328,7 @@ void HLTMuTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     //iEvent.getByLabel(tagRecoMu,muons2);
     iEvent.getByToken(tagRecoMu, muons2);
 
-    const edm::ESGetToken<TransientTrackBuilder, TransientTrackRecord> transientTrackToken(esConsumes(edm::ESInputTag("", "TransientTrackBuilder")));
-    edm::ESHandle<TransientTrackBuilder> theTTBuilder = iSetup.getHandle(transientTrackToken);
+    edm::ESHandle<TransientTrackBuilder> theTTBuilder = iSetup.getHandle(transientTrackToken_);
     KalmanVertexFitter vtxFitter;
 
     int nDiMu = 0;

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/QWZDC2018Producer2.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/QWZDC2018Producer2.cc
@@ -39,6 +39,8 @@ private:
 
   std::map<uint32_t, std::vector<double>> pedestal_;
   std::map<std::string, uint32_t> cname_;
+
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
 };
 
 QWZDC2018Producer2::QWZDC2018Producer2(const edm::ParameterSet& pset)
@@ -46,7 +48,9 @@ QWZDC2018Producer2::QWZDC2018Producer2(const edm::ParameterSet& pset)
       SOI_(pset.getUntrackedParameter<int>("SOI", 4)),
       bHardCode_(pset.getUntrackedParameter<bool>(
           "HardCode", true)),  // has to be hard coded now, calibration format is not working at the moment =_=
-      bDebug_(pset.getUntrackedParameter<bool>("Debug", false)) {
+      bDebug_(pset.getUntrackedParameter<bool>("Debug", false)),
+      hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>())      
+{
   consumes<QIE10DigiCollection>(Src_);
 
   for (int channel = 0; channel < 16; channel++) {
@@ -128,8 +132,7 @@ void QWZDC2018Producer2::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
   ESHandle<HcalDbService> conditions;
   if (!bHardCode_){
-    edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken;
-    conditions = iSetup.getHandle(hcalDatabaseToken);
+    conditions = iSetup.getHandle(hcalDatabaseToken_);
   }
 
   Handle<QIE10DigiCollection> digis;

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCTreeProducer.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCTreeProducer.cc
@@ -115,13 +115,12 @@ private:
   bool verbose_;
 
   edm::Service<TFileService> fs;
-  //edm::ESHandle<CaloGeometry> geo;
   const CaloGeometry* geo;
 
-  //edm::EDGetTokenT<ZDCDigiCollection> zdcDigiSrc_;
   edm::InputTag zdcDigiSrc_;
   edm::EDGetTokenT<ZDCRecHitCollection> zdcRecHitSrc_;
   edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geometryToken_;
+  edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
 
   bool doZDCRecHit_;
   bool doZDCDigi_;
@@ -139,7 +138,9 @@ constexpr double cone2 = 0.5 * 0.5;
 //
 // constructors and destructor
 //
-ZDCTreeProducer::ZDCTreeProducer(const edm::ParameterSet& iConfig) {
+ZDCTreeProducer::ZDCTreeProducer(const edm::ParameterSet& iConfig):
+  hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>())
+{
   //now do what ever initialization is needed
   doZDCRecHit_ = iConfig.getParameter<bool>("doZDCRecHit");
   doZDCDigi_ = iConfig.getParameter<bool>("doZDCDigi");
@@ -208,8 +209,7 @@ void ZDCTreeProducer::analyze(const edm::Event& ev, const edm::EventSetup& iSetu
     edm::Handle<QIE10DigiCollection> zdcdigis;
     ev.getByLabel(zdcDigiSrc_, zdcdigis);
 
-    edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken;
-    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken);
+    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken_);
 
     int nhits = 0;
     //    for (auto const& rh : *zdcdigis)  {


### PR DESCRIPTION
This pull request fixes a ESGetToken<> bug that was introduced in commit

https://github.com/CmsHI/cmssw/commit/e438c87d428fedc8411fd8071777c60a0fc95296

The old method to handle these tokens in CMSSW 12 was deprecated in CMSSW 13, so I needed to update the method. However, I did not include the proper ESConsumes line for the tokens, so they do not get properly initialized in the code. None of the four tokens that are fixed by this pull request are active in the default forest configuration, so I did not notice this bug before. The bug for ZDC tree was reported and a fix to it provided by @cfmcginn in

https://github.com/CmsHI/cmssw/pull/363 

However, since this same bug is also present for the three other producers included in this pull request, I decided to make a common pull request to fix all the tokens at once instead of fixing these in different pull requests.

@mandrenguyen @FHead 
