### PR TITLE
Fix event number filling in hltanalyzer

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/plugins/TriggerAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/TriggerAnalyzer.cc
@@ -35,7 +35,7 @@ public:
 private:
   TTree* t_;
 
-  int fEvent;
+  unsigned long long fEvent;
   int fLumiBlock;
   int fRun;
   int fBx;


### PR DESCRIPTION
The Event branch in hltanalyzer was not filled correctly, since the type of the variable was wrong. This is fixed in this pull request.
