### PR TITLE
Add calo jets to forest

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,13 +25,13 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 132X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/PhysicsHIPhysicsRawPrime0/374288/step3_RAW2DIGI_L1Reco_RECO_PAT.root'
+        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/miniaod_HIExpress_374354/reco_run374354_ls0050_streamHIExpress_StorageManager.root'
     ), 
 )
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(20)
+    input = cms.untracked.int32(25)
     )
 
 ###############################################################################
@@ -90,6 +90,8 @@ process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ################################
 # jet reco sequence
 process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_data_cff')
+process.load('HeavyIonsAnalysis.JetAnalysis.akPu4CaloJetSequence_pponPbPb_data_cff')
+process.akPu4CaloJetAnalyzer.doHiJetID = True
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
@@ -151,7 +153,8 @@ process.forest = cms.Path(
     #process.QWzdcreco +
     process.zdcanalyzer +
     process.unpackedMuons +
-    process.muonAnalyzer
+    process.muonAnalyzer +
+    process.akPu4CaloJetAnalyzer
     )
 
 #customisation

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiCaloJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiCaloJetAnalyzer.h
@@ -1,0 +1,147 @@
+#ifndef HiCaloJetAnalyzer_caloJetAnalyzer_
+#define HiCaloJetAnalyzer_caloJetAnalyzer_
+
+// system include files
+#include <memory>
+#include <string>
+#include <iostream>
+
+// ROOT headers
+#include "TTree.h"
+
+// user include files
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "fastjet/contrib/Njettiness.hh"
+//
+
+/**\class HiCaloJetAnalyzer
+
+   \author Jussi Viinikainen
+   \date   September 2023
+*/
+
+class HiCaloJetAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+public:
+  explicit HiCaloJetAnalyzer(const edm::ParameterSet&);
+
+  ~HiCaloJetAnalyzer() override;
+
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+
+  void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
+  void endRun(const edm::Run& run, const edm::EventSetup& es) override;
+
+  void beginJob() override;
+
+private:
+
+  edm::InputTag jetTagLabel_;
+  edm::EDGetTokenT<reco::CaloJetCollection> jetTag_;
+  edm::EDGetTokenT<edm::View<pat::PackedCandidate>> pfCandidateLabel_;
+  edm::EDGetTokenT<reco::GenParticleCollection> genParticleSrc_;
+  edm::EDGetTokenT<edm::View<reco::GenJet>> genjetTag_;
+  edm::EDGetTokenT<edm::HepMCProduct> eventInfoTag_;
+  edm::EDGetTokenT<GenEventInfoProduct> eventGenInfoTag_;
+
+  std::string jetName_;  //used as prefix for jet structures
+
+  bool isMC_;
+  bool useHepMC_;
+  bool fillGenJets_;
+  bool useQuality_;
+  std::string trackQuality_;
+
+  double genPtMin_;
+
+  bool doHiJetID_;
+
+  double rParam;
+  double hardPtMin_;
+  double jetPtMin_;
+  double jetAbsEtaMax_;
+
+  TTree* caloJetTree_;
+  edm::Service<TFileService> fs1;
+
+  static const int MAXJETS = 1000;
+  static const int MAXTRACKS = 5000;
+
+  struct JRA {
+    int nref = 0;
+    int run = 0;
+    int evt = 0;
+    int lumi = 0;
+
+    float rawpt[MAXJETS] = {0};
+    float jtpt[MAXJETS] = {0};
+    float jteta[MAXJETS] = {0};
+    float jtphi[MAXJETS] = {0};
+
+    float jty[MAXJETS] = {0};
+    float jtpu[MAXJETS] = {0};
+    float jtm[MAXJETS] = {0};
+    float jtarea[MAXJETS] = {0};
+
+    float trackMax[MAXJETS] = {0};
+    float trackSum[MAXJETS] = {0};
+    int trackN[MAXJETS] = {0};
+
+    float chargedMax[MAXJETS] = {0};
+    float chargedSum[MAXJETS] = {0};
+    int chargedN[MAXJETS] = {0};
+
+    float photonMax[MAXJETS] = {0};
+    float photonSum[MAXJETS] = {0};
+    int photonN[MAXJETS] = {0};
+
+    float trackHardSum[MAXJETS] = {0};
+    float chargedHardSum[MAXJETS] = {0};
+    float photonHardSum[MAXJETS] = {0};
+
+    int trackHardN[MAXJETS] = {0};
+    int chargedHardN[MAXJETS] = {0};
+    int photonHardN[MAXJETS] = {0};
+
+    float neutralMax[MAXJETS] = {0};
+    float neutralSum[MAXJETS] = {0};
+    int neutralN[MAXJETS] = {0};
+
+    float eMax[MAXJETS] = {0};
+    float eSum[MAXJETS] = {0};
+    int eN[MAXJETS] = {0};
+
+    float muMax[MAXJETS] = {0};
+    float muSum[MAXJETS] = {0};
+    int muN[MAXJETS] = {0};
+
+    float genChargedSum[MAXJETS] = {0};
+    float genHardSum[MAXJETS] = {0};
+    float signalChargedSum[MAXJETS] = {0};
+    float signalHardSum[MAXJETS] = {0};
+
+    float pthat = 0;
+    int beamId1 = 0;
+    int beamId2 = 0;
+    int ngen = 0;
+    float genpt[MAXJETS] = {0};
+    float geneta[MAXJETS] = {0};
+    float genphi[MAXJETS] = {0};
+    float genm[MAXJETS] = {0};
+    float geny[MAXJETS] = {0};
+
+  };
+
+  JRA jets_;
+};
+
+#endif

