### PR TITLE
switch to PNET

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_112X_MC.py
@@ -179,33 +179,62 @@ if addR3Jets or addR4Jets :
             process.akCs0PFJets.src = 'EventConstSub'
 
 
+# To apply PNET we have to remove the JEC first.  We could have just done this before the JEC is applied, but I copied this from the pp workflow
+# Maybe something to clean up for the future
+# Also note that it's only setup for R=0.4 for the moment. 
 addCandidateTagging = False
 
 if addCandidateTagging:
     process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-
     from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+
     updateJetCollection(
         process,
         jetSource = cms.InputTag('slimmedJets'),
-        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+        jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
         btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
         btagPrefix = 'TEST',
     )
-
-    process.updatedPatJets.addJetCorrFactors = False
-    process.updatedPatJets.discriminatorSources = cms.VInputTag(
-        cms.InputTag('pfDeepCSVJetTags:probb'),
-        cms.InputTag('pfDeepCSVJetTags:probc'),
-        cms.InputTag('pfDeepCSVJetTags:probudsg'),
-        cms.InputTag('pfDeepCSVJetTags:probbb'),
+    if addR4Jets : process.updatedPatJets.jetSource = 'akCs0PFpatJets'
+    process.updatedPatJets.addJetCorrFactors = True
+    process.undoPatJetCorrFactors = process.akCs0PFpatJetCorrFactors.clone(
+        levels = cms.vstring(),
+        src = cms.InputTag("akCs0PFpatJets"),
     )
+    process.updatedPatJets.jetCorrFactorsSource = cms.VInputTag(cms.InputTag("undoPatJetCorrFactors"))
 
-    process.akCs4PFJetAnalyzer.jetTag = "updatedPatJets"
-
-    process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
-
-
+    process.redoPatJetCorrFactors = process.akCs0PFpatJetCorrFactors.clone(
+        src = cms.InputTag("updatedPatJets"),
+    )
+    process.updatedCorrectedPatJets = process.updatedPatJets.clone(
+        jetSource = "updatedPatJets",
+        jetCorrFactorsSource = cms.VInputTag(cms.InputTag("redoPatJetCorrFactors")),
+        discriminatorSources = cms.VInputTag(
+            cms.InputTag('pfParticleNetAK4JetTags:probb'),
+            cms.InputTag('pfParticleNetAK4JetTags:probbb'),
+            cms.InputTag('pfParticleNetAK4JetTags:probc'),
+            cms.InputTag('pfParticleNetAK4JetTags:probcc'),
+            cms.InputTag('pfParticleNetAK4JetTags:probpu'),
+            cms.InputTag('pfParticleNetAK4JetTags:probg'),
+            cms.InputTag('pfParticleNetAK4JetTags:probuds'),
+            cms.InputTag('pfParticleNetAK4JetTags:probundef'),
+            cms.InputTag('pfParticleNetAK4DiscriminatorsJetTags:BvsAll'),
+            cms.InputTag('pfParticleNetAK4DiscriminatorsJetTags:CvsL'),
+            cms.InputTag('pfParticleNetAK4DiscriminatorsJetTags:QvsG'),
+            cms.InputTag('pfParticleNetAK4DiscriminatorsJetTags:CvsB'),
+        )
+    )
+    
+    process.forest.insert(-1,
+                          process.undoPatJetCorrFactors*
+                          process.updatedPatJets*
+                          process.candidateBtagging*
+                          process.redoPatJetCorrFactors*
+                          process.updatedCorrectedPatJets
+                      )
+    process.akCs4PFJetAnalyzer.jetTag = "updatedCorrectedPatJets"
+    process.akCs4PFJetAnalyzer.doCandidateBtagging = True
+    
 #########################
 # Event Selection -> add the needed filters here
 #########################

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -118,7 +118,15 @@ private:
   std::string simpleSVHighEffBJetTags_;
   std::string simpleSVHighPurBJetTags_;
   std::string combinedSVV2BJetTags_;
-  std::string deepCSVJetTags_;
+  std::string pnetBvsAllJetTags_;
+  std::string pnetProbBJetTags_;
+  std::string pnetProbBBJetTags_;
+  std::string pnetProbCJetTags_;
+  std::string pnetProbCCJetTags_;
+  std::string pnetProbGJetTags_;
+  std::string pnetProbUDSJetTags_;
+  std::string pnetProbPUJetTags_;
+  std::string pnetProbUNDEFJetTags_;
   std::string pfJPJetTags_;
 
   static const int MAXJETS = 1000;
@@ -257,7 +265,15 @@ private:
     int matchedPartonFlavor[MAXJETS]={0};
 
     float discr_csvV2[MAXJETS]={0};
-    float discr_deepCSV[MAXJETS]={0};
+    float discr_pnetBvsAll[MAXJETS]={0};
+    float discr_pnetProbB[MAXJETS]={0};
+    float discr_pnetProbBB[MAXJETS]={0};
+    float discr_pnetProbC[MAXJETS]={0};
+    float discr_pnetProbCC[MAXJETS]={0};
+    float discr_pnetProbG[MAXJETS]={0};
+    float discr_pnetProbUDS[MAXJETS]={0};
+    float discr_pnetProbPU[MAXJETS]={0};
+    float discr_pnetProbUNDEF[MAXJETS]={0};
     float discr_pfJP[MAXJETS]={0};
     float discr_muByIp3[MAXJETS]={0};
     float discr_muByPt[MAXJETS]={0};

--- a/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAOD_cff.py
@@ -6,15 +6,15 @@ pfImpactParameterTagInfos.candidates = "packedPFCandidates"
 pfImpactParameterTagInfos.primaryVertex = "offlineSlimmedPrimaryVerticesRecovery"
 from RecoBTag.SecondaryVertex.pfSecondaryVertexTagInfos_cfi import pfSecondaryVertexTagInfos
 # leave IVF workflow commented out for reference -matt
-#from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateVertexFinder
-#from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexMerger
-#from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexArbitrator
-#from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateSecondaryVertices
-#from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import pfInclusiveSecondaryVertexFinderTagInfos
-#inclusiveCandidateVertexFinder.primaryVertices  = "offlineSlimmedPrimaryVerticesRecovery"
-#inclusiveCandidateVertexFinder.tracks= "packedPFCandidates"
-#candidateVertexArbitrator.tracks = "packedPFCandidates"
-#candidateVertexArbitrator.primaryVertices = "offlineSlimmedPrimaryVerticesRecovery"
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateVertexFinder
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexMerger
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import candidateVertexArbitrator
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateSecondaryVertices
+from RecoBTag.SecondaryVertex.pfInclusiveSecondaryVertexFinderTagInfos_cfi import pfInclusiveSecondaryVertexFinderTagInfos
+inclusiveCandidateVertexFinder.primaryVertices  = "offlineSlimmedPrimaryVerticesRecovery"
+inclusiveCandidateVertexFinder.tracks= "packedPFCandidates"
+candidateVertexArbitrator.tracks = "packedPFCandidates"
+candidateVertexArbitrator.primaryVertices = "offlineSlimmedPrimaryVerticesRecovery"
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
 from RecoBTag.ImpactParameter.candidateJetProbabilityComputer_cfi import  *
@@ -23,15 +23,37 @@ from RecoBTag.Combined.pfDeepCSVTagInfos_cfi import pfDeepCSVTagInfos
 from RecoBTag.Combined.pfDeepCSVJetTags_cfi import pfDeepCSVJetTags
 pfDeepCSVTagInfos.svTagInfos = "pfSecondaryVertexTagInfos"
 
+from RecoBTag.ONNXRuntime.pfParticleNetAK4_cff import pfParticleNetAK4TagInfos, pfParticleNetAK4JetTags
+from RecoBTag.ONNXRuntime.pfParticleNetAK4DiscriminatorsJetTags_cfi import pfParticleNetAK4DiscriminatorsJetTags
+pfParticleNetAK4TagInfos.jets = "updatedPatJets"
+pfParticleNetAK4TagInfos.unsubjet_map = "unsubJets"
+pfParticleNetAK4TagInfos.use_puppiP4 = False
+pfParticleNetAK4TagInfos.pf_candidates = "packedPFCandidates"
+pfParticleNetAK4TagInfos.puppi_value_map = ''
+pfParticleNetAK4TagInfos.vertex_associator = ""
+pfParticleNetAK4TagInfos.vertices = "offlineSlimmedPrimaryVerticesRecovery"
+
+pfParticleNetAK4JetTags.src = "pfParticleNetAK4TagInfos"
+
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+ak4PFJets = ak4PFJets.clone(rParam = 0.4, src = 'packedPFCandidates')
+
+unsubJets = cms.EDProducer("JetMatcherDR",
+    matched = cms.InputTag("ak4PFJets"),
+    source = cms.InputTag("updatedPatJets")
+)
+
 candidateBtagging = cms.Sequence(
     pfImpactParameterTagInfos +
     pfSecondaryVertexTagInfos +
-    #inclusiveCandidateVertexFinder +
-    #candidateVertexMerger +
-    #candidateVertexArbitrator +
-    #inclusiveCandidateSecondaryVertices +
-    #pfInclusiveSecondaryVertexFinderTagInfos +
-    pfJetProbabilityBJetTags +
-    pfDeepCSVTagInfos + 
-    pfDeepCSVJetTags
+    inclusiveCandidateVertexFinder +
+    candidateVertexMerger +
+    candidateVertexArbitrator +
+    inclusiveCandidateSecondaryVertices +
+    pfInclusiveSecondaryVertexFinderTagInfos +
+    ak4PFJets +
+    unsubJets +
+    pfParticleNetAK4TagInfos +
+    pfParticleNetAK4JetTags +  
+    pfParticleNetAK4DiscriminatorsJetTags
 )

--- a/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/inclusiveJetAnalyzer_cff.py
@@ -27,5 +27,5 @@ inclusiveJetAnalyzer = cms.EDAnalyzer(
     doStandardJetID = cms.untracked.bool(False),
     doSubEvent = cms.untracked.bool(False),
     doLegacyBtagging = cms.untracked.bool(False),
-    doCandidateBtagging = cms.untracked.bool(True),
+    doCandidateBtagging = cms.untracked.bool(False),
     )

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -76,7 +76,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
   useRawPt_ = iConfig.getUntrackedParameter<bool>("useRawPt", true);
 
   doLegacyBtagging_ = iConfig.getUntrackedParameter<bool>("doLegacyBtagging", true);
-  doCandidateBtagging_ = iConfig.getUntrackedParameter<bool>("doCandidateBtagging", true);
+  doCandidateBtagging_ = iConfig.getUntrackedParameter<bool>("doCandidateBtagging", false);
 
   pfCandidateLabel_ =
       consumes<edm::View<pat::PackedCandidate>>(iConfig.getUntrackedParameter<edm::InputTag>("pfCandidateLabel"));
@@ -95,7 +95,15 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
     combinedSVV2BJetTags_ = "combinedSecondaryVertexV2BJetTags";
   }
   if (doCandidateBtagging_) {
-    deepCSVJetTags_ = jetName_ + "pfDeepCSVJetTags:probb";
+    pnetBvsAllJetTags_ = "pfParticleNetAK4DiscriminatorsJetTags:BvsAll";
+    pnetProbBJetTags_ = "pfParticleNetAK4JetTags:probb";
+    pnetProbBBJetTags_ = "pfParticleNetAK4JetTags:probbb";
+    pnetProbCJetTags_ = "pfParticleNetAK4JetTags:probc";
+    pnetProbCCJetTags_ = "pfParticleNetAK4JetTags:probcc";
+    pnetProbGJetTags_ = "pfParticleNetAK4JetTags:probg";
+    pnetProbUDSJetTags_ = "pfParticleNetAK4JetTags:probuds";
+    pnetProbPUJetTags_ = "pfParticleNetAK4JetTags:probpu";
+    pnetProbUNDEFJetTags_ = "pfParticleNetAK4JetTags:probundef";
     pfJPJetTags_ = jetName_ + "pfJetProbabilityBJetTags";
   }
   doSubEvent_ = false;
