### PR TITLE
Updated test file, added more HF filters

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run2_DATA.py
@@ -120,6 +120,8 @@ process.zdcanalyzer.doZDCRecHit = True
 process.zdcanalyzer.doZDCDigi = True
 process.zdcanalyzer.zdcRecHitSrc = cms.InputTag("QWzdcreco")
 process.zdcanalyzer.calZDCDigi = False
+process.zdcanalyzer.verbose = False
+
 ################################
 
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,13 +25,13 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 132X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        '/store/hidata/HIRun2022A/MinimumBias/MINIAOD/PromptReco-v1/000/362/348/00000/177c1a96-3e1f-4cfe-a282-690f3b6e7f7d.root'
+        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/PhysicsHIPhysicsRawPrime0/374288/step3_RAW2DIGI_L1Reco_RECO_PAT_ls0060.root'
     ), 
 )
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(50)
+    input = cms.untracked.int32(20)
     )
 
 ###############################################################################
@@ -228,7 +228,27 @@ process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
 process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
 process.load('HeavyIonsAnalysis.EventAnalysis.hffilter_cfi')
+process.pphfCoincFilter4Th2 = cms.Path(process.phfCoincFilter4Th2)
+process.pphfCoincFilter1Th3 = cms.Path(process.phfCoincFilter1Th3)
+process.pphfCoincFilter2Th3 = cms.Path(process.phfCoincFilter2Th3)
+process.pphfCoincFilter3Th3 = cms.Path(process.phfCoincFilter3Th3)
+process.pphfCoincFilter4Th3 = cms.Path(process.phfCoincFilter4Th3)
+process.pphfCoincFilter5Th3 = cms.Path(process.phfCoincFilter5Th3)
+process.pphfCoincFilter1Th4 = cms.Path(process.phfCoincFilter1Th4)
 process.pphfCoincFilter2Th4 = cms.Path(process.phfCoincFilter2Th4)
+process.pphfCoincFilter3Th4 = cms.Path(process.phfCoincFilter3Th4)
+process.pphfCoincFilter4Th4 = cms.Path(process.phfCoincFilter4Th4)
+process.pphfCoincFilter5Th4 = cms.Path(process.phfCoincFilter5Th4)
+process.pphfCoincFilter1Th5 = cms.Path(process.phfCoincFilter1Th5)
+process.pphfCoincFilter2Th5 = cms.Path(process.phfCoincFilter2Th5)
+process.pphfCoincFilter3Th5 = cms.Path(process.phfCoincFilter3Th5)
+process.pphfCoincFilter4Th5 = cms.Path(process.phfCoincFilter4Th5)
+process.pphfCoincFilter5Th5 = cms.Path(process.phfCoincFilter5Th5)
+process.pphfCoincFilter1Th6 = cms.Path(process.phfCoincFilter1Th6)
+process.pphfCoincFilter2Th6 = cms.Path(process.phfCoincFilter2Th6)
+process.pphfCoincFilter3Th6 = cms.Path(process.phfCoincFilter3Th6)
+process.pphfCoincFilter4Th6 = cms.Path(process.phfCoincFilter4Th6)
+process.pphfCoincFilter5Th6 = cms.Path(process.phfCoincFilter5Th6)
 process.pAna = cms.EndPath(process.skimanalysis)
 
 #from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel

--- a/HeavyIonsAnalysis/EventAnalysis/python/hffilter_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hffilter_cfi.py
@@ -1,7 +1,33 @@
 import FWCore.ParameterSet.Config as cms
 
 phfCoincFilter2Th4  = cms.EDFilter('HiHFFilter',
-   HFfilters      = cms.InputTag("hiHFfilters","hiHFfilters","PAT"),
+   HFfilters      = cms.InputTag("hiHFfilters","hiHFfilters"),
    threshold      = cms.int32(4),
    minnumtowers  = cms.int32(2)
 )
+
+phfCoincFilter1Th4 = phfCoincFilter2Th4.clone(minnumtowers = 1)
+phfCoincFilter3Th4 = phfCoincFilter2Th4.clone(minnumtowers = 3)
+phfCoincFilter4Th4 = phfCoincFilter2Th4.clone(minnumtowers = 4)
+phfCoincFilter5Th4 = phfCoincFilter2Th4.clone(minnumtowers = 5)
+
+phfCoincFilter1Th3 = phfCoincFilter2Th4.clone(threshold = 3, minnumtowers = 1)
+phfCoincFilter2Th3 = phfCoincFilter2Th4.clone(threshold = 3, minnumtowers = 2)
+phfCoincFilter3Th3 = phfCoincFilter2Th4.clone(threshold = 3, minnumtowers = 3)
+phfCoincFilter4Th3 = phfCoincFilter2Th4.clone(threshold = 3, minnumtowers = 4)
+phfCoincFilter5Th3 = phfCoincFilter2Th4.clone(threshold = 3, minnumtowers = 5)
+
+phfCoincFilter1Th5 = phfCoincFilter2Th4.clone(threshold = 5, minnumtowers = 1)
+phfCoincFilter2Th5 = phfCoincFilter2Th4.clone(threshold = 5, minnumtowers = 2)
+phfCoincFilter3Th5 = phfCoincFilter2Th4.clone(threshold = 5, minnumtowers = 3)
+phfCoincFilter4Th5 = phfCoincFilter2Th4.clone(threshold = 5, minnumtowers = 4)
+phfCoincFilter5Th5 = phfCoincFilter2Th4.clone(threshold = 5, minnumtowers = 5)
+
+phfCoincFilter1Th6 = phfCoincFilter2Th4.clone(threshold = 6, minnumtowers = 1)
+phfCoincFilter2Th6 = phfCoincFilter2Th4.clone(threshold = 6, minnumtowers = 2)
+phfCoincFilter3Th6 = phfCoincFilter2Th4.clone(threshold = 6, minnumtowers = 3)
+phfCoincFilter4Th6 = phfCoincFilter2Th4.clone(threshold = 6, minnumtowers = 4)
+phfCoincFilter5Th6 = phfCoincFilter2Th4.clone(threshold = 6, minnumtowers = 5)
+
+phfCoincFilter4Th2 = phfCoincFilter2Th4.clone(threshold = 2, minnumtowers = 4)
+


### PR DESCRIPTION
This PR updates the test file from run3 miniAOD, plus addresses an issue for HF filters and and more variations of the filter to the forest.

1) The test file for forest_miniAOD_run3_DATA.py is now a miniAOD file from PbPb 2023 run
2) Removed "PAT" specification for HFfilters in hffilter_cfi.py. The product is reRECO in 2023 run reconstruction. Not specifying the third option for HFfilters makes the same configuration work for run2 and run3
3) Following a request from global observables, added more options for HFFilter thresholds
