### PR TITLE
Migrate to deepNtupleSettings

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -3,8 +3,8 @@
 # Type: mc
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_pp_on_PbPb_2023_cff import Run3_pp_on_PbPb_2023
-process = cms.Process('HiForest', Run3_pp_on_PbPb_2023)
+from Configuration.Eras.Era_Run3_pp_on_PbPb_2024_cff import Run3_pp_on_PbPb_2024
+process = cms.Process('HiForest', Run3_pp_on_PbPb_2024)
 
 ###############################################################################
 
@@ -38,8 +38,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase1_2023_realistic_hi', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, '132X_mcRun3_2023_realistic_HI_v10', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '141X_mcRun3_2024_realistic_HI_v11', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 process.GlobalTag.snapshotTime = cms.string("9999-12-31 23:59:59.000")
 process.GlobalTag.toGet.extend([
@@ -108,17 +107,12 @@ process.muonAnalyzer.doGen = cms.bool(True)
 
 ###############################################################################
 
-# ZDC analyzer
-process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018Producer_cfi')
-process.load('HeavyIonsAnalysis.ZDCAnalysis.QWZDC2018RecHit_cfi')
-process.load('HeavyIonsAnalysis.ZDCAnalysis.zdcanalyzer_cfi')
-
-process.zdcanalyzer.doZDCRecHit = False
-process.zdcanalyzer.doZDCDigi = True
-process.zdcanalyzer.zdcRecHitSrc = cms.InputTag("QWzdcreco")
-process.zdcanalyzer.zdcDigiSrc = cms.InputTag("hcalDigis", "ZDC")
-process.zdcanalyzer.calZDCDigi = False
-process.zdcanalyzer.verbose = False
+#########################                                                                                                                                                 
+# ZDC RecHit Producer && Analyzer                                                                                                                                         
+#########################                                                                                                                                                 
+# to prevent crash related to HcalSeverityLevelComputerRcd record                                                                                                         
+process.load("RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi")
+process.load('HeavyIonsAnalysis.ZDCAnalysis.ZDCAnalyzersPbPb_cff')
 
 ###############################################################################
 # main forest sequence
@@ -133,36 +127,59 @@ process.forest = cms.Path(
     process.hiEvtAnalyzer +
     process.HiGenParticleAna +
     process.ggHiNtuplizer +
-#    process.zdcdigi +
-#    process.QWzdcreco +
-    process.zdcanalyzer #+
+    process.zdcSequencePbPb
 #    process.unpackedMuons +
 #    process.muonAnalyzer
     )
 
 #customisation
 
-addR3Jets = False
-addR3FlowJets = False
-addR4Jets = False
-addR4FlowJets = True
+# Select the types of jets filled
 matchJets = True             # Enables q/g and heavy flavor jet identification in MC
-addCandidateTagging = False
+jetPtMin = 15
+jetAbsEtaMax = 2.5
+
+# Choose which additional information is added to jet trees
+doHIJetID = True             # Fill jet ID and composition information branches
+doWTARecluster = False        # Add jet phi and eta for WTA axis
+doBtagging  =  False         # Note that setting to True increases computing time a lot
+
+# 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
+jetLabel = "0"
+
+# add candidate tagging, copy/paste to add other jet radii
+from HeavyIonsAnalysis.JetAnalysis.deepNtupleSettings_cff import candidateBtaggingMiniAOD
+candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
+
+# setup jet analyzer
+setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = 'selectedUpdatedPatJetsDeepFlavour'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFUnsubJetFlavourInfos"
+if doBtagging:
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").useNewBtaggers = True
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsDeepFlavour") 
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsDeepFlavour")
+process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
+
+# Options for reclustering jets with different parameters.                                                                                                                                                                                                                               
+# TODO:  Integrate with CS flow jets with deepNtupleSettings script above -Matt   
+addR3FlowJets = False
+addR4FlowJets = False
+matchJets = True             # Enables q/g and heavy flavor jet identification in MC
 doHIJetID = True             # Fill jet ID and composition information branches
 doWTARecluster = False        # Add jet phi and eta for WTA axis
 
-if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
+if addR3FlowJets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
     from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-
-    if addR3Jets :
-        process.jetsR3 = cms.Sequence()
-        jetName = 'akCs3PF'
-        setupHeavyIonJets(jetName, process.jetsR3, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = False, matchJets = matchJets)
-        process.akCs3PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets", doHiJetID = doHIJetID, doWTARecluster = doWTARecluster)
-        process.forest += process.extraJetsMC * process.jetsR3 * process.akCs3PFJetAnalyzer
 
     if addR3FlowJets :
         process.jetsR3flow = cms.Sequence()
@@ -170,21 +187,8 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         setupHeavyIonJets(jetName, process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True, matchJets = matchJets)
         process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
         process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets", doHiJetID = doHIJetID, doWTARecluster = doWTARecluster)
-        process.forest += process.extraFlowJetsMC * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
+        process.forest += process.extraFlowJets * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
 
-    if addR4Jets :
-        # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
-        process.jetsR4 = cms.Sequence()
-        jetName = 'akCs0PF'
-        setupHeavyIonJets(jetName, process.jetsR4, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = False, matchJets = matchJets)
-        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
-        process.akCs4PFJetAnalyzer.jetName = jetName
-        process.akCs4PFJetAnalyzer.matchJets = matchJets
-        process.akCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
-        process.akCs4PFJetAnalyzer.doHiJetID = doHIJetID
-        process.akCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraJetsMC * process.jetsR4 * process.akCs4PFJetAnalyzer
 
     if addR4FlowJets :
         process.jetsR4flow = cms.Sequence()
@@ -197,32 +201,8 @@ if addR3Jets or addR3FlowJets or addR4Jets or addR4FlowJets :
         process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
         process.akFlowPuCs4PFJetAnalyzer.doHiJetID = doHIJetID
         process.akFlowPuCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraFlowJetsMC * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer 
+        process.forest += process.extraFlowJets * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer 
 
-
-if addCandidateTagging:
-    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
-
-    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
-    updateJetCollection(
-        process,
-        jetSource = cms.InputTag('slimmedJets'),
-        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-        btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
-        btagPrefix = 'TEST',
-    )
-
-    process.updatedPatJets.addJetCorrFactors = False
-    process.updatedPatJets.discriminatorSources = cms.VInputTag(
-        cms.InputTag('pfDeepCSVJetTags:probb'),
-        cms.InputTag('pfDeepCSVJetTags:probc'),
-        cms.InputTag('pfDeepCSVJetTags:probudsg'),
-        cms.InputTag('pfDeepCSVJetTags:probbb'),
-    )
-
-    process.akCs4PFJetAnalyzer.jetTag = "updatedPatJets"
-
-    process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
 
 
 #########################

--- a/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
+++ b/HeavyIonsAnalysis/JetAnalysis/interface/HiInclusiveJetAnalyzer.h
@@ -22,6 +22,8 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "fastjet/contrib/Njettiness.hh"
+#include "DataFormats/JetMatching/interface/JetFlavourInfo.h"
+#include "DataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
 //
 
 /**\class HiInclusiveJetAnalyzer
@@ -72,6 +74,8 @@ private:
   edm::EDGetTokenT<edm::View<reco::GenJet>> genjetTag_;
   edm::EDGetTokenT<edm::HepMCProduct> eventInfoTag_;
   edm::EDGetTokenT<GenEventInfoProduct> eventGenInfoTag_;
+  // b and c hadrons                                                                                                                                                     
+  edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> jetFlavourInfosToken_;
 
   std::string jetName_;  //used as prefix for jet structures
   edm::EDGetTokenT<edm::View<reco::Jet>> subjetGenTag_;

--- a/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/akCs4PFJetSequence_pponPbPb_mc_cff.py
@@ -13,6 +13,7 @@ akCs4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     jetName = cms.untracked.string("akCs4PF"),
     genPtMin = cms.untracked.double(5),
     hltTrgResults = cms.untracked.string('TriggerResults::'+'HISIGNAL'),
+    jetFlavourInfos = cms.InputTag("ak4PFUnsubJetFlavourInfos")
     )
 
 akFlowPuCs4PFJetAnalyzer = akCs4PFJetAnalyzer.clone()

--- a/HeavyIonsAnalysis/JetAnalysis/python/deepNtupleSettings_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/deepNtupleSettings_cff.py
@@ -1,0 +1,261 @@
+import FWCore.ParameterSet.Config as cms
+
+def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = False, labelR = "0"):
+    # DeepNtuple settings
+    jetR = 0.1*int(labelR)
+    if labelR == "0": jetR = 0.4
+
+    #jetCorrectionsAK4 = ('AK4PF' if labelR == "0" else 'AK'+labelR+'PF', jetCorrLevels, 'None')
+    jetCorrectionsAK4 = ('AK4PF', jetCorrLevels, 'None')  # temporary while we wait for updated JECs
+
+
+    if doBtagging:
+        bTagInfos = [
+            'pfDeepCSVTagInfos',
+            'pfDeepFlavourTagInfos',
+            'pfImpactParameterTagInfos',
+            'pfInclusiveSecondaryVertexFinderTagInfos',
+            'pfParticleTransformerAK4TagInfos',
+            'pfUnifiedParticleTransformerAK4TagInfos'
+        ]
+
+        bTagDiscriminators = [
+            'pfUnifiedParticleTransformerAK4JetTags:probb',
+            'pfUnifiedParticleTransformerAK4JetTags:probbb',
+            'pfUnifiedParticleTransformerAK4JetTags:probc',
+            'pfUnifiedParticleTransformerAK4JetTags:probg',
+            'pfUnifiedParticleTransformerAK4JetTags:problepb',
+            'pfUnifiedParticleTransformerAK4JetTags:probu',
+            'pfUnifiedParticleTransformerAK4JetTags:probd',
+            'pfUnifiedParticleTransformerAK4JetTags:probs',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaup1h0p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaup1h1p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaup1h2p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaup3h0p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaup3h1p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaum1h0p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaum1h1p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaum1h2p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaum3h0p',
+            'pfUnifiedParticleTransformerAK4JetTags:probtaum3h1p',
+            'pfUnifiedParticleTransformerAK4JetTags:probele',
+            'pfUnifiedParticleTransformerAK4JetTags:probmu',
+            'pfUnifiedParticleTransformerAK4JetTags:ptcorr',
+            'pfUnifiedParticleTransformerAK4JetTags:ptnu',
+        ]
+    else: 
+        bTagInfos = ['None']
+        bTagDiscriminators = ['None']
+
+    # Create gen-level information
+    if isMC:
+        from RecoHI.HiJetAlgos.hiSignalParticleProducer_cfi import hiSignalParticleProducer as hiSignalGenParticles
+        process.hiSignalGenParticles = hiSignalGenParticles.clone(
+            src = "prunedGenParticles"
+        )
+        from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJets_cff import allPartons
+        process.allPartons = allPartons.clone(
+            src = 'hiSignalGenParticles'
+        )
+        from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
+        setattr(process,"ak"+labelR+"GenJetsWithNu",
+                ak4GenJets.clone(
+                    src = 'packedGenParticlesSignal',
+                    rParam = jetR
+                )
+        )
+        process.packedGenParticlesForJetsNoNu = cms.EDFilter("CandPtrSelector",
+            src = cms.InputTag("packedGenParticlesSignal"),
+            cut = cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
+        )
+        setattr(process,"ak"+labelR+"GenJetsRecluster",
+                ak4GenJets.clone(
+                    src = 'packedGenParticlesForJetsNoNu'
+                )
+        )
+        process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, getattr(process,"ak"+labelR+"GenJetsWithNu"), process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsRecluster"))
+
+    # Remake secondary vertices
+    from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateVertexFinder, candidateVertexMerger, candidateVertexArbitrator, inclusiveCandidateSecondaryVertices
+    process.inclusiveCandidateVertexFinder = inclusiveCandidateVertexFinder.clone(
+        tracks = "packedPFCandidates",
+        primaryVertices = "offlineSlimmedPrimaryVertices",
+        minHits = 0,
+        minPt = 0.8
+    )
+    process.candidateVertexMerger = candidateVertexMerger.clone()
+    process.candidateVertexArbitrator = candidateVertexArbitrator.clone(
+        tracks = "packedPFCandidates",
+        primaryVertices = "offlineSlimmedPrimaryVertices"
+    )
+    process.inclusiveCandidateSecondaryVertices = inclusiveCandidateSecondaryVertices.clone()
+    process.svTask = cms.Task(process.inclusiveCandidateVertexFinder, process.candidateVertexMerger, process.candidateVertexArbitrator, process.inclusiveCandidateSecondaryVertices)
+    svSource = cms.InputTag("inclusiveCandidateSecondaryVertices")
+
+    # Create unsubtracted reco jets
+
+    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import ak4PFJets
+    setattr(process, "ak"+labelR+"PFUnsubJets", 
+            ak4PFJets.clone(
+                src = 'packedPFCandidates',
+                jetPtMin = 5.,  # set lower than subtracted version
+                rParam = jetR
+            )
+    )
+    
+
+    if isMC:
+        from PhysicsTools.JetMCAlgos.HadronAndPartonSelector_cfi import selectedHadronsAndPartons
+        from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
+        process.selectedHadronsAndPartons = selectedHadronsAndPartons.clone(particles = "prunedGenParticles")
+        setattr(process,"ak"+labelR+"PFUnsubJetFlavourInfos",
+                ak4JetFlavourInfos.clone(
+                    jets = "ak"+labelR+"PFUnsubJets",
+                    partons = "selectedHadronsAndPartons:algorithmicPartons",
+                    hadronFlavourHasPriority = True,
+                    rParam = jetR
+                )
+        )
+        process.genTask.add(process.selectedHadronsAndPartons)
+        process.genTask.add(getattr(process,"ak"+labelR+"PFUnsubJetFlavourInfos"))
+
+    matchedGenJets = ""
+    if isMC:
+        if labelR == "0": matchedGenJets = "slimmedGenJets"
+        else: matchedGenJets  = "ak"+labelR+"GenJetsWithNu"
+
+
+
+    from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
+    addJetCollection(
+        process,
+        postfix            = "UnsubJets",
+        labelName          = str("AK"+labelR+"PF"),
+        jetSource          = cms.InputTag("ak"+labelR+"PFUnsubJets"),
+        algo               = "ak", #name of algo must be in this format
+        rParam             = jetR,
+        pvSource           = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        pfCandidates       = cms.InputTag("packedPFCandidates"),
+        svSource           = svSource,
+        muSource           = cms.InputTag("slimmedMuons"),
+        elSource           = cms.InputTag("slimmedElectrons"),
+        getJetMCFlavour    = isMC,
+        genJetCollection   = cms.InputTag(matchedGenJets),
+        genParticles       = cms.InputTag("hiSignalGenParticles" if isMC else ""),
+        #jetCorrections     = ('AK4PF' if labelR=='0' else 'AK'+labelR+'PF',) + jetCorrectionsAK4[1:],
+        jetCorrections     = ('AK4PF',) + jetCorrectionsAK4[1:],  #tempoorary while we wait for updated JECs
+    )
+
+    getattr(process,"patJetsAK"+labelR+"PFUnsubJets").useLegacyJetMCFlavour = False
+
+    process.patAlgosToolsTask.add(getattr(process,"ak"+labelR+"PFUnsubJets"))
+
+    # Create HIN subtracted reco jets
+    from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
+    addJetCollection(
+        process,
+        postfix            = "",
+        labelName          = "AKCs"+labelR+"PF",
+        jetSource          = cms.InputTag("akCs"+labelR+"PFJets"),
+        algo               = "ak", #name of algo must be in this format
+        rParam             = jetR,
+        pvSource           = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        pfCandidates       = cms.InputTag("packedPFCandidates"),
+        svSource           = svSource,
+        muSource           = cms.InputTag("slimmedMuons"),
+        elSource           = cms.InputTag("slimmedElectrons"),
+        getJetMCFlavour    = isMC,
+        genJetCollection   = cms.InputTag(matchedGenJets),
+        genParticles       = cms.InputTag("hiSignalGenParticles" if isMC else ""),
+        jetCorrections     = jetCorrectionsAK4,
+    )
+    getattr(process,"patJetsAKCs"+labelR+"PF").embedPFCandidates = True
+
+    if not isMC:
+        for label in ["patJetsAK"+labelR+"PFUnsubJets", "patJetsAKCs"+labelR+"PF"]:
+            getattr(process, label).addGenJetMatch = False
+            getattr(process, label).addGenPartonMatch = False
+            getattr(process, label).embedGenJetMatch = False
+            getattr(process, label).embedGenPartonMatch = False
+            getattr(process, label).genJetMatch = ""
+            getattr(process, label).genPartonMatch = ""
+
+    # left here for reference in case we want to move reclustering here
+    from PhysicsTools.PatAlgos.producersHeavyIons.heavyIonJets_cff import PackedPFTowers, hiPuRho
+    process.PackedPFTowers = PackedPFTowers.clone()
+    process.hiPuRho = hiPuRho.clone(
+        src = 'PackedPFTowers'
+    )
+    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import akCs4PFJets
+    setattr(process,"akCs"+labelR+"PFJets",
+            akCs4PFJets.clone(
+                src = 'packedPFCandidates',
+                jetPtMin = jetPtMin,
+                rParam = jetR
+            )
+    )
+    for mod in ["PackedPFTowers", "hiPuRho", "akCs"+labelR+"PFJets"]:
+        process.patAlgosToolsTask.add(getattr(process, mod))
+
+    # Create b-tagging sequence ----------------
+    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+    updateJetCollection(
+        process,
+        labelName = "DeepFlavour",
+        jetSource = cms.InputTag("slimmedJets" if labelR == "0" else "patJetsAKCs"+labelR+"PF"), 
+        jetCorrections = jetCorrectionsAK4,
+        pfCandidates = cms.InputTag('packedPFCandidates'),
+        pvSource = cms.InputTag("offlineSlimmedPrimaryVertices"),
+        svSource = svSource,
+        muSource = cms.InputTag('slimmedMuons'),
+        elSource = cms.InputTag('slimmedElectrons'),
+        btagInfos = bTagInfos,
+        btagDiscriminators = bTagDiscriminators,
+        explicitJTA = False
+    )
+
+    process.unsubUpdatedPatJetsDeepFlavour = cms.EDProducer("JetMatcherDR",
+                                                            source = cms.InputTag("updatedPatJetsDeepFlavour"),
+                                                            matched = cms.InputTag("patJetsAK"+labelR+"PFUnsubJets")
+    )
+    process.patAlgosToolsTask.add(process.unsubUpdatedPatJetsDeepFlavour)
+
+    if doBtagging:
+
+        process.pfUnifiedParticleTransformerAK4JetTagsDeepFlavour.model_path = 'RecoBTag/Combined/data/UParTAK4/HIN/V00/UParTAK4_PbPb_2023.onnx'
+        process.pfUnifiedParticleTransformerAK4TagInfosDeepFlavour.sort_cand_by_pt = True
+
+        if hasattr(process,'updatedPatJetsTransientCorrectedDeepFlavour'):
+            process.updatedPatJetsTransientCorrectedDeepFlavour.addTagInfos = True
+            process.updatedPatJetsTransientCorrectedDeepFlavour.addBTagInfo = True
+        else:
+            raise ValueError('I could not find updatedPatJetsTransientCorrectedDeepFlavour to embed the tagInfos, please check the cfg')
+
+            # Remove PUPPI
+        process.patAlgosToolsTask.remove(process.packedpuppi)
+        process.patAlgosToolsTask.remove(process.packedpuppiNoLep)
+        process.pfInclusiveSecondaryVertexFinderTagInfosDeepFlavour.weights = ""
+        for taginfo in ["pfDeepFlavourTagInfosDeepFlavour", "pfParticleTransformerAK4TagInfosDeepFlavour", "pfUnifiedParticleTransformerAK4TagInfosDeepFlavour"]:
+            getattr(process, taginfo).fallback_puppi_weight = True
+            getattr(process, taginfo).fallback_vertex_association = True
+            getattr(process, taginfo).unsubjet_map = "unsubUpdatedPatJetsDeepFlavour"
+            getattr(process, taginfo).puppi_value_map = ""
+
+    # Match with unsubtracted jets
+    process.unsubJetMap = process.unsubUpdatedPatJetsDeepFlavour.clone(
+        source = "selectedUpdatedPatJetsDeepFlavour"
+    )
+    process.patAlgosToolsTask.add(process.unsubJetMap)
+
+    # Add extra b tagging algos
+    from RecoBTag.ImpactParameter.pfJetProbabilityBJetTags_cfi import pfJetProbabilityBJetTags
+    process.pfJetProbabilityBJetTagsDeepFlavour = pfJetProbabilityBJetTags.clone(tagInfos = ["pfImpactParameterTagInfosDeepFlavour"])
+    if doBtagging:
+        process.patAlgosToolsTask.add(process.pfJetProbabilityBJetTagsDeepFlavour)
+
+    # Associate to forest sequence
+    if isMC:
+        process.forest.associate(process.genTask)
+    if doBtagging: 
+        process.forest.associate(process.svTask)
+    process.forest.associate(process.patAlgosToolsTask)

--- a/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
+++ b/HeavyIonsAnalysis/JetAnalysis/src/HiInclusiveJetAnalyzer.cc
@@ -74,6 +74,7 @@ HiInclusiveJetAnalyzer::HiInclusiveJetAnalyzer(const edm::ParameterSet& iConfig)
     if (useHepMC_)
       eventInfoTag_ = consumes<HepMCProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
     eventGenInfoTag_ = consumes<GenEventInfoProduct>(iConfig.getParameter<InputTag>("eventInfoTag"));
+    jetFlavourInfosToken_ = consumes<reco::JetFlavourInfoMatchingCollection>( iConfig.getParameter<edm::InputTag>("jetFlavourInfos") );
   }
   useRawPt_ = iConfig.getUntrackedParameter<bool>("useRawPt", true);
 
@@ -411,9 +412,12 @@ void HiInclusiveJetAnalyzer::analyze(const Event& iEvent, const EventSetup& iSet
 
   edm::Handle<edm::View<pat::PackedCandidate>> pfCandidates;
   iEvent.getByToken(pfCandidateLabel_, pfCandidates);
+  edm::Handle<reco::JetFlavourInfoMatchingCollection> jetFlavourInfos;
+
   if (isMC_) {
     edm::Handle<reco::GenParticleCollection> genparts;
     iEvent.getByToken(genParticleSrc_, genparts);
+    iEvent.getByToken(jetFlavourInfosToken_, jetFlavourInfos );
   }
 
   edm::Handle<JetTagCollection> bTags_partTransf, bTags_partTransfBB, bTags_partTransfLepB;


### PR DESCRIPTION
Migrating to the new jet task in deepNtupleSettings, synchronizing with 13_2_X.
This is done and tested only for `forest_miniAOD_run3_MC.py` and `forest_miniAOD_run3_DATA.py`
Other configs should work as before.  

May need the latest 14_1_X to now, I will update the instructions. 