@@ -266,7 +274,15 @@ void HiInclusiveJetAnalyzer::beginJob() {
     t->Branch("muchg", jets_.muchg, "muchg[nref]/I");
   }
   if(doCandidateBtagging_){
-    t->Branch("discr_deepCSV", jets_.discr_deepCSV, "discr_deepCSV[nref]/F");
+    t->Branch("discr_pnetBvsAll", jets_.discr_pnetBvsAll, "discr_pnetBvsAll[nref]/F");
+    t->Branch("discr_pnetProbB", jets_.discr_pnetProbB, "discr_pnetProbB[nref]/F");
+    t->Branch("discr_pnetProbBB", jets_.discr_pnetProbBB, "discr_pnetProbBB[nref]/F");
+    t->Branch("discr_pnetProbC", jets_.discr_pnetProbC, "discr_pnetProbC[nref]/F");
+    t->Branch("discr_pnetProbCC", jets_.discr_pnetProbCC, "discr_pnetProbCC[nref]/F");
+    t->Branch("discr_pnetProbG", jets_.discr_pnetProbG, "discr_pnetProbG[nref]/F");
+    t->Branch("discr_pnetProbUDS", jets_.discr_pnetProbUDS, "discr_pnetProbUDS[nref]/F");
+    t->Branch("discr_pnetProbPU", jets_.discr_pnetProbPU, "discr_pnetProbPU[nref]/F");
+    t->Branch("discr_pnetProbUNDEF", jets_.discr_pnetProbUNDEF, "discr_pnetProbUNDEF[nref]/F");
     t->Branch("discr_pfJP", jets_.discr_pfJP, "discr_pfJP[nref]/F");
     }
   if (isMC_) {
@@ -404,7 +420,15 @@ void HiInclusiveJetAnalyzer::beginJob() {
     memset(jets_.discr_ssvHighPur, 0, MAXJETS * sizeof(float));
   }
   if (doCandidateBtagging_) {
-    memset(jets_.discr_deepCSV, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_pnetBvsAll, 0, MAXJETS * sizeof(float));
+    memset(jets_.discr_pnetProbB, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbBB, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbC, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbCC, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbG, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbUDS, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbPU, 0, MAXJETS * sizeof(float));    
+    memset(jets_.discr_pnetProbUNDEF, 0, MAXJETS * sizeof(float));    
     memset(jets_.discr_pfJP, 0, MAXJETS * sizeof(float));
   }
 }
