### PR TITLE
Default configuration update

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
@@ -119,7 +119,7 @@ process.load('HeavyIonsAnalysis.ZDCAnalysis.zdcanalyzer_cfi')
 process.zdcanalyzer.doZDCRecHit = True
 process.zdcanalyzer.doZDCDigi = False
 process.zdcanalyzer.zdcRecHitSrc = cms.InputTag("QWzdcreco")
-process.zdcanalyzer.calZDCDigi = True
+process.zdcanalyzer.calZDCDigi = False
 ################################
 
 

--- a/HeavyIonsAnalysis/EGMAnalysis/python/ggHiNtuplizer_cfi.py
+++ b/HeavyIonsAnalysis/EGMAnalysis/python/ggHiNtuplizer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 ggHiNtuplizer = cms.EDAnalyzer("ggHiNtuplizer",
     doGenParticles = cms.bool(False),
     doSuperClusters = cms.bool(False),
-    doElectrons = cms.bool(False),
+    doElectrons = cms.bool(True),
     doPhotons = cms.bool(True),
     doMuons = cms.bool(True),
 


### PR DESCRIPTION
Updating default configuration in the HiForest. The following updates are done for the default configuration:

1) Now electrons are included by default in ggHiNtuplizer
2) Now calZDCDigi is set to false.

The electrons are many times needed in the forest, so it is better to have them included by default and the used can disable them if not needed. The reason for point 2 is that the current code version will crash if the ZDC digis are calculated manually using the above flag.

@hbharadwaj