### PR TITLE
Remove declustering for default R=0.4 AKCS jets

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,12 +25,13 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 132X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://xrootd-cms.infn.it//store/hidata/HIRun2023A/HIPhysicsRawPrime0/MINIAOD/PromptReco-v2/000/375/790/00000/56ad580f-b228-4f3c-b8e3-17f9d95c7654.root'
+        '/store/hidata/HIRun2023A/HIPhysicsRawPrime0/MINIAOD/PromptReco-v2/000/375/790/00000/56ad580f-b228-4f3c-b8e3-17f9d95c7654.root'
     ), 
 )
 
-import FWCore.PythonUtilities.LumiList as LumiList
-process.source.lumisToProcess = LumiList.LumiList(filename = '/eos/user/c/cmsdqm/www/CAF/certification/Collisions23HI/Cert_Collisions2023HI_374288_375823_Golden.json').getVLuminosityBlockRange()
+#only accessible from lxplus?
+#import FWCore.PythonUtilities.LumiList as LumiList
+#process.source.lumisToProcess = LumiList.LumiList(filename = '/eos/user/c/cmsdqm/www/CAF/certification/Collisions23HI/Cert_Collisions2023HI_374288_375823_Golden.json').getVLuminosityBlockRange()
 
 # number of events to process, set to -1 to process all events
 process.maxEvents = cms.untracked.PSet(
@@ -151,8 +152,8 @@ process.forest = cms.Path(
 addR3Jets = False
 addR3FlowJets = False
 addR4Jets = True
-addR4FlowJets = True
-addUnsubtractedR4Jets = True
+addR4FlowJets = False
+addUnsubtractedR4Jets = False
 
 # Choose which additional information is added to jet trees
 doHIJetID = True             # Fill jet ID and composition information branches
@@ -184,13 +185,16 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets or addUnsubtractedR4
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
-        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
-        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        #setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
+        setupHeavyIonJets('akCs4PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False, noReclustering =  True)
+        #process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        #process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
+        #process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.akCs4PFJetAnalyzer.jetName = 'akCs4PF'
         process.akCs4PFJetAnalyzer.doHiJetID = doHIJetID
         process.akCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
+        #process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
+        process.forest += process.jetsR4 * process.akCs4PFJetAnalyzer
 
     if addR4FlowJets :
         process.jetsR4flow = cms.Sequence()

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -129,6 +129,7 @@ process.forest = cms.Path(
     process.ggHiNtuplizer +
 #    process.zdcdigi +
 #    process.QWzdcreco +
+    #process.akCs4PFJetAnalyzer +
     process.zdcanalyzer #+
 #    process.unpackedMuons +
 #    process.muonAnalyzer
@@ -138,8 +139,8 @@ process.forest = cms.Path(
 
 addR3Jets = False
 addR3FlowJets = False
-addR4Jets = False
-addR4FlowJets = True
+addR4Jets = True
+addR4FlowJets = False
 matchJets = True             # Enables q/g and heavy flavor jet identification in MC
 addCandidateTagging = False
 doHIJetID = True             # Fill jet ID and composition information branches
@@ -169,16 +170,18 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
     if addR4Jets :
         # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
-        jetName = 'akCs0PF'
-        setupHeavyIonJets(jetName, process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False, matchJets = matchJets)
-        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
+        #jetName = 'akCs0PF'
+        jetName = 'akCs4PF'
+        setupHeavyIonJets(jetName, process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False, matchJets = matchJets, noReclustering = True)
+        #process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
+        #process.akCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
         process.akCs4PFJetAnalyzer.jetName = jetName
         process.akCs4PFJetAnalyzer.matchJets = matchJets
         process.akCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
         process.akCs4PFJetAnalyzer.doHiJetID = doHIJetID
         process.akCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
+        #process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer        
+        process.forest += process.extraPpJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
 
     if addR4FlowJets :
         process.jetsR4flow = cms.Sequence()

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -168,7 +168,7 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
 
     if addR4Jets :
-        # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
+        # If reclustering, use an alias "0" in order not to get mixed up with the default AK4 collections
         process.jetsR4 = cms.Sequence()
         #jetName = 'akCs0PF'
         jetName = 'akCs4PF'

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -272,8 +272,6 @@ private:
     int mjtPartonFlavor[MAXJETS] = {0};
     int mjtNbHad[MAXJETS]={0};
     int mjtNcHad[MAXJETS]={0};
-    int mjtNbPar[MAXJETS]={0};
-    int mjtNcPar[MAXJETS]={0};
 
     float discr_csvV2[MAXJETS] = {0};
     float discr_deepCSV[MAXJETS] = {0};

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -22,6 +22,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "fastjet/contrib/Njettiness.hh"
+#include "DataFormats/JetMatching/interface/JetFlavourInfo.h"
+#include "DataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
+
 //
 
 /**\class HiInclusiveJetAnalyzer
@@ -72,6 +75,8 @@ private:
   edm::EDGetTokenT<edm::View<reco::GenJet>> genjetTag_;
   edm::EDGetTokenT<edm::HepMCProduct> eventInfoTag_;
   edm::EDGetTokenT<GenEventInfoProduct> eventGenInfoTag_;
+  // b and c hadrons
+  edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> jetFlavourInfosToken_;
 
   std::string jetName_;  //used as prefix for jet structures
   edm::EDGetTokenT<edm::View<reco::Jet>> subjetGenTag_;
@@ -259,12 +264,16 @@ private:
 
     int subid[MAXJETS] = {0};
 
-    float matchedPt[MAXJETS] = {0};
-    float matchedRawPt[MAXJETS] = {0};
-    float matchedR[MAXJETS] = {0};
-    float matchedPu[MAXJETS] = {0};
-    int matchedHadronFlavor[MAXJETS] = {0};
-    int matchedPartonFlavor[MAXJETS] = {0};
+    float mjtPt[MAXJETS] = {0};
+    float mjtRawPt[MAXJETS] = {0};
+    float mjtR[MAXJETS] = {0};
+    float mjtPu[MAXJETS] = {0};
+    int mjtHadronFlavor[MAXJETS] = {0};
+    int mjtPartonFlavor[MAXJETS] = {0};
+    int mjtNbHad[MAXJETS]={0};
+    int mjtNcHad[MAXJETS]={0};
+    int mjtNbPar[MAXJETS]={0};
+    int mjtNcPar[MAXJETS]={0};
 
     float discr_csvV2[MAXJETS] = {0};
     float discr_deepCSV[MAXJETS] = {0};

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
@@ -13,6 +13,7 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     jetName = cms.untracked.string("akCs4PF"),
     genPtMin = cms.untracked.double(5),
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+    jetFlavourInfos = cms.InputTag("ak4PFMatchingForakCs4PFpatJetFlavourAssociation")
     )
 
 akFlowPuCs4PFJetAnalyzer = akCs4PFJetAnalyzer.clone()

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -42,7 +42,6 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
         else:
             genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
 
-        if noReclustering == False:
             addToSequence( genjetcollection,
                            ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
                            process, sequence)

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -15,7 +15,7 @@ def addToSequence(label, module, process, sequence):
     setattr(process, label, module)
     sequence += getattr(process, label)
 
-def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None', doFlow = False, matchJets = False):
+def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None', doFlow = False, matchJets = False, noReclustering = False):
 
     if radius < 0:
        radiustag = get_radius(tag)
@@ -23,25 +23,29 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
     else:
        radiustag = "{:.0f}".format(radius*10)
 
-    addToSequence( tag+'Jets',
-                   akCs4PFJets.clone(rParam = radius, src = 'packedPFCandidates', useModulatedRho = doFlow),
-                   process, sequence)
+    if noReclustering == False:
+        addToSequence( tag+'Jets',
+                       akCs4PFJets.clone(rParam = radius, src = 'packedPFCandidates', useModulatedRho = doFlow),
+                       process, sequence)
+        if JECTag == 'None':
+            JECTag = 'AK' + str(radiustag) + 'PF'
 
-    if JECTag == 'None':
-       JECTag = 'AK' + str(radiustag) + 'PF'
-
-    addToSequence( tag+'patJetCorrFactors',
-                   patJetCorrFactors.clone(payload = JECTag, src = tag+'Jets'),
-                   process, sequence)
+        addToSequence( tag+'patJetCorrFactors',
+                       patJetCorrFactors.clone(payload = JECTag, src = tag+'Jets'),
+                       process, sequence)
 
     # Add Monte Carlo specific collections to the sequence
     if isMC :
 
-        genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
+        if noReclustering:
+            genjetcollection = 'slimmedGenJets'
+        else:
+            genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
 
-        addToSequence( genjetcollection,
-                       ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
-                       process, sequence)
+        if noReclustering == False:
+            addToSequence( genjetcollection,
+                           ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = radius),
+                           process, sequence)
 
         # To find parton flavor for CS subtracted jets, they need to be matched with unsubtracted jets
         if matchJets:
@@ -97,66 +101,70 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                          process, sequence)
 
         # Configuration for unsubtracted jets ready
+        
+        # the whole rest of the function is only for unsubtracted jets
+        if noReclustering == False:
 
-        addToSequence( tag+'patJetPartonMatch',
-                       patJetPartonMatch.clone(maxDeltaR = radius,
-                       matched = 'hiSignalGenParticles',
-                       src = tag+'Jets'),
-                       process, sequence)
+            addToSequence( tag+'patJetPartonMatch',
+                           patJetPartonMatch.clone(maxDeltaR = radius,
+                                                   matched = 'hiSignalGenParticles',
+                                                   src = tag+'Jets'),
+                           process, sequence)
+            
+            addToSequence( tag+'patJetGenJetMatch',
+                           patJetGenJetMatch.clone(maxDeltaR = radius,
+                                                   matched = genjetcollection,
+                                                   src = tag + 'Jets'),
+                           process, sequence)
+            
+            addToSequence( tag+'patJetPartonAssociationLegacy',
+                           patJetPartonAssociationLegacy.clone(jets = tag + 'Jets'),
+                           process, sequence)
+            
+            addToSequence( tag+'patJetFlavourAssociationLegacy',
+                           patJetFlavourAssociationLegacy.clone(srcByReference = tag+'patJetPartonAssociationLegacy'),
+                           process, sequence)
+            
+            addToSequence( tag+'patJetPartons',
+                           patJetPartons.clone(partonMode = 'Pythia8'),
+                           process, sequence)
+            
+            # Monte Carlo specific collections added
 
-        addToSequence( tag+'patJetGenJetMatch',
-                       patJetGenJetMatch.clone(maxDeltaR = radius,
-                          matched = genjetcollection,
-                          src = tag + 'Jets'),
-                       process, sequence)
-
-        addToSequence( tag+'patJetPartonAssociationLegacy',
-                       patJetPartonAssociationLegacy.clone(jets = tag + 'Jets'),
-                       process, sequence)
-
-        addToSequence( tag+'patJetFlavourAssociationLegacy',
-                       patJetFlavourAssociationLegacy.clone(srcByReference = tag+'patJetPartonAssociationLegacy'),
-                       process, sequence)
-
-        addToSequence( tag+'patJetPartons',
-                       patJetPartons.clone(partonMode = 'Pythia8'),
-                       process, sequence)
-
-    # Monte Carlo specific collections added
-
-    addToSequence( tag+'pfImpactParameterTagInfos',
-                   pfImpactParameterTagInfos.clone(jets = tag +'Jets',
-                      candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVertices'),
-                   process, sequence)
-
-    addToSequence( tag+'pfSecondaryVertexTagInfos',
-                   pfSecondaryVertexTagInfos.clone(trackIPTagInfos = tag+'pfImpactParameterTagInfos'),
-                   process, sequence)
-
-    addToSequence( tag+'pfDeepCSVTagInfos',
-                   pfDeepCSVTagInfos.clone(svTagInfos = tag+'pfSecondaryVertexTagInfos'),
-                   process, sequence)
-
-    addToSequence( tag+'pfDeepCSVJetTags',
-                   pfDeepCSVJetTags.clone(src = tag+'pfDeepCSVTagInfos'),
-                   process, sequence)
-
-    addToSequence( tag+'pfJetProbabilityBJetTags',
-                   pfJetProbabilityBJetTags.clone(tagInfos = [tag+'pfImpactParameterTagInfos']),
-                   process, sequence)
-
-    addToSequence( tag+'patJets',
-                   patJets.clone(
-                       JetFlavourInfoSource = tag+'patJetFlavourAssociation',
-                       JetPartonMapSource = tag+'patJetFlavourAssociationLegacy',
-                       genJetMatch = tag+'patJetGenJetMatch',
-                       genPartonMatch = tag+'patJetPartonMatch',
-                       jetCorrFactorsSource = cms.VInputTag(tag+'patJetCorrFactors'),
-                       jetSource = tag+'Jets',
-                       discriminatorSources = cms.VInputTag(cms.InputTag(tag+'pfDeepCSVJetTags','probb'), cms.InputTag(tag+'pfDeepCSVJetTags','probc'), cms.InputTag(tag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(tag+'pfDeepCSVJetTags','probbb'), cms.InputTag(tag+'pfJetProbabilityBJetTags')),
-                       addAssociatedTracks = False,
-                   ),
-                   process, sequence)
+            addToSequence( tag+'pfImpactParameterTagInfos',
+                           pfImpactParameterTagInfos.clone(jets = tag +'Jets',
+                                                           candidates = 'packedPFCandidates', primaryVertex = 'offlineSlimmedPrimaryVertices'),
+                           process, sequence)
+            
+        
+            addToSequence( tag+'pfSecondaryVertexTagInfos',
+                           pfSecondaryVertexTagInfos.clone(trackIPTagInfos = tag+'pfImpactParameterTagInfos'),
+                           process, sequence)
+        
+            addToSequence( tag+'pfDeepCSVTagInfos',
+                           pfDeepCSVTagInfos.clone(svTagInfos = tag+'pfSecondaryVertexTagInfos'),
+                           process, sequence)
+        
+            addToSequence( tag+'pfDeepCSVJetTags',
+                           pfDeepCSVJetTags.clone(src = tag+'pfDeepCSVTagInfos'),
+                           process, sequence)
+            
+            addToSequence( tag+'pfJetProbabilityBJetTags',
+                           pfJetProbabilityBJetTags.clone(tagInfos = [tag+'pfImpactParameterTagInfos']),
+                           process, sequence)
+            
+            addToSequence( tag+'patJets',
+                           patJets.clone(
+                               JetFlavourInfoSource = tag+'patJetFlavourAssociation',
+                               JetPartonMapSource = tag+'patJetFlavourAssociationLegacy',
+                               genJetMatch = tag+'patJetGenJetMatch',
+                               genPartonMatch = tag+'patJetPartonMatch',
+                               jetCorrFactorsSource = cms.VInputTag(tag+'patJetCorrFactors'),
+                               jetSource = tag+'Jets',
+                               discriminatorSources = cms.VInputTag(cms.InputTag(tag+'pfDeepCSVJetTags','probb'), cms.InputTag(tag+'pfDeepCSVJetTags','probc'), cms.InputTag(tag+'pfDeepCSVJetTags','probudsg'), cms.InputTag(tag+'pfDeepCSVJetTags','probbb'), cms.InputTag(tag+'pfJetProbabilityBJetTags')),
+                               addAssociatedTracks = False,
+                           ),
+                           process, sequence)
 
 def setupPprefJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'):
 

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -74,9 +74,9 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
     if (useHepMC_)
       eventInfoTag_ = consumes<HepMCProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
     eventGenInfoTag_ = consumes<GenEventInfoProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
+    jetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>( iConfig.getParameter<edm::InputTag>("jetFlavourInfos") );
   }
   useRawPt_ = iConfig.getUntrackedParameter<bool>("useRawPt", true);
-  jetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>( iConfig.getParameter<edm::InputTag>("jetFlavourInfos") );
   doLegacyBtagging_ = iConfig.getUntrackedParameter<bool>("doLegacyBtagging", true);
   doCandidateBtagging_ = iConfig.getUntrackedParameter<bool>("doCandidateBtagging", true);
   useNewBtaggers_ = iConfig.getUntrackedParameter<bool>("useNewBtaggers", false);
@@ -279,8 +279,6 @@ void HiInclusiveJetAnalyzer::beginJob() {
       t->Branch("mjtPartonFlavor", jets_.mjtPartonFlavor, "mjtPartonFlavor[nref]/I");
       t->Branch("mjtNbHad", jets_.mjtNbHad, "mjtNbHad[nref]/I");
       t->Branch("mjtNcHad", jets_.mjtNcHad, "mjtNcHad[nref]/I");
-      t->Branch("mjtNbPar", jets_.mjtNbPar, "mjtNbPar[nref]/I");
-      t->Branch("mjtNcPar", jets_.mjtNcPar, "mjtNcPar[nref]/I");
     }
   }
 
@@ -784,19 +782,6 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
 		jets_.mjtNbHad[jets_.nref] = bHadronsInJet.size();
 		jets_.mjtNcHad[jets_.nref] = cHadronsInJet.size();
 
-		const GenParticleRefVector &partonsInJet = jetInfo.getPartons();
-
-		int nb=0;
-		int nc=0;
-
-		for (GenParticleRefVector::const_iterator it = partonsInJet.begin(); it != partonsInJet.end(); ++it) {
-		  int parFlav = (*it)->pdgId();
-		  if(abs(parFlav)==5) nb++;
-		  else if(abs(parFlav)==4) nc++;		  
-		}
-		
-		jets_.mjtNbPar[jets_.nref] = nb;
-		jets_.mjtNcPar[jets_.nref] = nc;
 		break;
 	      }
 	    } // end loop over flavour info
@@ -822,11 +807,13 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
       std::vector<fastjet::PseudoJet> candidates;
       auto daughters = jet.getJetConstituents();
       for (auto it = daughters.begin(); it != daughters.end(); ++it) {
-        candidates.push_back(fastjet::PseudoJet((**it).px(), (**it).py(), (**it).pz(), (**it).energy()));
+	if (!it->isAvailable()) continue;
+	const reco::CandidatePtr &constit = *it;
+	if (constit.isNull() || constit->pt() <= std::numeric_limits<double>::epsilon()) continue;
+	candidates.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
       }
       auto cs = new fastjet::ClusterSequence(candidates, WTAjtDef);
       std::vector<fastjet::PseudoJet> wtajt = fastjet::sorted_by_pt(cs->inclusive_jets(0));
-
       jets_.WTAeta[jets_.nref] = (!wtajt.empty()) ? wtajt[0].eta() : -999;
       jets_.WTAphi[jets_.nref] = (!wtajt.empty()) ? wtajt[0].phi_std() : -999;
       delete cs;
@@ -1066,7 +1053,9 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
           std::vector<fastjet::PseudoJet> candidates;
           auto daughters = genjet.getJetConstituents();
           for (auto it = daughters.begin(); it != daughters.end(); ++it) {
-            candidates.push_back(fastjet::PseudoJet((**it).px(), (**it).py(), (**it).pz(), (**it).energy()));
+	    if (!it->isAvailable()) continue;  
+	    const reco::CandidatePtr &constit = *it;
+	    candidates.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
           }
           auto cs = new fastjet::ClusterSequence(candidates, WTAjtDef);
           std::vector<fastjet::PseudoJet> wtajt = fastjet::sorted_by_pt(cs->inclusive_jets(0));

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -76,7 +76,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
     eventGenInfoTag_ = consumes<GenEventInfoProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
   }
   useRawPt_ = iConfig.getUntrackedParameter<bool>("useRawPt", true);
-
+  jetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>( iConfig.getParameter<edm::InputTag>("jetFlavourInfos") );
   doLegacyBtagging_ = iConfig.getUntrackedParameter<bool>("doLegacyBtagging", true);
   doCandidateBtagging_ = iConfig.getUntrackedParameter<bool>("doCandidateBtagging", true);
   useNewBtaggers_ = iConfig.getUntrackedParameter<bool>("useNewBtaggers", false);
@@ -270,13 +270,17 @@ void HiInclusiveJetAnalyzer::beginJob() {
 
   // Jet ID
   if (doMatch_) {
-    t->Branch("matchedPt", jets_.matchedPt, "matchedPt[nref]/F");
-    t->Branch("matchedRawPt", jets_.matchedRawPt, "matchedRawPt[nref]/F");
-    t->Branch("matchedPu", jets_.matchedPu, "matchedPu[nref]/F");
-    t->Branch("matchedR", jets_.matchedR, "matchedR[nref]/F");
+    t->Branch("mjtPt", jets_.mjtPt, "mjtPt[nref]/F");
+    t->Branch("mjtRawPt", jets_.mjtRawPt, "mjtRawPt[nref]/F");
+    t->Branch("mjtPu", jets_.mjtPu, "mjtPu[nref]/F");
+    t->Branch("mjtR", jets_.mjtR, "mjtR[nref]/F");
     if (isMC_) {
-      t->Branch("matchedHadronFlavor", jets_.matchedHadronFlavor, "matchedHadronFlavor[nref]/I");
-      t->Branch("matchedPartonFlavor", jets_.matchedPartonFlavor, "matchedPartonFlavor[nref]/I");
+      t->Branch("mjtHadronFlavor", jets_.mjtHadronFlavor, "mjtHadronFlavor[nref]/I");
+      t->Branch("mjtPartonFlavor", jets_.mjtPartonFlavor, "mjtPartonFlavor[nref]/I");
+      t->Branch("mjtNbHad", jets_.mjtNbHad, "mjtNbHad[nref]/I");
+      t->Branch("mjtNcHad", jets_.mjtNcHad, "mjtNcHad[nref]/I");
+      t->Branch("mjtNbPar", jets_.mjtNbPar, "mjtNbPar[nref]/I");
+      t->Branch("mjtNcPar", jets_.mjtNcPar, "mjtNcPar[nref]/I");
     }
   }
 
@@ -491,9 +495,12 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
 
   edm::Handle<edm::View<pat::PackedCandidate>> pfCandidates;
   iEvent.getByToken(pfCandidateLabel_, pfCandidates);
+  edm::Handle<reco::JetFlavourInfoMatchingCollection> jetFlavourInfos;
+
   if (isMC_) {
     edm::Handle<reco::GenParticleCollection> genparts;
     iEvent.getByToken(genParticleSrc_, genparts);
+    iEvent.getByToken(jetFlavourInfosToken_, jetFlavourInfos );
   }
 
   std::map<std::string, std::map<std::string, edm::Handle<JetTagCollection>>> jetTaggers;
@@ -760,16 +767,42 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
 
         double dr = deltaR(jet, mjet);
         if (dr < drMin) {
-          jets_.matchedPt[jets_.nref] = mjet.pt();
+          jets_.mjtPt[jets_.nref] = mjet.pt();
 
-          jets_.matchedRawPt[jets_.nref] = mjet.correctedJet("Uncorrected").pt();
-          jets_.matchedPu[jets_.nref] = mjet.pileup();
+          jets_.mjtRawPt[jets_.nref] = mjet.correctedJet("Uncorrected").pt();
+          jets_.mjtPu[jets_.nref] = mjet.pileup();
           if (isMC_) {
-            jets_.matchedHadronFlavor[jets_.nref] = mjet.hadronFlavour();
-            jets_.matchedPartonFlavor[jets_.nref] = mjet.partonFlavour();
+            jets_.mjtHadronFlavor[jets_.nref] = mjet.hadronFlavour();
+            jets_.mjtPartonFlavor[jets_.nref] = mjet.partonFlavour();
+
+	    for (const JetFlavourInfoMatching& jetFlavourInfoMatching : *jetFlavourInfos) {
+	      if (deltaR(mjet.p4(), jetFlavourInfoMatching.first->p4()) < 1e-6) {
+		JetFlavourInfo jetInfo = jetFlavourInfoMatching.second;
+		const GenParticleRefVector &bHadronsInJet = jetInfo.getbHadrons();
+		const GenParticleRefVector &cHadronsInJet = jetInfo.getcHadrons();
+
+		jets_.mjtNbHad[jets_.nref] = bHadronsInJet.size();
+		jets_.mjtNcHad[jets_.nref] = cHadronsInJet.size();
+
+		const GenParticleRefVector &partonsInJet = jetInfo.getPartons();
+
+		int nb=0;
+		int nc=0;
+
+		for (GenParticleRefVector::const_iterator it = partonsInJet.begin(); it != partonsInJet.end(); ++it) {
+		  int parFlav = (*it)->pdgId();
+		  if(abs(parFlav)==5) nb++;
+		  else if(abs(parFlav)==4) nc++;		  
+		}
+		
+		jets_.mjtNbPar[jets_.nref] = nb;
+		jets_.mjtNcPar[jets_.nref] = nc;
+		break;
+	      }
+	    } // end loop over flavour info
           }
 
-          jets_.matchedR[jets_.nref] = dr;
+          jets_.mjtR[jets_.nref] = dr;
           drMin = dr;
         }
       }


### PR DESCRIPTION
There is no need to run reclustering by default for people who just want the standard CS jet collection from miniAOD. 
Once removed the forest will execute much more rapidly as there is no reco, only ntuple-ization
It's definitely not the most elegant implementation in the world. 
Perhaps we could add a flag if people want to recluster them for some reason. 
So far I only handled `forest_miniAOD_run3_DATA.py` and `forest_miniAOD_run3_MC.py`
We should probably merge back the new ParticleTransformer stuff into the main cfg, possibly with a flag. 