@@ -492,7 +516,15 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
       continue;
 
     if (doCandidateBtagging_){
-      jets_.discr_deepCSV[jets_.nref]=jet.bDiscriminator(deepCSVJetTags_);
+      jets_.discr_pnetBvsAll[jets_.nref]=jet.bDiscriminator(pnetBvsAllJetTags_);
+      jets_.discr_pnetProbB[jets_.nref]=jet.bDiscriminator(pnetProbBJetTags_);
+      jets_.discr_pnetProbBB[jets_.nref]=jet.bDiscriminator(pnetProbBBJetTags_);
+      jets_.discr_pnetProbC[jets_.nref]=jet.bDiscriminator(pnetProbCJetTags_);
+      jets_.discr_pnetProbCC[jets_.nref]=jet.bDiscriminator(pnetProbCCJetTags_);
+      jets_.discr_pnetProbG[jets_.nref]=jet.bDiscriminator(pnetProbGJetTags_);
+      jets_.discr_pnetProbUDS[jets_.nref]=jet.bDiscriminator(pnetProbUDSJetTags_);
+      jets_.discr_pnetProbPU[jets_.nref]=jet.bDiscriminator(pnetProbPUJetTags_);
+      jets_.discr_pnetProbUNDEF[jets_.nref]=jet.bDiscriminator(pnetProbUNDEFJetTags_);
       jets_.discr_pfJP[jets_.nref]=jet.bDiscriminator(pfJPJetTags_);
     }
     if (doLegacyBtagging_) {

--- a/RecoJets/JetProducers/plugins/JetMatcherDR.cc
+++ b/RecoJets/JetProducers/plugins/JetMatcherDR.cc
@@ -1,0 +1,50 @@
+/* \class JetMatcherDR
+ *
+ * Producer for association map:
+ * class to match two collections of jet with one-to-one matching
+ * All elements of class "matched" are matched to each element of class "source" minimizing DeltaR
+ *
+ */
+
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/makeRefToBaseProdFrom.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/JetReco/interface/JetCollection.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+class JetMatcherDR : public edm::global::EDProducer<> {
+public:
+  typedef edm::AssociationMap<edm::OneToOne<reco::JetView, reco::JetView> > JetMatchMap;
+  explicit JetMatcherDR(const edm::ParameterSet& iConfig)
+      : sourceToken_(consumes<reco::JetView>(iConfig.getParameter<edm::InputTag>("source"))),
+        matchedToken_(consumes<reco::JetView>(iConfig.getParameter<edm::InputTag>("matched"))) {
+    produces<JetMatchMap>();
+  };
+  ~JetMatcherDR() override{};
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  const edm::EDGetTokenT<reco::JetView> sourceToken_;
+  const edm::EDGetTokenT<reco::JetView> matchedToken_;
+};
+
+void JetMatcherDR::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  const auto& source = iEvent.getHandle(sourceToken_);
+  const auto& matched = iEvent.getHandle(matchedToken_);
+  auto matching = std::make_unique<JetMatchMap>(source, matched);
+  for (size_t i = 0; i < source->size(); i++) {
+    std::pair<int, float> m(-1, 999.f);
+    for (size_t j = 0; j < matched->size(); j++) {
+      const auto dR = deltaR((*source)[i].p4(), (*matched)[j].p4());
+      if (dR < m.second)
+        m = {j, dR};
+    }
+    matching->insert(source->refAt(i), m.first >= 0 ? matched->refAt(m.first) : reco::JetBaseRef());
+  }
+  iEvent.put(std::move(matching));
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(JetMatcherDR);


### PR DESCRIPTION
This switches from DeepCSV to PNET.
These advanced candidate tagging features are not added by default, b/c the inclusive vertex finder is quite slow to run. 
You have to toggle the flag in the forest cfg. 
There should be no change otherwise. 
