### PR TITLE
Remove background subtraction related processes from pp jets

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,7 +25,7 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 132X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://eoscms.cern.ch//store/group/phys_heavyions/wangj/RECO2023/miniaod_PhysicsHIForward0_374596/reco_run374596_ls0274_streamPhysicsHIForward0_StorageManager.root'
+        'root://xrootd-cms.infn.it//store/hidata/HIRun2023A/HIPhysicsRawPrime0/MINIAOD/PromptReco-v2/000/375/790/00000/56ad580f-b228-4f3c-b8e3-17f9d95c7654.root'
     ), 
 )
 
@@ -34,7 +34,7 @@ process.source.lumisToProcess = LumiList.LumiList(filename = '/eos/cms/store/gro
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(25)
+    input = cms.untracked.int32(20)
     )
 
 ###############################################################################
@@ -244,7 +244,7 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets or addUnsubtractedR4
         process.ak04PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
         process.ak4PFJetAnalyzer.jetTag = "ak04PFpatJets"
         process.ak4PFJetAnalyzer.jetName = "ak04PF"
-        process.forest += process.extraJetsData * process.unsubtractedJetR4 * process.ak4PFJetAnalyzer
+        process.forest += process.unsubtractedJetR4 * process.ak4PFJetAnalyzer
 
 
 if addCandidateTagging:

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
@@ -163,7 +163,7 @@ if addR2Jets or addR3Jets or addR4Jets or addR8Jets:
         process.ak2PFpatJetCorrFactors.primaryVertices = "offlineSlimmedPrimaryVertices"
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.ak2PFJetAnalyzer = process.ak4PFJetAnalyzer.clone(jetTag = "ak2PFpatJets", jetName = 'ak2PF', genjetTag = "ak2GenJetsNoNu")
-        process.forest += process.extraJetsData * process.jetsR2 * process.ak2PFJetAnalyzer
+        process.forest += process.jetsR2 * process.ak2PFJetAnalyzer
 
     if addR3Jets :
         process.jetsR3 = cms.Sequence()
@@ -172,7 +172,7 @@ if addR2Jets or addR3Jets or addR4Jets or addR8Jets:
         process.ak3PFpatJetCorrFactors.primaryVertices = "offlineSlimmedPrimaryVertices"
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.ak3PFJetAnalyzer = process.ak4PFJetAnalyzer.clone(jetTag = "ak3PFpatJets", jetName = 'ak3PF', genjetTag = "ak3GenJetsNoNu")
-        process.forest += process.extraJetsData * process.jetsR3 * process.ak3PFJetAnalyzer
+        process.forest += process.jetsR3 * process.ak3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
@@ -184,7 +184,7 @@ if addR2Jets or addR3Jets or addR4Jets or addR8Jets:
         process.ak4PFJetAnalyzer.jetTag = 'ak04PFpatJets'
         process.ak4PFJetAnalyzer.jetName = 'ak04PF'
         process.ak4PFJetAnalyzer.doSubEvent = False # Need to disable this, since there is some issue with the gen jet constituents. More debugging needed is want to use constituents.
-        process.forest += process.extraJetsData * process.jetsR4 * process.ak4PFJetAnalyzer
+        process.forest += process.jetsR4 * process.ak4PFJetAnalyzer
 
     if addR8Jets :
         process.jetsR8 = cms.Sequence()
@@ -193,4 +193,4 @@ if addR2Jets or addR3Jets or addR4Jets or addR8Jets:
         process.ak8PFpatJetCorrFactors.primaryVertices = "offlineSlimmedPrimaryVertices"
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.ak8PFJetAnalyzer = process.ak4PFJetAnalyzer.clone(jetTag = "ak8PFpatJets", jetName = 'ak8PF', genjetTag = "ak8GenJetsNoNu")
-        process.forest += process.extraJetsData * process.jetsR8 * process.ak8PFJetAnalyzer
+        process.forest += process.jetsR8 * process.ak8PFJetAnalyzer

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
@@ -146,7 +146,7 @@ if addR3Jets or addR4Jets :
         process.ak3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
         process.ak3PFJetAnalyzer = process.ak4PFJetAnalyzer.clone(jetTag = "ak3PFpatJets", jetName = 'ak3PF', genjetTag = "ak3GenJetsNoNu")
-        process.forest += process.extraJetsMC * process.jetsR3 * process.ak3PFJetAnalyzer
+        process.forest += process.extraPpJetsMC * process.jetsR3 * process.ak3PFJetAnalyzer
 
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
@@ -158,4 +158,4 @@ if addR3Jets or addR4Jets :
         process.ak4PFJetAnalyzer.jetTag = 'ak04PFpatJets'
         process.ak4PFJetAnalyzer.jetName = 'ak04PF'
         process.ak4PFJetAnalyzer.doSubEvent = False # Need to disable this, since there is some issue with the gen jet constituents. More debugging needed is want to use constituents.
-        process.forest += process.extraJetsMC * process.jetsR4 * process.ak4PFJetAnalyzer
+        process.forest += process.extraPpJetsMC * process.jetsR4 * process.ak4PFJetAnalyzer

--- a/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/extraJets_cff.py
@@ -11,5 +11,6 @@ hiFJRhoFlowModulation.jetTag = "ak4PFJetsForFlow"  # Jet collection used for jet
 # Create extra jet sequences
 extraJetsData = cms.Sequence(PackedPFTowers + hiPuRho)
 extraFlowJetsData = cms.Sequence(PackedPFTowers + hiPuRho + ak4PFJetsForFlow + hiFJRhoFlowModulation)
+extraPpJetsMC = cms.Sequence(hiSignalGenParticles + allPartons)
 extraJetsMC = cms.Sequence(PackedPFTowers + hiPuRho + hiSignalGenParticles + allPartons)
 extraFlowJetsMC = cms.Sequence(PackedPFTowers + hiPuRho + hiSignalGenParticles + allPartons + ak4PFJetsForFlow + hiFJRhoFlowModulation)


### PR DESCRIPTION
In the previous version, for the jets without background subtraction, the extraJets sequence was applied. This sequence provides necessary processes for background subtraction. However, if no background is subtracted from the jets, these processes are not necessary and running them just costs additional processing time and memory. In this pull request, these processes have been removed from unsubtracted jets.
