### PR TITLE
Forest data config updates

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
@@ -3,8 +3,8 @@
 # Type: data
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_pp_on_PbPb_2024_cff import Run3_pp_on_PbPb_2024
-process = cms.Process('HiForest',Run3_pp_on_PbPb_2024)
+from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
+process = cms.Process('HiForest', Run3_2024_UPC)
 
 ###############################################################################
 
@@ -50,10 +50,11 @@ process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 
 ###############################################################################
 
-# Define centrality binning
-process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
-process.centralityBin.Centrality = cms.InputTag("hiCentrality")
-process.centralityBin.centralityVariable = cms.string("HFtowers")
+# No centrality binning for UPC
+## Define centrality binning
+#process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
+#process.centralityBin.Centrality = cms.InputTag("hiCentrality")
+#process.centralityBin.centralityVariable = cms.string("HFtowers")
 
 ###############################################################################
 
@@ -75,15 +76,15 @@ process.TFileService = cms.Service("TFileService",
 ###############################################################################
 
 # event analysis
-process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.skimanalysis_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.hltobject_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.l1object_cfi')
 
-#process.hiEvtAnalyzer.doCentrality = cms.bool(False)
-#process.hiEvtAnalyzer.doHFfilters = cms.bool(False)
+# No centrality binning for UPC
+process.hiEvtAnalyzer.doCentrality = cms.bool(False)
+process.hiEvtAnalyzer.doHFfilters = cms.bool(False)
 
 # FIXME: Do we have an updated trigger list?
 #from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_data_2023_skimmed
@@ -97,9 +98,13 @@ process.ggHiNtuplizer.doMuons = cms.bool(False)
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ################################
 # jet reco sequence
-process.load('HeavyIonsAnalysis.JetAnalysis.akCs4PFJetSequence_pponPbPb_data_cff')
-process.load('HeavyIonsAnalysis.JetAnalysis.akPu4CaloJetSequence_pponPbPb_data_cff')
-process.akPu4CaloJetAnalyzer.doHiJetID = True
+process.load(
+    'HeavyIonsAnalysis.JetAnalysis.ak2PFJetSequence_ppref_data_cff')
+process.load(
+    'HeavyIonsAnalysis.JetAnalysis.ak3PFJetSequence_ppref_data_cff')
+process.load(
+    'HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
+process.load('HeavyIonsAnalysis.JetAnalysis.ak4CaloJetSequence_pp_data_cff')
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
@@ -109,8 +114,9 @@ process.load("HeavyIonsAnalysis.MuonAnalysis.muonAnalyzer_cfi")
 ###############################################################################
 
 # ZDC RecHit Producer
-process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018Producer_cfi')
-process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018RecHit_cfi')
+# FIXME: Removing old Producer and RecHit, need updated RecHit?
+#process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018Producer_cfi')
+#process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018RecHit_cfi')
 process.load('HeavyIonsAnalysis.ZDCAnalysis.zdcanalyzer_cfi')
 
 process.zdcdigi.SOI = cms.untracked.int32(2)
@@ -127,12 +133,13 @@ process.zdcanalyzer.nZdcTs = cms.int32(6)
 # main forest sequence
 process.forest = cms.Path(
     process.HiForestInfo +
-    process.centralityBin +
+    #process.centralityBin +
     process.hiEvtAnalyzer +
     process.hltanalysis +
     process.hltobject +
     process.l1object +
-    process.trackSequencePbPb +
+    process.trackSequencePP +
+    process.ak4CaloJetAnalyzer +
     process.particleFlowAnalyser +
     process.ggHiNtuplizer +
     #process.zdcdigi +
@@ -140,7 +147,7 @@ process.forest = cms.Path(
     process.zdcanalyzer +
     process.unpackedMuons +
     process.muonAnalyzer +
-    process.akPu4CaloJetAnalyzer
+    #process.akPu4CaloJetAnalyzer
     )
 
 #customisation

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
@@ -47,7 +47,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, '141X_dataRun3_Prompt_v3', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 
-# TODO: Old calibration here, might need to update
+# FIXME: Old calibration here, might need to update
 # Commenting out until understood
 #process.GlobalTag.toGet.extend([
 #    cms.PSet(record = cms.string("BTagTrackProbability3DRcd"),
@@ -94,10 +94,11 @@ process.load('HeavyIonsAnalysis.EventAnalysis.l1object_cfi')
 
 process.load('HeavyIonsAnalysis.EventAnalysis.skimanalysis_cfi')
 
+process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
 
-#Dont know the triggerlist for the pp reference so comment out (for now)
-#from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_mc
-#process.hltobject.triggerNames = trigger_list_mc
+# FIXME: Do we have an updated trigger list?
+#from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_data_2023_skimmed
+#process.hltobject.triggerNames = trigger_list_data_2023_skimmed
 
 #####################################################################################
 
@@ -130,7 +131,8 @@ process.forest = cms.Path(
 #    process.hltobject +
     process.l1object +
     process.ggHiNtuplizer +
-    process.trackSequencePP
+    process.trackSequencePP +
+    process.particleFlowAnalyser
 )
 
 


### PR DESCRIPTION
#### PR description:

Updates to all data configs with expected updates to CMSSW_14_1_4_patch2.

`forest_miniAOD_run3_ppref_DATA.py` has particleFlowAnalyzer and trackSequencePP added to `process.forest`.

`forest_miniAOD_run3_DATA.py` has particleFlowAnalyzer uncommented in `process.forest`. This should be tested with PbPb data once available.

`forest_miniAOD_run3_UPC_DATA.py` is a new config for UPC data. This should be tested with PbPb data once available.

#### PR validation:

`forest_miniAOD_run3_ppref_DATA.py` has been tested with CMSSW_14_1_4_patch2 and runs successfully. `forest_miniAOD_run3_DATA.py` and `forest_miniAOD_run3_UPC_DATA.py` will need to be tested with 2024 PbPb data.
