### PR TITLE
Update TriggerAnalyzer.cc

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/plugins/TriggerAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/TriggerAnalyzer.cc
@@ -233,7 +233,9 @@ void TriggerAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const& i
       bool accept = result.getAlgoDecisionFinal(l1index);
       l1flag[index] = accept;
 
-      l1GtUtils.getPrescaleByBit(l1index, (double&)l1Prescl[index]);
+      double prescale = -1;
+      l1GtUtils.getPrescaleByBit(l1index, prescale);
+      l1Prescl[index] = prescale;
     }
 
     // l1results.isValid


### PR DESCRIPTION
Bug fix to get L1 prescales correctly.  Old version gives all zero.  Tested with MiniAOD but this change will not break anything

Please make sure to mention (using the @ syntax) anyone who might be interested in this PR.
@jusaviin 