--- a/HeavyIonsAnalysis/JetAnalysis/python/akPu4CaloJetSequence_pponPbPb_data_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akPu4CaloJetSequence_pponPbPb_data_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+from HeavyIonsAnalysis.JetAnalysis.caloJetAnalyzer_cff import *
+
+akPu4CaloJetAnalyzer = caloJetAnalyzer.clone(
+    jetTag = cms.InputTag("slimmedCaloJets"),
+    rParam = 0.4,
+    fillGenJets = False,
+    isMC = False,
+    jetName = cms.untracked.string("akPu4Calo"),
+    hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL')
+    )

--- a/HeavyIonsAnalysis/JetAnalysis/python/caloJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/caloJetAnalyzer_cff.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+caloJetAnalyzer = cms.EDAnalyzer(
+    "HiCaloJetAnalyzer",
+    jetTag = cms.InputTag("slimmedCaloJets"),
+    jetName = cms.untracked.string("akPu4Calo"),
+    jetPtMin = cms.double(5.0),
+    genjetTag = cms.InputTag("ak4HiGenJets"),
+    eventInfoTag = cms.InputTag("generator"),
+    isMC = cms.untracked.bool(False), 
+    fillGenJets = cms.untracked.bool(False),
+    rParam = cms.double(0.4),
+    pfCandidateLabel = cms.untracked.InputTag('packedPFCandidates'),
+    trackTag = cms.InputTag("hiTracks"),
+    trackQuality  = cms.untracked.string("highPurity"),
+    towersSrc = cms.InputTag("towerMaker"),
+    useHepMC = cms.untracked.bool(False),
+    useQuality = cms.untracked.bool(True),
+    doHiJetID = cms.untracked.bool(False)
+    )

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
@@ -1,0 +1,364 @@
+/*
+  Based on the HiCaloJetAnalyzer
+  Modified by Jussi Viinikainen, September 2023
+*/
+
+#include "HeavyIonsAnalysis/JetAnalysis/interface/HiCaloJetAnalyzer.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/GenJetCollection.h"
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "fastjet/contrib/Njettiness.hh"
+#include "fastjet/AreaDefinition.hh"
+#include "fastjet/ClusterSequence.hh"
+#include "fastjet/ClusterSequenceArea.hh"
+#include "fastjet/contrib/SoftDrop.hh"
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+HiCaloJetAnalyzer::HiCaloJetAnalyzer(const edm::ParameterSet& iConfig) {
+  jetTag_ = consumes<reco::CaloJetCollection>(iConfig.getParameter<InputTag>("jetTag"));
+
+  useQuality_ = iConfig.getUntrackedParameter<bool>("useQuality", true);
+  trackQuality_ = iConfig.getUntrackedParameter<string>("trackQuality", "highPurity");
+
+  jetName_ = iConfig.getUntrackedParameter<string>("jetName");
+
+  isMC_ = iConfig.getUntrackedParameter<bool>("isMC", false);
+  useHepMC_ = iConfig.getUntrackedParameter<bool>("useHepMC", false);
+  fillGenJets_ = iConfig.getUntrackedParameter<bool>("fillGenJets", false);
+
+  doHiJetID_ = iConfig.getUntrackedParameter<bool>("doHiJetID", false);
+
+  rParam = iConfig.getParameter<double>("rParam");
+  hardPtMin_ = iConfig.getUntrackedParameter<double>("hardPtMin", 4);
+  jetPtMin_ = iConfig.getParameter<double>("jetPtMin");
+  jetAbsEtaMax_ = iConfig.getUntrackedParameter<double>("jetAbsEtaMax", 5.1);
+
+  if (isMC_) {
+    genjetTag_ = consumes<edm::View<reco::GenJet>>(iConfig.getParameter<InputTag>("genjetTag"));
+    if (useHepMC_)
+      eventInfoTag_ = consumes<HepMCProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
+    eventGenInfoTag_ = consumes<GenEventInfoProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
+  }
+
+  pfCandidateLabel_ =
+      consumes<edm::View<pat::PackedCandidate>>(iConfig.getUntrackedParameter<edm::InputTag>("pfCandidateLabel"));
+
+  if (isMC_)
+    genParticleSrc_ =
+        consumes<reco::GenParticleCollection>(iConfig.getUntrackedParameter<edm::InputTag>("genParticles"));
+
+  if (isMC_) {
+    genPtMin_ = iConfig.getUntrackedParameter<double>("genPtMin", 10);
+  }
+}
+
+HiCaloJetAnalyzer::~HiCaloJetAnalyzer() {}
+
+void HiCaloJetAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& es) {}
+void HiCaloJetAnalyzer::endRun(const edm::Run& run, const edm::EventSetup& es) {}
+
+void HiCaloJetAnalyzer::beginJob() {
+  string jetTagTitle = jetTagLabel_.label() + " Jet Analysis Tree";
+  caloJetTree_ = fs1->make<TTree>("caloJetTree", jetTagTitle.c_str());
+
+  caloJetTree_->Branch("run", &jets_.run, "run/I");
+  caloJetTree_->Branch("evt", &jets_.evt, "evt/I");
+  caloJetTree_->Branch("lumi", &jets_.lumi, "lumi/I");
+  caloJetTree_->Branch("nref", &jets_.nref, "nref/I");
+  caloJetTree_->Branch("rawpt", jets_.rawpt, "rawpt[nref]/F");
+  caloJetTree_->Branch("jtpt", jets_.jtpt, "jtpt[nref]/F");
+  caloJetTree_->Branch("jteta", jets_.jteta, "jteta[nref]/F");
+  caloJetTree_->Branch("jty", jets_.jty, "jty[nref]/F");
+  caloJetTree_->Branch("jtphi", jets_.jtphi, "jtphi[nref]/F");
+  caloJetTree_->Branch("jtpu", jets_.jtpu, "jtpu[nref]/F");
+  caloJetTree_->Branch("jtm", jets_.jtm, "jtm[nref]/F");
+  caloJetTree_->Branch("jtarea", jets_.jtarea, "jtarea[nref]/F");
+
+  // jet ID information, jet composition
+  if (doHiJetID_) {
+    caloJetTree_->Branch("trackMax", jets_.trackMax, "trackMax[nref]/F");
+    caloJetTree_->Branch("trackSum", jets_.trackSum, "trackSum[nref]/F");
+    caloJetTree_->Branch("trackN", jets_.trackN, "trackN[nref]/I");
+    caloJetTree_->Branch("trackHardSum", jets_.trackHardSum, "trackHardSum[nref]/F");
+    caloJetTree_->Branch("trackHardN", jets_.trackHardN, "trackHardN[nref]/I");
+
+    caloJetTree_->Branch("chargedMax", jets_.chargedMax, "chargedMax[nref]/F");
+    caloJetTree_->Branch("chargedSum", jets_.chargedSum, "chargedSum[nref]/F");
+    caloJetTree_->Branch("chargedN", jets_.chargedN, "chargedN[nref]/I");
+    caloJetTree_->Branch("chargedHardSum", jets_.chargedHardSum, "chargedHardSum[nref]/F");
+    caloJetTree_->Branch("chargedHardN", jets_.chargedHardN, "chargedHardN[nref]/I");
+
+    caloJetTree_->Branch("photonMax", jets_.photonMax, "photonMax[nref]/F");
+    caloJetTree_->Branch("photonSum", jets_.photonSum, "photonSum[nref]/F");
+    caloJetTree_->Branch("photonN", jets_.photonN, "photonN[nref]/I");
+    caloJetTree_->Branch("photonHardSum", jets_.photonHardSum, "photonHardSum[nref]/F");
+    caloJetTree_->Branch("photonHardN", jets_.photonHardN, "photonHardN[nref]/I");
+
+    caloJetTree_->Branch("neutralMax", jets_.neutralMax, "neutralMax[nref]/F");
+    caloJetTree_->Branch("neutralSum", jets_.neutralSum, "neutralSum[nref]/F");
+    caloJetTree_->Branch("neutralN", jets_.neutralN, "neutralN[nref]/I");
+
+    caloJetTree_->Branch("eMax", jets_.eMax, "eMax[nref]/F");
+    caloJetTree_->Branch("eSum", jets_.eSum, "eSum[nref]/F");
+    caloJetTree_->Branch("eN", jets_.eN, "eN[nref]/I");
+
+    caloJetTree_->Branch("muMax", jets_.muMax, "muMax[nref]/F");
+    caloJetTree_->Branch("muSum", jets_.muSum, "muSum[nref]/F");
+    caloJetTree_->Branch("muN", jets_.muN, "muN[nref]/I");
+  }
+
+  if (isMC_) {
+    if (useHepMC_) {
+      caloJetTree_->Branch("beamId1", &jets_.beamId1, "beamId1/I");
+      caloJetTree_->Branch("beamId2", &jets_.beamId2, "beamId2/I");
+    }
+
+    caloJetTree_->Branch("pthat", &jets_.pthat, "pthat/F");
+
+    caloJetTree_->Branch("genChargedSum", jets_.genChargedSum, "genChargedSum[nref]/F");
+    caloJetTree_->Branch("genHardSum", jets_.genHardSum, "genHardSum[nref]/F");
+    caloJetTree_->Branch("signalChargedSum", jets_.signalChargedSum, "signalChargedSum[nref]/F");
+    caloJetTree_->Branch("signalHardSum", jets_.signalHardSum, "signalHardSum[nref]/F");
+
+    if (fillGenJets_) {
+      // For all gen jets, matched or unmatched
+      caloJetTree_->Branch("ngen", &jets_.ngen, "ngen/I");
+      caloJetTree_->Branch("genpt", jets_.genpt, "genpt[ngen]/F");
+      caloJetTree_->Branch("geneta", jets_.geneta, "geneta[ngen]/F");
+      caloJetTree_->Branch("geny", jets_.geny, "geny[ngen]/F");
+      caloJetTree_->Branch("genphi", jets_.genphi, "genphi[ngen]/F");
+      caloJetTree_->Branch("genm", jets_.genm, "genm[ngen]/F");
+
+    }
+  }
+
+}
+
+void HiCaloJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
+  int event = iEvent.id().event();
+  int run = iEvent.id().run();
+  int lumi = iEvent.id().luminosityBlock();
+
+  jets_.run = run;
+  jets_.evt = event;
+  jets_.lumi = lumi;
+
+  LogDebug("HiCaloJetAnalyzer") << "START event: " << event << " in run " << run << endl;
+
+  // loop the events
+  edm::Handle<reco::CaloJetCollection> jets;
+  iEvent.getByToken(jetTag_, jets);
+
+  edm::Handle<edm::View<pat::PackedCandidate>> pfCandidates;
+  iEvent.getByToken(pfCandidateLabel_, pfCandidates);
+  if (isMC_) {
+    edm::Handle<reco::GenParticleCollection> genparts;
+    iEvent.getByToken(genParticleSrc_, genparts);
+  }
+
+  // FILL JRA TREE
+  jets_.nref = 0;
+
+  for (unsigned int j = 0; j < jets->size(); ++j) {
+    const pat::Jet& jet = (*jets)[j];
+
+    auto pt = jet.pt();
+    if (pt < jetPtMin_)
+      continue;
+    if (std::abs(jet.eta()) > jetAbsEtaMax_)
+      continue;
+
+    if (doHiJetID_) {
+      // Jet ID variables
+
+      jets_.muMax[jets_.nref] = 0;
+      jets_.muSum[jets_.nref] = 0;
+      jets_.muN[jets_.nref] = 0;
+
+      jets_.eMax[jets_.nref] = 0;
+      jets_.eSum[jets_.nref] = 0;
+      jets_.eN[jets_.nref] = 0;
+
+      jets_.neutralMax[jets_.nref] = 0;
+      jets_.neutralSum[jets_.nref] = 0;
+      jets_.neutralN[jets_.nref] = 0;
+
+      jets_.photonMax[jets_.nref] = 0;
+      jets_.photonSum[jets_.nref] = 0;
+      jets_.photonN[jets_.nref] = 0;
+      jets_.photonHardSum[jets_.nref] = 0;
+      jets_.photonHardN[jets_.nref] = 0;
+
+      jets_.chargedMax[jets_.nref] = 0;
+      jets_.chargedSum[jets_.nref] = 0;
+      jets_.chargedN[jets_.nref] = 0;
+      jets_.chargedHardSum[jets_.nref] = 0;
+      jets_.chargedHardN[jets_.nref] = 0;
+
+      jets_.trackMax[jets_.nref] = 0;
+      jets_.trackSum[jets_.nref] = 0;
+      jets_.trackN[jets_.nref] = 0;
+      jets_.trackHardSum[jets_.nref] = 0;
+      jets_.trackHardN[jets_.nref] = 0;
+
+      jets_.genChargedSum[jets_.nref] = 0;
+      jets_.genHardSum[jets_.nref] = 0;
+
+      jets_.signalChargedSum[jets_.nref] = 0;
+      jets_.signalHardSum[jets_.nref] = 0;
+
+      for (unsigned int icand = 0; icand < pfCandidates->size(); ++icand) {
+        const pat::PackedCandidate& currentCandidate = (*pfCandidates)[icand];
+
+        if (!currentCandidate.hasTrackDetails())
+          continue;
+
+        reco::Track const& track = currentCandidate.pseudoTrack();
+
+        if (useQuality_) {
+          bool goodtrack = track.quality(reco::TrackBase::qualityByName(trackQuality_));
+          if (!goodtrack)
+            continue;
+        }
+
+        double dr = deltaR(jet, track);
+        if (dr < rParam) {
+          double ptcand = track.pt();
+          jets_.trackSum[jets_.nref] += ptcand;
+          jets_.trackN[jets_.nref] += 1;
+
+          if (ptcand > hardPtMin_) {
+            jets_.trackHardSum[jets_.nref] += ptcand;
+            jets_.trackHardN[jets_.nref] += 1;
+          }
+          if (ptcand > jets_.trackMax[jets_.nref])
+            jets_.trackMax[jets_.nref] = ptcand;
+        }
+      }
+
+      reco::PFCandidate converter = reco::PFCandidate();
+      for (unsigned int icand = 0; icand < pfCandidates->size(); ++icand) {
+        const pat::PackedCandidate& track = (*pfCandidates)[icand];
+        double dr = deltaR(jet, track);
+        if (dr < rParam) {
+          double ptcand = track.pt();
+          int pfid = converter.translatePdgIdToType(track.pdgId());
+
+          switch (pfid) {
+            case 1:
+              jets_.chargedSum[jets_.nref] += ptcand;
+              jets_.chargedN[jets_.nref] += 1;
+              if (ptcand > hardPtMin_) {
+                jets_.chargedHardSum[jets_.nref] += ptcand;
+                jets_.chargedHardN[jets_.nref] += 1;
+              }
+              if (ptcand > jets_.chargedMax[jets_.nref])
+                jets_.chargedMax[jets_.nref] = ptcand;
+              break;
+
+            case 2:
+              jets_.eSum[jets_.nref] += ptcand;
+              jets_.eN[jets_.nref] += 1;
+              if (ptcand > jets_.eMax[jets_.nref])
+                jets_.eMax[jets_.nref] = ptcand;
+              break;
+
+            case 3:
+              jets_.muSum[jets_.nref] += ptcand;
+              jets_.muN[jets_.nref] += 1;
+              if (ptcand > jets_.muMax[jets_.nref])
+                jets_.muMax[jets_.nref] = ptcand;
+              break;
+
+            case 4:
+              jets_.photonSum[jets_.nref] += ptcand;
+              jets_.photonN[jets_.nref] += 1;
+              if (ptcand > hardPtMin_) {
+                jets_.photonHardSum[jets_.nref] += ptcand;
+                jets_.photonHardN[jets_.nref] += 1;
+              }
+              if (ptcand > jets_.photonMax[jets_.nref])
+                jets_.photonMax[jets_.nref] = ptcand;
+              break;
+
+            case 5:
+              jets_.neutralSum[jets_.nref] += ptcand;
+              jets_.neutralN[jets_.nref] += 1;
+              if (ptcand > jets_.neutralMax[jets_.nref])
+                jets_.neutralMax[jets_.nref] = ptcand;
+              break;
+
+            default:
+              break;
+          }
+        }
+      }
+    }
+
+    jets_.rawpt[jets_.nref] = jet.pt();
+    jets_.jtpt[jets_.nref] = jet.pt();
+    jets_.jteta[jets_.nref] = jet.eta();
+    jets_.jtphi[jets_.nref] = jet.phi();
+    jets_.jty[jets_.nref] = jet.eta();
+    jets_.jtpu[jets_.nref] = jet.pileup();
+    jets_.jtm[jets_.nref] = jet.mass();
+    jets_.jtarea[jets_.nref] = jet.jetArea();
+
+    jets_.nref++;
+  }
+
+  if (isMC_) {
+    if (useHepMC_) {
+      edm::Handle<HepMCProduct> hepMCProduct;
+      iEvent.getByToken(eventInfoTag_, hepMCProduct);
+      const HepMC::GenEvent* MCEvt = hepMCProduct->GetEvent();
+
+      std::pair<HepMC::GenParticle*, HepMC::GenParticle*> beamParticles = MCEvt->beam_particles();
+      jets_.beamId1 = (beamParticles.first != 0) ? beamParticles.first->pdg_id() : 0;
+      jets_.beamId2 = (beamParticles.second != 0) ? beamParticles.second->pdg_id() : 0;
+    }
+
+    edm::Handle<GenEventInfoProduct> hEventInfo;
+    iEvent.getByToken(eventGenInfoTag_, hEventInfo);
+
+    // binning values and qscale appear to be equivalent, but binning values not always present
+    jets_.pthat = hEventInfo->qScale();
+
+    edm::Handle<edm::View<reco::GenJet>> genjets;
+    iEvent.getByToken(genjetTag_, genjets);
+
+    jets_.ngen = 0;
+
+    for (unsigned int igen = 0; igen < genjets->size(); ++igen) {
+      const reco::GenJet& genjet = (*genjets)[igen];
+      float genjet_pt = genjet.pt();
+
+      // threshold to reduce size of output in minbias PbPb
+      if (genjet_pt > genPtMin_) {
+        jets_.genpt[jets_.ngen] = genjet_pt;
+        jets_.geneta[jets_.ngen] = genjet.eta();
+        jets_.genphi[jets_.ngen] = genjet.phi();
+        jets_.genm[jets_.ngen] = genjet.mass();
+        jets_.geny[jets_.ngen] = genjet.eta();
+
+        jets_.ngen++;
+      }
+    }
+  }
+  
+  caloJetTree_->Fill();
+
+  jets_ = {0};
+}
+
+DEFINE_FWK_MODULE(HiCaloJetAnalyzer);

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -13,6 +13,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "fastjet/contrib/Njettiness.hh"
 #include "fastjet/AreaDefinition.hh"
 #include "fastjet/ClusterSequence.hh"
