### PR TITLE
Add ZdcRecHitAnalyzers

### DIFF
--- a/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzerHC_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzerHC_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+zdcanalyzer = cms.EDAnalyzer(
+   "ZDCRecHitAnalyzerHC",
+   ZDCRecHitSource    = cms.InputTag('zdcrecoRun3'),
+   ZDCDigiSource    = cms.InputTag('hcalDigis', 'ZDC'),
+   AuxZDCRecHitSource    = cms.InputTag('zdcrecoRun3'),
+   doZdcRecHits = cms.bool(True),
+   doZdcDigis = cms.bool(True),
+   doAuxZdcRecHits = cms.bool(False),
+   skipRPD = cms.bool(True),
+   doHardcodedRecHitsRPD = cms.bool(True),
+   doHardcodedDigisRPD = cms.bool(True)
+ )
+

--- a/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzer_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+zdcanalyzer = cms.EDAnalyzer(
+   "ZDCRecHitAnalyzer",
+   ZDCRecHitSource    = cms.InputTag('zdcrecoRun3'),
+   ZDCDigiSource    = cms.InputTag('hcalDigis', 'ZDC'),
+   doZdcRecHits = cms.bool(True),
+   doZdcDigis = cms.bool(True),
+   skipRPD = cms.bool(True)
+ ) # zdcreco
+

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCHardCodeHelper.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCHardCodeHelper.cc
@@ -1,0 +1,195 @@
+#include "ZDCHardCodeHelper.h"
+
+ZDCHardCodeHelper::ZDCHardCodeHelper(){setLowEdges(nbins_, binMin2);};
+
+ZDCHardCodeHelper::~ZDCHardCodeHelper(){};
+
+
+double ZDCHardCodeHelper::charge( unsigned fAdc, unsigned fCapId){
+  unsigned range = range_(fAdc);
+  unsigned index = 4*fCapId + range;
+  return (center(fAdc) - exact_offsets[index]) / exact_slopes[index];
+  // return (center(fAdc) -LUT_array.offsets[0][0][0][index])/ LUT_array.slopes[0][0][0][index];
+}
+
+double ZDCHardCodeHelper::charge(const QIE10DataFrame& digi, int ts){
+  return charge( digi[ts].adc(), digi[ts].capid());
+}
+
+
+int ZDCHardCodeHelper::rechit_Energy_TriggerBit_EM(const QIE10DataFrame& digi){
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double noise = 0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = EM_Peds[0][channel-1]; width = EM_PedWidths[0][channel-1]; gain = EM_Gains[0][channel-1];}
+   else {ped = EM_Peds[1][channel-1]; width = EM_PedWidths[1][channel-1]; gain = EM_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   noise = ootpuFrac*subPedestal(charge(digi, noiseTs_), ped, width)*gain;
+   int int_Energy = std::min(std::max(0, int(energy/(50.0))), 1023);
+   int int_Noise = std::min(std::max(0, int(noise/(50.0))), 1023);
+   return(std::max(0, int_Energy- int_Noise));
+}
+
+int ZDCHardCodeHelper::rechit_Energy_TriggerBit_HAD(const QIE10DataFrame& digi){
+     
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double noise = 0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = HAD_Peds[0][channel-1]; width = HAD_PedWidths[0][channel-1]; gain = HAD_Gains[0][channel-1];}
+   else {ped = HAD_Peds[1][channel-1]; width = HAD_PedWidths[1][channel-1]; gain = HAD_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   noise = ootpuFrac*subPedestal(charge(digi, noiseTs_), ped, width)*gain;
+   int int_Energy = std::min(std::max(0, int(energy/(50.0))), 1023);
+   int int_Noise = std::min(std::max(0, int(noise/(50.0))), 1023);
+   return(std::max(0, int_Energy- int_Noise));
+}
+
+double ZDCHardCodeHelper::rechit_Energy_Trigger_EM(const QIE10DataFrame& digi){
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double noise = 0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = EM_Peds[0][channel-1]; width = EM_PedWidths[0][channel-1]; gain = EM_Gains[0][channel-1];}
+   else {ped = EM_Peds[1][channel-1]; width = EM_PedWidths[1][channel-1]; gain = EM_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   noise = ootpuFrac*subPedestal(charge(digi, noiseTs_), ped, width)*gain;
+   return(std::max(0.0, energy- noise));
+}
+
+double ZDCHardCodeHelper::rechit_Energy_Trigger_HAD(const QIE10DataFrame& digi){
+     
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double noise = 0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = HAD_Peds[0][channel-1]; width = HAD_PedWidths[0][channel-1]; gain = HAD_Gains[0][channel-1];}
+   else {ped = HAD_Peds[1][channel-1]; width = HAD_PedWidths[1][channel-1]; gain = HAD_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   noise = ootpuFrac*subPedestal(charge(digi, noiseTs_), ped, width)*gain;
+   return(std::max(0.0, energy- noise));
+}
+
+
+double ZDCHardCodeHelper::rechit_Energy_RPD(const QIE10DataFrame& digi){
+     
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = RPD_Peds[0][channel-1]; width = RPD_PedWidths[0][channel-1]; gain = RPD_Gains[0][channel-1];}
+   else {ped = RPD_Peds[1][channel-1]; width = RPD_PedWidths[1][channel-1]; gain = RPD_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   return(energy);
+}
+
+double ZDCHardCodeHelper::rechit_Time(const QIE10DataFrame& digi){
+   double time = -9999.0;
+   if(signalTs_ > 0 && signalTs_ <digi.samples() -1 ){
+      
+      
+      double tmp_energy = 0;
+      double weight_energy = 0;
+      double total_energy = 0;
+      for( int i = -1; i <=1 ; ++i){
+         tmp_energy = std::max(0.0, charge(digi, signalTs_ +i));
+         weight_energy += tmp_energy*(signalTs_ +i);
+         total_energy  += tmp_energy;
+      
+      }
+      if(total_energy >0) time = 25.0*(weight_energy / total_energy);
+   }
+   return(time);
+}
+double ZDCHardCodeHelper::rechit_TDCtime(const QIE10DataFrame& digi){
+    float tmp_tdctime = 0;
+    int le_tdc = digi[signalTs_].le_tdc();
+    // TDC error codes will be 60=-1, 61 = -2, 62 = -3, 63 = -4
+    if (le_tdc >= 60)
+      tmp_tdctime = -1 * (le_tdc - 59);
+    else
+      tmp_tdctime = signalTs_ * 25. + (le_tdc / 2.0);
+   return(tmp_tdctime);
+}
+
+double ZDCHardCodeHelper::rechit_ChargeWeightedTime(const QIE10DataFrame& digi){
+   double time = -99.0;
+      
+   double tmp_energy = 0;
+   double weight_energy = 0;
+   double total_energy = 0;
+   for( int i = 0; i <digi.samples() ; ++i){
+      tmp_energy = std::max(0.0, charge(digi, i));
+      weight_energy+= tmp_energy*(i);
+      total_energy += tmp_energy;
+   }
+   if(total_energy >0) time = 25.0*(weight_energy / total_energy);
+   return(time);
+}
+
+double ZDCHardCodeHelper::rechit_EnergySOIp1(const QIE10DataFrame& digi){
+     
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double energy = 0;
+   double gain = 0;
+   if(zside < 0) { gain = RPD_Gains[0][channel-1];}
+   else { gain = RPD_Gains[1][channel-1];}
+   energy = subPedestal(charge(digi, signalTs_ +1), 0.0, 0.0)*gain;
+   return(energy);
+}
+double ZDCHardCodeHelper::rechit_RatioSOIp1(const QIE10DataFrame& digi){
+
+   HcalZDCDetId zdcid = digi.id();
+   int zside = zdcid.zside();
+   int channel = zdcid.channel();
+   
+   double ratio = -1.0;
+   double ped =0;
+   double width =0;
+   double gain = 0;
+   if(zside < 0) {ped = RPD_Peds[0][channel-1]; width = RPD_PedWidths[0][channel-1]; gain = RPD_Gains[0][channel-1];}
+   else {ped = RPD_Peds[1][channel-1]; width = RPD_PedWidths[1][channel-1]; gain = RPD_Gains[0][channel-1];}
+   double energy0 = subPedestal(charge(digi, signalTs_), ped, width)*gain;
+   double energy1 = subPedestal(charge(digi, signalTs_+1), ped, width)*gain;
+   if(energy0 > 0 && energy1 > 0) ratio = energy0/ energy1;
+   return(ratio);
+}
+
+int ZDCHardCodeHelper::rechit_Saturation(const QIE10DataFrame& digi){
+   int isSaturated = 0;
+    for (int i =0; i < digi.samples(); i++) {
+      if (digi[i].adc() >= maxValue_) {
+        isSaturated = 1;
+        break;
+      }
+    }
+    return(isSaturated);
+}

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCHardCodeHelper.h
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCHardCodeHelper.h
@@ -1,0 +1,165 @@
+#ifndef HeavyIonsAnalysis_ZDCAnalysis_plugins_ZDCHardCodeHelper
+#define HeavyIonsAnalysis_ZDCAnalysis_plugins_ZDCHardCodeHelper
+
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include <vector>
+
+using namespace std;
+class ZDCHardCodeHelper {
+public:
+  ZDCHardCodeHelper();
+  virtual ~ZDCHardCodeHelper();
+  // int  eta2ieta(double eta);
+  double charge(const QIE10DataFrame& digi, int ts);
+  double charge( unsigned fAdc, unsigned fCapId);
+
+  int rechit_Energy_TriggerBit_EM(const QIE10DataFrame& digi);
+  int rechit_Energy_TriggerBit_HAD(const QIE10DataFrame& digi);
+  
+  double rechit_Energy_Trigger_EM(const QIE10DataFrame& digi);
+  double rechit_Energy_Trigger_HAD(const QIE10DataFrame& digi);
+  double rechit_Energy_RPD(const QIE10DataFrame& digi);
+  double rechit_Time(const QIE10DataFrame& digi);
+  double rechit_TDCtime(const QIE10DataFrame& digi);
+  double rechit_ChargeWeightedTime(const QIE10DataFrame& digi);
+  double rechit_EnergySOIp1(const QIE10DataFrame& digi);
+  double rechit_RatioSOIp1(const QIE10DataFrame& digi);
+  int rechit_Saturation(const QIE10DataFrame& digi);
+  
+
+
+private:
+
+std::vector<double> mValues;
+unsigned int nbins_ = 64;
+
+double exact_offsets[16] = {-0.50000, -0.66002, 18.71833, -270.46150, -0.50000, -0.66002, 18.71833, -270.46150,
+-0.50000, -0.66002, 18.71833, -270.46150, -0.50000, -0.66002, 18.71833, -270.46150}; 
+double exact_slopes[16] = { 0.30683, 0.31046, 0.31191, 0.31766, 0.30683, 0.31046, 0.31191, 0.31766,
+0.30683, 0.31046, 0.31191, 0.31766, 0.30683, 0.31046, 0.31191, 0.31766};
+
+const double binMin2[64] = {-0.5,  0.5,   1.5,   2.5,   3.5,   4.5,   5.5,   6.5,   7.5,   8.5,   9.5,
+                     10.5,  11.5,  12.5,  13.5,  14.5,  // 16 bins with width 1x
+                     15.5,  17.5,  19.5,  21.5,  23.5,  25.5,  27.5,  29.5,  31.5,  33.5,  35.5,
+                     37.5,  39.5,  41.5,  43.5,  45.5,  47.5,  49.5,  51.5,  53.5,  // 20 bins with width 2x
+                     55.5,  59.5,  63.5,  67.5,  71.5,  75.5,  79.5,  83.5,  87.5,  91.5,  95.5,
+                     99.5,  103.5, 107.5, 111.5, 115.5, 119.5, 123.5, 127.5, 131.5, 135.5,  // 21 bins with width 4x
+                     139.5, 147.5, 155.5, 163.5, 171.5, 179.5, 187.5};                      // 7 bins with width 8x
+                     
+                     
+double center(unsigned fAdc){
+  if (fAdc < 4 * nbins_) {
+    if (fAdc % nbins_ == nbins_ - 1)
+      return 0.5 * (3 * mValues[fAdc] - mValues[fAdc - 1]);  // extrapolate
+    else
+      return 0.5 * (mValues[fAdc] + mValues[fAdc + 1]);  // interpolate
+  }
+  return 0.;
+}
+
+  unsigned range_(unsigned fAdc) {
+    //6 bit mantissa in QIE10, 5 in QIE8
+    return (nbins_ == 32) ? (fAdc >> 5) & 0x3 : (fAdc >> 6) & 0x3;
+  }
+
+void expand() {
+  int scale = 1;
+  for (unsigned range = 1; range < 4; range++) {
+    int factor = nbins_ == 32 ? 5 : 8;  // QIE8/QIE10 -> 5/8
+    scale *= factor;
+    unsigned index = range * nbins_;
+    unsigned overlap = (nbins_ == 32) ? 2 : 3;  // QIE10 -> 3 bin overlap
+    mValues[index] = mValues[index - overlap];  // link to previous range
+    for (unsigned i = 1; i < nbins_; i++) {
+      mValues[index + i] = mValues[index + i - 1] + scale * (mValues[i] - mValues[i - 1]);
+    }
+  }
+  mValues[nbins_ * 4] = 2 * mValues[nbins_ * 4 - 1] - mValues[nbins_ * 4 - 2];  // extrapolate
+}
+
+bool setLowEdge(double fValue, unsigned fAdc) {
+  if (fAdc >= nbins_)
+    return false;
+  mValues[fAdc] = fValue;
+  return true;
+}
+
+bool setLowEdges(unsigned int nbins_, const double *fValue) {
+  mValues.clear();
+  mValues.resize(4 * nbins_ + 1);
+  bool result = true;
+  for (unsigned int adc = 0; adc < nbins_; adc++)
+    result = result && setLowEdge(fValue[adc], adc);
+  expand();
+  return result;
+}
+
+double RPD_Peds[2][16] = {{91.09000, 78.96000, 72.24000, 80.10000,
+102.30000, 91.76000, 97.17000, 134.89999,
+144.30000, 123.90000, 129.20000, 140.60001,
+78.42000, 84.01000, 69.50000, 67.18000},
+{55.32000, 45.91000, 36.20000, 38.67000,
+38.23000, 36.85000, 32.18000, 35.90000,
+34.93000, 36.02000, 30.25000, 41.78000,
+70.23000, 59.18000, 59.21000, 63.49000}
+};
+double RPD_PedWidths[2][16] = {{124.70000, 113.20000, 97.31000, 110.10000,
+144.89999, 127.20000, 139.00000, 190.70000,
+207.39999, 179.1000, 185.20000, 202.39999,
+105.60000, 113.90000, 92.76000, 87.8200},
+{116.3000, 119.00000, 45.24000, 76.88000,
+88.19000, 74.40000, 66.26000, 59.59000,
+70.50000, 72.09000, 54.09000, 74.78000,
+129.00000, 102.4000, 89.08000, 112.0000}
+};
+
+double RPD_Gains[2][16] = {{1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0},
+{1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0,
+1.0, 1.0, 1.0, 1.0}
+};
+
+
+double EM_Peds[2][5] = {{120.900, 118.200, 265.400, 113.600, 126.100},
+{136.700, 91.010, 148.000, 78.600, 144.600}
+};
+double EM_PedWidths[2][5] = {{173.600, 161.400, 425.900, 165.200, 196.000},
+{170.700, 112.900, 198.300, 95.610, 193.800}
+};
+
+double EM_Gains[2][5] = {{0.0573900, 0.0573900, 0.0573900, 0.0573900, 0.0573900},
+{0.1026100, 0.1026100, 0.1026100, 0.1026100, 0.1026100}
+};
+
+double HAD_Peds[2][4] = {{181.400, 143.100, 136.800, 127.700},
+{54.670, 47.520, 60.920, 64.960}
+};
+double HAD_PedWidths[2][4] = {{252.000, 199.500, 187.600, 183.600},
+{62.620, 55.460, 72.370, 81.590}
+};
+
+double HAD_Gains[2][4] = {{0.5739000, 0.5739000, 0.5739000, 0.5739000},
+{1.0261000, 1.0261000, 1.0261000, 1.0261000}
+};
+
+int nTs_ = 6;
+int signalTs_ = 2;
+int noiseTs_ = 1; 
+float ootpuFrac = 97.0/256.0;
+int maxValue_ = 255;
+
+inline double subPedestal(const float charge, const float ped, const float width) {
+ if (charge - ped > width)
+   return (charge - ped);
+ else
+   return (0);
+}
+
+};
+
+#endif

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzer.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzer.cc
@@ -1,0 +1,335 @@
+// -*- C++ -*-
+//
+// Package:    HeavyIonAnalyzer/ZDCAnalysis/ZDCRecHitAnalyzer
+// Class:      ZDCRecHitAnalyzer
+//
+/**\class ZDCRecHitAnalyzer ZDCRecHitAnalyzer.cc HeavyIonAnalyzer/ZDCAnalysis/plugins/ZDCRecHitAnalyzer
+
+ Description: Produced Tree with ZDC RecHit and zdcdigi information 
+*/
+//
+// Original Author:  Matthew Nickel, University of Kansas
+//         Created:  08-10-2024
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TH1.h"
+#include "TTree.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<>
+// This will improve performance in multithreaded jobs.
+
+struct MyZDCDigi {
+  int n;
+  float chargefC[10][50];
+  int adc[10][50];
+  int tdc[10][50];
+  int zside[50];
+  int section[50];
+  int channel[50];
+};
+
+using reco::TrackCollection;
+
+
+
+class ZDCRecHitAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit ZDCRecHitAnalyzer(const edm::ParameterSet&);
+  ~ZDCRecHitAnalyzer();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+   const edm::EDGetTokenT<QIE10DigiCollection> ZDCDigiToken_; 
+   const edm::EDGetTokenT<edm::SortedCollection<ZDCRecHit>> ZDCRecHitToken_; 
+   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
+  bool doZdcRecHits_;
+  bool doZdcDigis_;
+  bool skipRPD_;
+   edm::Service<TFileService> fs;
+   TTree* t1;
+   
+   
+     MyZDCDigi zdcDigi;
+   
+   // tree branch variables
+   int zdc_n;
+   int zdc_side[50];
+   int zdc_section[50];
+   int zdc_channel[50];
+   float zdc_Energy[50];
+   float zdc_Time[50];
+   float zdc_TDCtime[50];
+   float zdc_ChargeWeightedTime[50];
+   float zdc_EnergySOIp1[50];
+   float zdc_RatioSOIp1[50];
+   int zdc_Saturation[50];
+
+   float ZDCp_Energy;
+   float ZDCm_Energy;  
+   
+
+#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  edm::ESGetToken<SetupData, SetupRecord> setupToken_;
+#endif
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ZDCRecHitAnalyzer::ZDCRecHitAnalyzer(const edm::ParameterSet& iConfig) :
+      ZDCDigiToken_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("ZDCDigiSource"))), 
+      ZDCRecHitToken_(consumes<edm::SortedCollection<ZDCRecHit>>(iConfig.getParameter<edm::InputTag>("ZDCRecHitSource"))), 
+      hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>()),
+      doZdcRecHits_(iConfig.getParameter<bool>("doZdcRecHits")),
+      doZdcDigis_(iConfig.getParameter<bool>("doZdcDigis")),
+      skipRPD_(iConfig.getParameter<bool>("skipRPD"))
+      {
+#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  setupDataToken_ = esConsumes<SetupData, SetupRecord>();
+
+#endif
+  //now do what ever initialization is needed
+}
+
+ZDCRecHitAnalyzer::~ZDCRecHitAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  //
+  // please remove this method altogether if it would be left empty
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void ZDCRecHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+  
+  
+  if(doZdcRecHits_){
+     zdc_n = 0;
+     ZDCp_Energy = 0;
+     ZDCm_Energy = 0;
+     for (unsigned int i = 0; i < 50; i++) {
+     zdc_side[i] = -99;
+     zdc_section [i]= -99;
+     zdc_channel[i] = -99;
+
+     zdc_Energy[i] = -99;
+     zdc_Time[i] = -99;
+     zdc_TDCtime[i] = -99;
+     zdc_ChargeWeightedTime[i] = -99;
+     zdc_EnergySOIp1[i] = -99;
+     zdc_RatioSOIp1[i] = -99;
+     zdc_Saturation[i] = -99;
+       
+     }
+     
+       edm::Handle<ZDCRecHitCollection> zdcrechits;
+      iEvent.getByToken(ZDCRecHitToken_, zdcrechits);
+       // zdc_n = zdcrechits->size();   
+       int nhits = 0;
+       for (auto const& rh : *zdcrechits) {
+          
+         if (nhits  >= 50) break;          
+         HcalZDCDetId zdcid = rh.id();
+          int side = zdcid.zside();
+          int section = zdcid.section();
+          int channel =zdcid.channel(); 
+          float energy = rh.energy();
+          
+          if(section ==4 && skipRPD_ ) continue;
+          
+          zdc_side[nhits] = side;
+          zdc_section[nhits] = section;
+          zdc_channel[nhits] = channel;
+          
+          zdc_Energy[nhits]  = energy;
+          zdc_Time[nhits]  = rh.time();
+          zdc_TDCtime[nhits]  = rh.TDCtime();
+          zdc_ChargeWeightedTime[nhits] = rh.chargeWeightedTime();
+          zdc_EnergySOIp1[nhits]  = rh.energySOIp1();
+          zdc_RatioSOIp1[nhits]  = rh.ratioSOIp1();
+          zdc_Saturation[nhits] = static_cast<int>( rh.flagField(HcalCaloFlagLabels::ADCSaturationBit) );
+          
+          if(side <0 && (section ==1 || section ==2)) ZDCm_Energy += energy;
+          if(side >0 && (section ==1 || section ==2)) ZDCp_Energy += energy;
+
+         nhits++;
+       } // end loop zdc rechits 
+       
+       zdc_n = nhits;  
+  }
+  
+  if(doZdcDigis_){
+    edm::Handle<QIE10DigiCollection> zdcdigis;
+    iEvent.getByToken(ZDCDigiToken_, zdcdigis);
+    
+    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken_);
+    
+    int nhits = 0;
+
+
+    for (auto it = zdcdigis->begin(); it != zdcdigis->end(); it++) {      
+      const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+
+      HcalZDCDetId zdcid = digi.id();
+       int side = zdcid.zside();
+       int section = zdcid.section();
+       int channel = zdcid.channel();
+      if(section== 1 && channel> 5) continue; // ignore extra EM channels 
+      if(section ==4 && skipRPD_ ) continue;
+      
+      if (nhits  >= 50) break;       
+
+      CaloSamples caldigi;
+
+      //const ZDCDataFrame & rh = (*zdcdigis)[it];
+
+        const HcalQIECoder* qiecoder = conditions->getHcalCoder(zdcid);
+        const HcalQIEShape* qieshape = conditions->getHcalShape(qiecoder);
+        HcalCoderDb coder(*qiecoder, *qieshape);
+        //        coder.adc2fC(rh,caldigi);
+        coder.adc2fC(digi, caldigi);
+
+
+        zdcDigi.zside[nhits] = side;
+        zdcDigi.section[nhits] = section;
+        zdcDigi.channel[nhits] = channel;
+
+        for (int ts = 0; ts < digi.samples(); ts++) {
+
+          zdcDigi.chargefC[ts][nhits] = caldigi[ts];
+          zdcDigi.adc[ts][nhits] = digi[ts].adc();
+          zdcDigi.tdc[ts][nhits] = digi[ts].le_tdc();
+        }
+      nhits++;
+    }  // end loop zdc digis
+
+    zdcDigi.n = nhits;
+  }    
+    t1->Fill();
+
+// #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  // // if the SetupData is always needed
+  // auto setup = iSetup.getData(setupToken_);
+  // // if need the ESHandle to check if the SetupData was there or not
+  // auto pSetup = iSetup.getHandle(setupToken_);
+// #endif                                       
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void ZDCRecHitAnalyzer::beginJob() {
+  // please remove this method if not needed
+  t1 = fs->make<TTree>("zdcrechit", "zdcrechit");
+   if(doZdcRecHits_){
+     
+     t1->Branch("ZDCp_Energy",&ZDCp_Energy); 
+     t1->Branch("ZDCm_Energy",&ZDCm_Energy);
+     
+     t1->Branch("zdcrechit_n",&zdc_n);
+     t1->Branch("zdcrechit_side",zdc_side,"zdcrechit_side[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_section",zdc_section,"zdcrechit_section[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_channel",zdc_channel,"zdcrechit_channel[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_Energy",zdc_Energy,"zdcrechit_Energy[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_Time",zdc_Time,"zdcrechit_Time[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_TDCtime",zdc_TDCtime,"zdcrechit_TDCtime[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_ChargeWeightedTime",zdc_ChargeWeightedTime,"zdcrechit_ChargeWeightedTime[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_EnergySOIp1",zdc_EnergySOIp1,"zdcrechit_EnergySOIp1[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_RatioSOIp1",zdc_RatioSOIp1,"zdcrechit_RatioSOIp1[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_Saturation",zdc_Saturation,"zdcrechit_Saturation[zdcrechit_n]/I");    
+     
+
+     
+  }
+  
+  if(doZdcDigis_){
+    t1->Branch("zdcdigi_n", &zdcDigi.n, "zdcdigi_n/I");
+    t1->Branch("zdcdigi_zside", zdcDigi.zside, "zdcdigi_zside[zdcdigi_n]/I");
+    t1->Branch("zdcdigi_section", zdcDigi.section, "zdcdigi_section[zdcdigi_n]/I");
+    t1->Branch("zdcdigi_channel", zdcDigi.channel, "zdcdigi_channel[zdcdigi_n]/I");
+    for (int i = 0; i < 6; i++) {
+      TString adcTsSt("zdcdigi_adcTs"), chargefCTsSt("zdcdigi_chargefCTs"), tdcTsSt("zdcdigi_tdcTs");
+      adcTsSt += i;
+      chargefCTsSt += i;
+      tdcTsSt += i;
+
+      t1->Branch(adcTsSt, zdcDigi.adc[i], adcTsSt + "[zdcdigi_n]/I");
+      t1->Branch(chargefCTsSt, zdcDigi.chargefC[i], chargefCTsSt + "[zdcdigi_n]/F");
+      t1->Branch(tdcTsSt, zdcDigi.tdc[i], tdcTsSt + "[zdcdigi_n]/I");
+    }
+  }
+  
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void ZDCRecHitAnalyzer::endJob() {
+  // please remove this method if not needed
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void ZDCRecHitAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+
+  //Specify that only 'tracks' is allowed
+  //To use, remove the default given above and uncomment below
+  //ParameterSetDescription desc;
+  //desc.addUntracked<edm::InputTag>("tracks","ctfWithMaterialTracks");
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ZDCRecHitAnalyzer);

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzerHC.cc
@@ -1,0 +1,439 @@
+// -*- C++ -*-
+//
+// Package:    HeavyIonAnalyzer/ZDCAnalysis/ZDCRecHitAnalyzerHC
+// Class:      ZDCRecHitAnalyzerHC
+//
+/**\class ZDCRecHitAnalyzerHC ZDCRecHitAnalyzerHC.cc HeavyIonAnalyzer/ZDCAnalysis/plugins/ZDCRecHitAnalyzerHC
+
+ Description: Produced Tree with ZDC RecHit and zdcdigi information 
+*/
+//
+// Original Author:  Matthew Nickel, University of Kansas
+//         Created:  08-10-2024
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "TH1.h"
+#include "TTree.h"
+
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+
+#include "ZDCHardCodeHelper.h"
+
+//
+// class declaration
+//
+
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<>
+// This will improve performance in multithreaded jobs.
+
+struct MyZDCDigi {
+  int n;
+  float chargefC[10][50];
+  int adc[10][50];
+  int tdc[10][50];
+  int zside[50];
+  int section[50];
+  int channel[50];
+};
+
+using reco::TrackCollection;
+
+
+
+class ZDCRecHitAnalyzerHC : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+public:
+  explicit ZDCRecHitAnalyzerHC(const edm::ParameterSet&);
+  ~ZDCRecHitAnalyzerHC();
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  void beginJob() override;
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  void endJob() override;
+
+  // ----------member data ---------------------------
+   const edm::EDGetTokenT<QIE10DigiCollection> ZDCDigiToken_;  
+   const edm::EDGetTokenT<edm::SortedCollection<ZDCRecHit>> ZDCRecHitToken_;
+   const edm::EDGetTokenT<edm::SortedCollection<ZDCRecHit>> AuxZDCRecHitToken_; 
+   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
+  bool doZdcRecHits_;
+  bool doZdcDigis_;
+  bool doAuxZdcRecHits_;
+  bool skipRPD_;
+  bool doHardcodedRecHitsRPD_;
+  bool doHardcodedDigisRPD_;
+   edm::Service<TFileService> fs;
+   TTree* t1;
+   
+   
+     MyZDCDigi zdcDigi;
+   
+   // tree branch variables
+   int zdc_n;
+   int zdc_side[50];
+   int zdc_section[50];
+   int zdc_channel[50];
+   float zdc_Energy[50];
+   float zdc_Time[50];
+   float zdc_TDCtime[50];
+   float zdc_ChargeWeightedTime[50];
+   float zdc_EnergySOIp1[50];
+   float zdc_RatioSOIp1[50];
+   int zdc_Saturation[50];
+
+   
+   
+   float ZDCp_Energy;
+   float ZDCm_Energy;
+   
+   float ZDCp_Aux_Energy;
+   float ZDCm_Aux_Energy;
+   
+
+#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  edm::ESGetToken<SetupData, SetupRecord> setupToken_;
+#endif
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ZDCRecHitAnalyzerHC::ZDCRecHitAnalyzerHC(const edm::ParameterSet& iConfig) :
+      ZDCDigiToken_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("ZDCDigiSource"))), 
+      ZDCRecHitToken_(consumes<edm::SortedCollection<ZDCRecHit>>(iConfig.getParameter<edm::InputTag>("ZDCRecHitSource"))), 
+      AuxZDCRecHitToken_(consumes<edm::SortedCollection<ZDCRecHit>>(iConfig.getParameter<edm::InputTag>("AuxZDCRecHitSource"))), 
+      hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>()),
+      doZdcRecHits_(iConfig.getParameter<bool>("doZdcRecHits")),
+      doZdcDigis_(iConfig.getParameter<bool>("doZdcDigis")),
+      doAuxZdcRecHits_(iConfig.getParameter<bool>("doAuxZdcRecHits")),
+      skipRPD_(iConfig.getParameter<bool>("skipRPD")),
+      doHardcodedRecHitsRPD_(iConfig.getParameter<bool>("doHardcodedRecHitsRPD")),
+      doHardcodedDigisRPD_(iConfig.getParameter<bool>("doHardcodedDigisRPD"))
+      {
+#ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  setupDataToken_ = esConsumes<SetupData, SetupRecord>();
+#endif
+  //now do what ever initialization is needed
+}
+
+ZDCRecHitAnalyzerHC::~ZDCRecHitAnalyzerHC() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  //
+  // please remove this method altogether if it would be left empty
+}
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void ZDCRecHitAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
+  ZDCHardCodeHelper HardCodeZDC;
+  if(doZdcRecHits_){
+     zdc_n = 0;
+     ZDCp_Energy = 0;
+     ZDCm_Energy = 0;
+     for (unsigned int i = 0; i < 50; i++) {
+     zdc_side[i] = -99;
+     zdc_section [i]= -99;
+     zdc_channel[i] = -99;
+
+     zdc_Energy[i] = -99;
+     zdc_Time[i] = -99;
+     zdc_TDCtime[i] = -99;
+     zdc_ChargeWeightedTime[i] = -99;
+     zdc_EnergySOIp1[i] = -99;
+     zdc_RatioSOIp1[i] = -99;
+     zdc_Saturation[i] = -99;
+       
+     }
+     
+       edm::Handle<ZDCRecHitCollection> zdcrechits;
+      iEvent.getByToken(ZDCRecHitToken_, zdcrechits);
+       // zdc_n = zdcrechits->size();   
+       int nhits = 0;
+       for (auto const& rh : *zdcrechits) {
+          
+         if (nhits  >= 50) break;          
+         HcalZDCDetId zdcid = rh.id();
+          int side = zdcid.zside();
+          int section = zdcid.section();
+          int channel =zdcid.channel(); 
+          float energy = rh.energy();
+          
+          if(section ==4 && skipRPD_ ) continue;
+          
+          zdc_side[nhits] = side;
+          zdc_section[nhits] = section;
+          zdc_channel[nhits] = channel;
+          
+          zdc_Energy[nhits]  = energy;
+          zdc_Time[nhits]  = rh.time();
+          zdc_TDCtime[nhits]  = rh.TDCtime();
+          zdc_ChargeWeightedTime[nhits] = rh.chargeWeightedTime();
+          zdc_EnergySOIp1[nhits]  = rh.energySOIp1();
+          zdc_RatioSOIp1[nhits]  = rh.ratioSOIp1();
+          zdc_Saturation[nhits] = static_cast<int>( rh.flagField(HcalCaloFlagLabels::ADCSaturationBit) );
+          
+          if(side <0 && (section ==1 || section ==2)) ZDCm_Energy += energy;
+          if(side >0 && (section ==1 || section ==2)) ZDCp_Energy += energy;
+
+         nhits++;
+       } // end loop zdc rechits 
+       
+       zdc_n = nhits;  
+  }
+  
+  if(doZdcDigis_){
+    edm::Handle<QIE10DigiCollection> zdcdigis;
+    iEvent.getByToken(ZDCDigiToken_, zdcdigis);
+    
+    edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken_);
+    
+    int nhits = 0;
+
+
+    for (auto it = zdcdigis->begin(); it != zdcdigis->end(); it++) {      
+      const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+
+      HcalZDCDetId zdcid = digi.id();
+       int side = zdcid.zside();
+       int section = zdcid.section();
+       int channel = zdcid.channel();
+      if(section== 1 && channel> 5) continue; // ignore extra EM channels 
+      if(section ==4 && skipRPD_ ) continue;
+      
+      if (nhits  >= 50) break;       
+
+      CaloSamples caldigi;
+
+      //const ZDCDataFrame & rh = (*zdcdigis)[it];
+
+        const HcalQIECoder* qiecoder = conditions->getHcalCoder(zdcid);
+        const HcalQIEShape* qieshape = conditions->getHcalShape(qiecoder);
+        HcalCoderDb coder(*qiecoder, *qieshape);
+        //        coder.adc2fC(rh,caldigi);
+        coder.adc2fC(digi, caldigi);
+
+
+        zdcDigi.zside[nhits] = side;
+        zdcDigi.section[nhits] = section;
+        zdcDigi.channel[nhits] = channel;
+
+        for (int ts = 0; ts < digi.samples(); ts++) {
+
+          zdcDigi.chargefC[ts][nhits] = caldigi[ts];
+          zdcDigi.adc[ts][nhits] = digi[ts].adc();
+          zdcDigi.tdc[ts][nhits] = digi[ts].le_tdc();
+        }
+      nhits++;
+    }  // end loop zdc digis
+
+    zdcDigi.n = nhits;
+    
+   if((doHardcodedDigisRPD_ || doHardcodedRecHitsRPD_) && skipRPD_){
+    nhits = 0;      
+    for (auto it = zdcdigis->begin(); it != zdcdigis->end(); it++) {
+      const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
+
+      HcalZDCDetId zdcid = digi.id();
+       int side = zdcid.zside();
+       int section = zdcid.section();
+       int channel = zdcid.channel();
+      if(section== 1 && channel> 5) continue; // ignore extra EM channels 
+      
+      if(nhits > 50) break;
+      
+      if(section !=4){
+         
+         // Do saturation offline since currently error with integer division in CMSSW - 10.15.24
+         zdc_TDCtime[nhits]  = HardCodeZDC.rechit_TDCtime(digi);
+         // Do saturation offline since currently error in CMSSW where saturation is always 1 - 10.15.24
+         zdc_Saturation[nhits] = HardCodeZDC.rechit_Saturation(digi);
+         nhits++;
+      }
+      else{
+         if(doHardcodedDigisRPD_){
+           zdcDigi.zside[nhits] = side;
+           zdcDigi.section[nhits] = section;
+           zdcDigi.channel[nhits] = channel;
+
+           for (int ts = 0; ts < digi.samples(); ts++) {
+
+             zdcDigi.chargefC[ts][nhits] = HardCodeZDC.charge(digi[ts].adc(),digi[ts].capid());
+             zdcDigi.adc[ts][nhits] = digi[ts].adc();
+             zdcDigi.tdc[ts][nhits] = digi[ts].le_tdc();
+           }
+         }
+         if(doHardcodedRecHitsRPD_){
+
+             zdc_side[nhits] = side;
+             zdc_section[nhits] = section;
+             zdc_channel[nhits] = channel;
+             
+             zdc_Energy[nhits]  = HardCodeZDC.rechit_Energy_RPD(digi);
+             zdc_Time[nhits]  = HardCodeZDC.rechit_Time(digi);
+             zdc_TDCtime[nhits]  = HardCodeZDC.rechit_TDCtime(digi);
+             zdc_ChargeWeightedTime[nhits] = HardCodeZDC.rechit_ChargeWeightedTime(digi);
+             zdc_EnergySOIp1[nhits]  = HardCodeZDC.rechit_EnergySOIp1(digi);
+             zdc_RatioSOIp1[nhits]  = HardCodeZDC.rechit_RatioSOIp1(digi);
+             zdc_Saturation[nhits] = HardCodeZDC.rechit_Saturation(digi);
+             
+             
+         }
+            nhits++;
+      }
+         
+    }
+    zdcDigi.n = nhits;
+    zdc_n = nhits;
+   }
+  }
+
+
+  if(doAuxZdcRecHits_){
+     ZDCp_Aux_Energy = 0;
+     ZDCm_Aux_Energy = 0;
+     
+       edm::Handle<ZDCRecHitCollection> auxrechits;
+       iEvent.getByToken(AuxZDCRecHitToken_, auxrechits);
+       int nhits = 0;
+       for (auto const& rh : *auxrechits) {
+          
+         if (nhits  >= 50) break;          
+         HcalZDCDetId zdcid = rh.id();
+          int side = zdcid.zside();
+          int section = zdcid.section();
+          float energy = rh.energy();
+          
+          if(section ==4) continue;
+          
+          if(side <0 && (section ==1 || section ==2)) ZDCm_Aux_Energy += energy;
+          if(side >0 && (section ==1 || section ==2)) ZDCp_Aux_Energy += energy;
+
+         nhits++;
+       } // end loop Aux rechits 
+       
+  }  
+    t1->Fill();
+
+// #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
+  // // if the SetupData is always needed
+  // auto setup = iSetup.getData(setupToken_);
+  // // if need the ESHandle to check if the SetupData was there or not
+  // auto pSetup = iSetup.getHandle(setupToken_);
+// #endif                                       
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void ZDCRecHitAnalyzerHC::beginJob() {
+  // please remove this method if not needed
+  t1 = fs->make<TTree>("zdcrechit", "zdcrechit");
+  
+  if(doZdcRecHits_){
+     
+     t1->Branch("ZDCp_Energy",&ZDCp_Energy); 
+     t1->Branch("ZDCm_Energy",&ZDCm_Energy);
+     
+     t1->Branch("zdcrechit_n",&zdc_n);
+     t1->Branch("zdcrechit_side",zdc_side,"zdcrechit_side[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_section",zdc_section,"zdcrechit_section[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_channel",zdc_channel,"zdcrechit_channel[zdcrechit_n]/I");
+     t1->Branch("zdcrechit_Energy",zdc_Energy,"zdcrechit_Energy[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_Time",zdc_Time,"zdcrechit_Time[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_TDCtime",zdc_TDCtime,"zdcrechit_TDCtime[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_ChargeWeightedTime",zdc_ChargeWeightedTime,"zdcrechit_ChargeWeightedTime[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_EnergySOIp1",zdc_EnergySOIp1,"zdcrechit_EnergySOIp1[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_RatioSOIp1",zdc_RatioSOIp1,"zdcrechit_RatioSOIp1[zdcrechit_n]/F");    
+     t1->Branch("zdcrechit_Saturation",zdc_Saturation,"zdcrechit_Saturation[zdcrechit_n]/I");    
+     
+
+     
+  }
+  
+  if(doZdcDigis_){
+    t1->Branch("zdcdigi_n", &zdcDigi.n, "zdcdigi_n/I");
+    t1->Branch("zdcdigi_zside", zdcDigi.zside, "zdcdigi_zside[zdcdigi_n]/I");
+    t1->Branch("zdcdigi_section", zdcDigi.section, "zdcdigi_section[zdcdigi_n]/I");
+    t1->Branch("zdcdigi_channel", zdcDigi.channel, "zdcdigi_channel[zdcdigi_n]/I");
+    for (int i = 0; i < 6; i++) {
+      TString adcTsSt("zdcdigi_adcTs"), chargefCTsSt("zdcdigi_chargefCTs"), tdcTsSt("zdcdigi_tdcTs");
+      adcTsSt += i;
+      chargefCTsSt += i;
+      tdcTsSt += i;
+
+      t1->Branch(adcTsSt, zdcDigi.adc[i], adcTsSt + "[zdcdigi_n]/I");
+      t1->Branch(chargefCTsSt, zdcDigi.chargefC[i], chargefCTsSt + "[zdcdigi_n]/F");
+      t1->Branch(tdcTsSt, zdcDigi.tdc[i], tdcTsSt + "[zdcdigi_n]/I");
+    }
+  }
+  
+  
+  if(doAuxZdcRecHits_){
+     t1->Branch("ZDCp_Aux_Energy",&ZDCp_Aux_Energy); 
+     t1->Branch("ZDCm_Aux_Energy",&ZDCm_Aux_Energy);
+     
+  }
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void ZDCRecHitAnalyzerHC::endJob() {
+  // please remove this method if not needed
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void ZDCRecHitAnalyzerHC::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+
+  //Specify that only 'tracks' is allowed
+  //To use, remove the default given above and uncomment below
+  //ParameterSetDescription desc;
+  //desc.addUntracked<edm::InputTag>("tracks","ctfWithMaterialTracks");
+  //descriptions.addWithDefaultLabel(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ZDCRecHitAnalyzerHC);


### PR DESCRIPTION

#### PR description:

Added Two ZdcRecHit Analyzers:
ZdcRecHitAnalyzerHC.cc included methods for determining RPD rechits via hardcoded conditions which are located in ZDCHardCodeHelper.

ZdcRecHitAnalyzer.cc does not involve any hardcoded conditions and can be used once the RPD conditions are working online

#### PR validation:

Ran on CMSSW_14_1_3 with this cmsRun script 
[runZdcRecHits_AOD_TestConditions_py.txt](https://github.com/user-attachments/files/17496236/runZdcRecHits_AOD_TestConditions_py.txt) without crashing

