### PR TITLE
Add EM and hadronic energy fractions for CaloJets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiCaloJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiCaloJetAnalyzer.h
@@ -64,6 +64,7 @@ private:
   double genPtMin_;
 
   bool doHiJetID_;
+  bool doCaloEnergyFractions_;
 
   double rParam;
   double hardPtMin_;
@@ -82,16 +83,19 @@ private:
     int evt = 0;
     int lumi = 0;
 
+    // Basic jet kinematic variables
     float rawpt[MAXJETS] = {0};
     float jtpt[MAXJETS] = {0};
     float jteta[MAXJETS] = {0};
     float jtphi[MAXJETS] = {0};
 
+    // Advanced jet variables
     float jty[MAXJETS] = {0};
     float jtpu[MAXJETS] = {0};
     float jtm[MAXJETS] = {0};
     float jtarea[MAXJETS] = {0};
 
+    // Arrays for HiJetID
     float trackMax[MAXJETS] = {0};
     float trackSum[MAXJETS] = {0};
     int trackN[MAXJETS] = {0};
@@ -129,6 +133,11 @@ private:
     float signalChargedSum[MAXJETS] = {0};
     float signalHardSum[MAXJETS] = {0};
 
+    // Arrays for calorimeter energy fractions
+    float emEnergyFraction[MAXJETS] = {0};
+    float hadronicEnergyFraction[MAXJETS] = {0};
+
+    // Variables for generator level jets
     float pthat = 0;
     int beamId1 = 0;
     int beamId2 = 0;

--- a/HeavyIonsAnalysis/JetAnalysis/python/caloJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/caloJetAnalyzer_cff.py
@@ -16,5 +16,6 @@ caloJetAnalyzer = cms.EDAnalyzer(
     towersSrc = cms.InputTag("towerMaker"),
     useHepMC = cms.untracked.bool(False),
     useQuality = cms.untracked.bool(True),
-    doHiJetID = cms.untracked.bool(False)
+    doHiJetID = cms.untracked.bool(False),
+    doCaloEnergyFractions = cms.untracked.bool(False)
     )

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
@@ -37,6 +37,7 @@ HiCaloJetAnalyzer::HiCaloJetAnalyzer(const edm::ParameterSet& iConfig) {
   fillGenJets_ = iConfig.getUntrackedParameter<bool>("fillGenJets", false);
 
   doHiJetID_ = iConfig.getUntrackedParameter<bool>("doHiJetID", false);
+  doCaloEnergyFractions_ = iConfig.getUntrackedParameter<bool>("doCaloEnergyFractions", false);
 
   rParam = iConfig.getParameter<double>("rParam");
   hardPtMin_ = iConfig.getUntrackedParameter<double>("hardPtMin", 4);
@@ -117,6 +118,14 @@ void HiCaloJetAnalyzer::beginJob() {
     caloJetTree_->Branch("muN", jets_.muN, "muN[nref]/I");
   }
 
+  // Calorimeter energy fractions
+  if(doCaloEnergyFractions_){
+    caloJetTree_->Branch("emEnergyFraction", jets_.emEnergyFraction, "emEnergyFraction[nref]/F");
+    caloJetTree_->Branch("hadronicEnergyFraction", jets_.hadronicEnergyFraction, "hadronicEnergyFraction[nref]/F");
+  }
+
+
+
   if (isMC_) {
     if (useHepMC_) {
       caloJetTree_->Branch("beamId1", &jets_.beamId1, "beamId1/I");
@@ -170,7 +179,8 @@ void HiCaloJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
   jets_.nref = 0;
 
   for (unsigned int j = 0; j < jets->size(); ++j) {
-    const pat::Jet& jet = (*jets)[j];
+    //const pat::Jet& jet = (*jets)[j];
+    const reco::CaloJet& jet = (*jets)[j];
 
     auto pt = jet.pt();
     if (pt < jetPtMin_)
@@ -303,6 +313,12 @@ void HiCaloJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
           }
         }
       }
+    }
+
+    // Calorimeter energy fractions
+    if(doCaloEnergyFractions_){
+      jets_.emEnergyFraction[jets_.nref] = jet.emEnergyFraction();
+      jets_.hadronicEnergyFraction[jets_.nref] = jet.energyFractionHadronic();
     }
 
     jets_.rawpt[jets_.nref] = jet.pt();

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiCaloJetAnalyzer.cc
@@ -179,7 +179,6 @@ void HiCaloJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
   jets_.nref = 0;
 
   for (unsigned int j = 0; j < jets->size(); ++j) {
-    //const pat::Jet& jet = (*jets)[j];
     const reco::CaloJet& jet = (*jets)[j];
 
     auto pt = jet.pt();


### PR DESCRIPTION
In this PR two new branches are added to CaloJet trees. These are

emEnergyFraction = electromagnetic energy fraction of the total CaloJet energy
hadronicEnergyFraction = hadronic energy fraction of the total CaloJet energy

The filling of these branches is disabled by default. To use them, you will need to enable the flag doCaloEnergyFractions.

@FHead