@@ -611,12 +612,13 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
         }
       }
 
+      reco::PFCandidate converter = reco::PFCandidate();
       for (unsigned int icand = 0; icand < pfCandidates->size(); ++icand) {
         const pat::PackedCandidate& track = (*pfCandidates)[icand];
         double dr = deltaR(jet, track);
         if (dr < rParam) {
           double ptcand = track.pt();
-          int pfid = track.pdgId();
+          int pfid = converter.translatePdgIdToType(track.pdgId());
 
           switch (pfid) {
             case 1:


### PR DESCRIPTION
The main update in this pull request is to add call jets to the forest. This is done in following way:

1) A simplified version of HiInclusiveJetAnalyzer is written for calo jets. This is done because PF jets are of at type PAT::Jet, and calo jets of type Reco::CaloJet. Thus calo jets have much less functions available, and cannot readily be used with the standard HiInclusiveJetAnalyzer
2) A new python configuration is made to define analyzer for calo jets, in which slimmedCaloJets are defined as a jet source
3) The analyzer is loaded in the main foresting file

In addition to this, there is also a small bug fix for HiJetID. In the old version of the code, PFCandidate::particleID() is directly replaced by PackedCandidate::pdgId(). This does not work, since these two have different information. The pdgId needs to be transformed into particleId, which is now added to the code.
