### PR TITLE
Removed 2023 LumiList from forest configs

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -29,9 +29,6 @@ process.source = cms.Source("PoolSource",
     ), 
 )
 
-import FWCore.PythonUtilities.LumiList as LumiList
-process.source.lumisToProcess = LumiList.LumiList(filename = '/eos/user/c/cmsdqm/www/CAF/certification/Collisions23HI/Cert_Collisions2023HI_374288_375823_Golden.json').getVLuminosityBlockRange()
-
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(20)


### PR DESCRIPTION
#### PR description:

Removes the LumiList from `forest_miniAOD_run3_DATA.py` (lines shown below):
https://github.com/CmsHI/cmssw/blob/2c3117d2637758a8ff5399cdbf0ba4b478d19650/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py#L32-L33

 These were for reprocessing 2023 data, and should not be included with 2024 foresting.


#### PR validation:

Tested config locally with above lines removed, no issues.
