### PR TITLE
Enable multiple R values in single pass

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -25,8 +25,8 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 141X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        # '/store/hidata/HIRun2024A/HIPhysicsRawPrime2/MINIAOD/PromptReco-v1/000/387/908/00000/93a76f4f-4e90-4357-9a7f-3c64a1be8e29.root'
-        '/store/group/phys_heavyions/wangj/RECO2024/miniaod_PhysicsHIPhysicsRawPrime0_388056_ZB.root'
+         '/store/hidata/HIRun2024A/HIPhysicsRawPrime2/MINIAOD/PromptReco-v1/000/387/908/00000/93a76f4f-4e90-4357-9a7f-3c64a1be8e29.root'
+        #'/store/group/phys_heavyions/wangj/RECO2024/miniaod_PhysicsHIPhysicsRawPrime0_388056_ZB.root'
     ), 
 )
 
@@ -152,6 +152,7 @@ process.forest = cms.Path(
 #customisation
 
 # Select the types of jets filled
+matchJets = False             # Enables q/g and heavy flavor jet identification in MC 
 jetPtMin = 15
 jetAbsEtaMax = 2.5
 
@@ -169,17 +170,18 @@ candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLeve
 
 # setup jet analyzer
 setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = 'selectedUpdatedPatJetsDeepFlavour'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
 if doBtagging:
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").useNewBtaggers = True
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsDeepFlavour") 
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsDeepFlavour")
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag")
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
 process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
 

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -153,7 +153,7 @@ candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevel
 
 # setup jet analyzer
 setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = 'selectedUpdatedPatJetsDeepFlavour'
+getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag =  "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
@@ -165,18 +165,15 @@ getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
 getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFUnsubJetFlavourInfos"
 if jetLabel!="0": getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
 if doBtagging:
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").useNewBtaggers = True
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsDeepFlavour") 
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsDeepFlavour")
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag") 
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
 process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
 # Options for reclustering jets with different parameters.                                                                                                                                                                                                                               
 # TODO:  Integrate with CS flow jets with deepNtupleSettings script above -Matt   
 addR3FlowJets = False
 addR4FlowJets = False
-matchJets = True             # Enables q/g and heavy flavor jet identification in MC
-doHIJetID = True             # Fill jet ID and composition information branches
-doWTARecluster = False        # Add jet phi and eta for WTA axis
+
 
 if addR3FlowJets or addR4FlowJets :
     process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
@@ -179,7 +179,7 @@ candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLeve
 # setup jet analyzer                                                   
                                                                       
 setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = 'selectedUpdatedPatJetsDeepFlavour'
+getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
@@ -189,6 +189,6 @@ getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
 if doBtagging:
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsDeepFlavour")
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsDeepFlavour")
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
 process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
@@ -153,7 +153,7 @@ candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevel
 # setup jet analyzer                                                   
                                                                       
 setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = 'selectedUpdatedPatJetsDeepFlavour'
+getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
@@ -165,6 +165,6 @@ getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
 getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFFlavourInfos"
 if jetLabel!="0": getattr(process,"ak"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
 if doBtagging:
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsDeepFlavour")
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsDeepFlavour")
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
 process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
@@ -181,7 +181,7 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
     from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
     updateJetCollection(
         process,
-        labelName = "DeepFlavour",
+        labelName = "AK"+labelR+"PFCHSBtag",
         jetSource = cms.InputTag("slimmedJets" if labelR == "0" else "patJetsAK"+labelR+"PFCHS"), 
         jetCorrections = jetCorrectionsAK4,
         pfCandidates = cms.InputTag('packedPFCandidates'),
@@ -194,43 +194,50 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
         explicitJTA = False
     )
 
-    process.unsubUpdatedPatJetsDeepFlavour = cms.EDProducer("JetMatcherDR",
-                                                            source = cms.InputTag("updatedPatJetsDeepFlavour"),
-                                                            matched = cms.InputTag("patJetsAK"+labelR+"PFUnsubJets")
-    )
-    process.patAlgosToolsTask.add(process.unsubUpdatedPatJetsDeepFlavour)
+    setattr(process,"unsubUpdatedPatJetsAK"+labelR+"PFCHS",
+            cms.EDProducer("JetMatcherDR",
+                           source = cms.InputTag("updatedPatJets"+labelR+"PFCHSBtag"),
+                           matched = cms.InputTag("patJetsAK"+labelR+"PFUnsubJets")
+                       )
+        )
+    process.patAlgosToolsTask.add(getattr(process,"unsubUpdatedPatJetsAK"+labelR+"PFCHS"))
 
     if doBtagging:
+        getattr(process,"pfUnifiedParticleTransformerAK4JetTagsAK"+labelR+"PFCHSBtag").model_path = 'RecoBTag/Combined/data/UParTAK4/HIN/V00/UParTAK4_PbPb_2023.onnx'
+        getattr(process,"pfUnifiedParticleTransformerAK4TagInfosAK"+labelR+"PFCHSBtag").sort_cand_by_pt = True 
+        getattr(process,"pfUnifiedParticleTransformerAK4TagInfosAK"+labelR+"PFCHSBtag").fix_lt_sorting = True
 
-        process.pfUnifiedParticleTransformerAK4JetTagsDeepFlavour.model_path = 'RecoBTag/Combined/data/UParTAK4/HIN/V00/UParTAK4_PbPb_2023.onnx'
-        process.pfUnifiedParticleTransformerAK4TagInfosDeepFlavour.sort_cand_by_pt = True
-
-        if hasattr(process,'updatedPatJetsTransientCorrectedDeepFlavour'):
-            process.updatedPatJetsTransientCorrectedDeepFlavour.addTagInfos = True
-            process.updatedPatJetsTransientCorrectedDeepFlavour.addBTagInfo = True
+        if hasattr(process,'updatedPatJetsTransientCorrectedAK'+labelR+'PFCHSBtag'):
+            getattr(process,'updatedPatJetsTransientCorrectedAK'+labelR+'PFCHSBtag').addTagInfos = True
+            getattr(process,'updatedPatJetsTransientCorrectedAK'+labelR+'PFCHSBtag').addBTagInfo = True
         else:
-            raise ValueError('I could not find updatedPatJetsTransientCorrectedDeepFlavour to embed the tagInfos, please check the cfg')
+            raise ValueError('I could not find updatedPatJetsTransientCorrected to embed the tagInfos, please check the cfg')
 
             # Remove PUPPI
         process.patAlgosToolsTask.remove(process.packedpuppi)
         process.patAlgosToolsTask.remove(process.packedpuppiNoLep)
-        process.pfInclusiveSecondaryVertexFinderTagInfosDeepFlavour.weights = ""
-        for taginfo in ["pfDeepFlavourTagInfosDeepFlavour", "pfParticleTransformerAK4TagInfosDeepFlavour", "pfUnifiedParticleTransformerAK4TagInfosDeepFlavour"]:
+        getattr(process,"pfInclusiveSecondaryVertexFinderTagInfosAK"+labelR+"PFCHSBtag").weights = ""
+        for taginfo in [ "pfDeepFlavourTagInfosAK"+labelR+"PFCHSBtag", "pfParticleTransformerAK4TagInfosAK"+labelR+"PFCHSBtag", "pfUnifiedParticleTransformerAK4TagInfosAK"+labelR+"PFCHSBtag"]:
             getattr(process, taginfo).fallback_puppi_weight = True
             getattr(process, taginfo).fallback_vertex_association = True
             getattr(process, taginfo).puppi_value_map = ""
 
     # Match with unsubtracted jets
-    process.unsubJetMap = process.unsubUpdatedPatJetsDeepFlavour.clone(
-        source = "selectedUpdatedPatJetsDeepFlavour"
-    )
-    process.patAlgosToolsTask.add(process.unsubJetMap)
+    setattr(process,"unsubAK"+labelR+"JetMap",
+            getattr(process,"unsubUpdatedPatJetsAK"+labelR+"PFCHS").clone(
+                source = "selectedUpdatedPatJetsAK"+labelR+"PFCHS"
+            )
+        )
+
+    process.patAlgosToolsTask.add(getattr(process,"unsubAK"+labelR+"JetMap"))
 
     # Add extra b tagging algos
     from RecoBTag.ImpactParameter.pfJetProbabilityBJetTags_cfi import pfJetProbabilityBJetTags
-    process.pfJetProbabilityBJetTagsDeepFlavour = pfJetProbabilityBJetTags.clone(tagInfos = ["pfImpactParameterTagInfosDeepFlavour"])
+    setattr(process,"pfJetProbabilityBJetTagsAK"+labelR+"PFCHSBtag",
+            pfJetProbabilityBJetTags.clone(tagInfos = ["pfImpactParameterTagInfosAK"+labelR+"PFCHSBtag"])
+        )
     if doBtagging:
-        process.patAlgosToolsTask.add(process.pfJetProbabilityBJetTagsDeepFlavour)
+        process.patAlgosToolsTask.add(getattr(process,"pfJetProbabilityBJetTagsAK"+labelR+"PFCHSBtag"))
 
     # Associate to forest sequence
     if isMC:


### PR DESCRIPTION
The forest was previously adapted to switch to a different R value by a single string in the cfg. 
However, running multiple R values in the same cfg was not working correctly because certain collections were being overwritten. 
This PR fixes that issue.  Now every jet collection should be customized by its R value. 
This will also have to be fixed in 13_2_X. 

In addition, it seems the parameter `fix_lt_sorting` was not set, which is needed in 14_1_X, but not 13_2_X.

@stahlleiton 
