### PR TITLE
Remove dummy branches from HLT and L1

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,7 +25,7 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 132X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/PhysicsHIPhysicsRawPrime0/374288/step3_RAW2DIGI_L1Reco_RECO_PAT_ls0060.root'
+        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/PhysicsHIPhysicsRawPrime0/374288/step3_RAW2DIGI_L1Reco_RECO_PAT.root'
     ), 
 )
 

--- a/HeavyIonsAnalysis/EventAnalysis/python/dummybranches_cff.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/dummybranches_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+dummy_branches_for_PbPb_2023_HLT = cms.vstring([])
+dummy_branches_for_PbPb_2023_L1 = cms.vstring([])
+
 dummy_branches_for_PbPb_2018_HLT = cms.vstring([
     'DST_Physics_v7',
     'AlCa_EcalEtaEBonlyForHI_v1',

--- a/HeavyIonsAnalysis/EventAnalysis/python/hltanalysis_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hltanalysis_cfi.py
@@ -7,7 +7,7 @@ hltanalysis = cms.EDAnalyzer(
     HLTProcessName = cms.string('HLT'),
     hltresults = cms.InputTag('TriggerResults::HLT'),
     l1results = cms.InputTag('gtStage2Digis'),
-    hltdummybranches = dummy_branches_for_PbPb_2018_HLT,
-    l1dummybranches = dummy_branches_for_PbPb_2018_L1,
+    hltdummybranches = dummy_branches_for_PbPb_2023_HLT,
+    l1dummybranches = dummy_branches_for_PbPb_2023_L1,
     hltPSProvCfg=cms.PSet(stageL1Trigger = cms.uint32(2)),
     )


### PR DESCRIPTION
Removing dummy branches from HLT and L1. This reduces the branches in HLT bit analyzer from 3745 to 1488 by removing obsolete dummy branches from run2.

@FHead
