### PR TITLE
Add flow jets to new configuration style

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -162,69 +162,39 @@ doWTARecluster = True        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
-jetLabel = "0"
+# Add all the values you want to process to the list
+# These will create collections of CS subtracted jets (only eta dependent background)
+jetLabelsCS = ["4"]
 
-# add candidate tagging, copy/paste to add other jet radii
+# For this list, give the R-values for flow subtracted CS jets (eta and phi dependent background)
+jetLabelsFlowCS = ["4"]
+
+# Combine the two lists such that all selected jets can be easily looped over
+# Also add "Flow" tag for the flow jets to distinguish them from non-flow jets
+allJetLabels = jetLabelsCS + [flowR + "Flow" for flowR in jetLabelsFlowCS]
+
+# add candidate tagging
 from HeavyIonsAnalysis.JetAnalysis.setupJets_PbPb_cff import candidateBtaggingMiniAOD
-candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L2L3Residual'], doBtagging = doBtagging, labelR = jetLabel)
 
-# setup jet analyzer
-setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
-if doBtagging:
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag")
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
-process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
+for jetLabel in allJetLabels:
+    candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L2L3Residual'], doBtagging = doBtagging, labelR = jetLabel)
 
-
-# Options for reclustering jets with different parameters. 
-# TODO:  Integrate with deepNtupleSettings script above -Matt
-addR3FlowJets = False
-addR4FlowJets = False
-addUnsubtractedR4Jets = False
-
-
-
-if addR3FlowJets or addR4FlowJets or addUnsubtractedR4Jets :
-    process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
-    from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-
-    if addR3FlowJets :
-        process.jetsR3flow = cms.Sequence()
-        setupHeavyIonJets('akCs3PFFlow', process.jetsR3flow, process, isMC = 0, radius = 0.30, JECTag = 'AK3PF', doFlow = True)
-        process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = "akCs3PFFlowpatJets", jetName = 'akCs3PFFlow', doHiJetID = doHIJetID, doWTARecluster = doWTARecluster)
-        process.forest += process.extraFlowJets * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
-
-
-    if addR4FlowJets :
-        process.jetsR4flow = cms.Sequence()
-        setupHeavyIonJets('akCs4PFFlow', process.jetsR4flow, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = True)
-        process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.akFlowPuCs4PFJetAnalyzer.jetTag = 'akCs4PFFlowpatJets'
-        process.akFlowPuCs4PFJetAnalyzer.jetName = 'akCs4PFFlow'
-        process.akFlowPuCs4PFJetAnalyzer.doHiJetID = doHIJetID
-        process.akFlowPuCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraFlowJets * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer
-
-    if addUnsubtractedR4Jets:
-        process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
-        from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupPprefJets
-        process.unsubtractedJetR4 = cms.Sequence()
-        setupPprefJets('ak04PF', process.unsubtractedJetR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
-        process.ak04PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
-        process.ak4PFJetAnalyzer.jetTag = "ak04PFpatJets"
-        process.ak4PFJetAnalyzer.jetName = "ak04PF"
-        process.forest += process.unsubtractedJetR4 * process.ak4PFJetAnalyzer
-
+    # setup jet analyzer
+    setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doBtagging = doBtagging
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=="0" else float(jetLabel.replace("Flow",""))*0.1
+    if doBtagging:
+        getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag")
+        getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
+    process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
 
 #########################

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -145,62 +145,41 @@ doWTARecluster = False        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
-jetLabel = "0"
+# Add all the values you want to process to the list
+# These will create collections of CS subtracted jets (only eta dependent background)
+jetLabelsCS = ["4"]
+
+# For this list, give the R-values for flow subtracted CS jets (eta and phi dependent background)
+jetLabelsFlowCS = ["4"]
+
+# Combine the two lists such that all selected jets can be easily looped over
+# Also add "Flow" tag for the flow jets to distinguish them from non-flow jets
+allJetLabels = jetLabelsCS + [flowR + "Flow" for flowR in jetLabelsFlowCS]
 
 # add candidate tagging, copy/paste to add other jet radii
 from HeavyIonsAnalysis.JetAnalysis.setupJets_PbPb_cff import candidateBtaggingMiniAOD
-candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
 
-# setup jet analyzer
-setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag =  "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
-getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFUnsubJetFlavourInfos"
-if jetLabel!="0": getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
-if doBtagging:
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag") 
-    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
-process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
+for jetLabel in allJetLabels:
+    candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
 
-# Options for reclustering jets with different parameters.                                                                                                                                                                                                                               
-# TODO:  Integrate with CS flow jets with deepNtupleSettings script above -Matt   
-addR3FlowJets = False
-addR4FlowJets = False
-
-
-if addR3FlowJets or addR4FlowJets :
-    process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
-    from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
-
-    if addR3FlowJets :
-        process.jetsR3flow = cms.Sequence()
-        jetName = 'akCs3PFFlow'
-        setupHeavyIonJets(jetName, process.jetsR3flow, process, isMC = 1, radius = 0.30, JECTag = 'AK3PF', doFlow = True, matchJets = matchJets)
-        process.akCs3PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akFlowPuCs3PFJetAnalyzer = process.akCs4PFJetAnalyzer.clone(jetTag = jetName + "patJets", jetName = jetName, genjetTag = "ak3GenJetsNoNu", matchJets = matchJets, matchTag = "ak3PFMatchingFor" + jetName + "patJets", doHiJetID = doHIJetID, doWTARecluster = doWTARecluster)
-        process.forest += process.extraFlowJets * process.jetsR3flow * process.akFlowPuCs3PFJetAnalyzer
-
-
-    if addR4FlowJets :
-        process.jetsR4flow = cms.Sequence()
-        jetName = 'akCs4PFFlow'
-        setupHeavyIonJets(jetName, process.jetsR4flow, process, isMC = 1, radius = 0.40, JECTag = 'AK4PF', doFlow = True, matchJets = matchJets)
-        process.akCs4PFFlowpatJetCorrFactors.levels = ['L2Relative', 'L3Absolute']
-        process.akFlowPuCs4PFJetAnalyzer.jetTag = jetName + 'patJets'
-        process.akFlowPuCs4PFJetAnalyzer.jetName = jetName
-        process.akFlowPuCs4PFJetAnalyzer.matchJets = matchJets
-        process.akFlowPuCs4PFJetAnalyzer.matchTag = 'ak4PFMatchingFor' + jetName + 'patJets'
-        process.akFlowPuCs4PFJetAnalyzer.doHiJetID = doHIJetID
-        process.akFlowPuCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
-        process.forest += process.extraFlowJets * process.jetsR4flow * process.akFlowPuCs4PFJetAnalyzer 
-
+    # setup jet analyzer
+    setattr(process,"akCs"+jetLabel+"PFJetAnalyzer",process.akCs4PFJetAnalyzer.clone())
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetTag =  "selectedUpdatedPatJetsAK"+jetLabel+"PFBtag"
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetName = 'akCs'+jetLabel+'PF'
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doBtagging = doBtagging
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=="0" else  float(jetLabel.replace("Flow",""))*0.1
+    getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFUnsubJetFlavourInfos"
+    if jetLabel!="0": getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
+    if doBtagging:
+        getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag") 
+        getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
+    process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
 
 #########################

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
@@ -156,39 +156,40 @@ process.primaryVertexFilter = cms.EDFilter("VertexSelector",
 )
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
 
-
 #####################################################################################
-# Select the types of jets filled                                                                                                                                                           
-                                                                            
-matchJets = True             # Enables q/g and heavy flavor jet identification in MC                                                                        
+# Select the types of jets filled
+matchJets = True             # Enables q/g and heavy flavor jet identification in MC 
 jetPtMin = 15
 jetAbsEtaMax = 2.5
 
-# Choose which additional information is added to jet trees                                                                                                                                        
-doHIJetID = True             # Fill jet ID and composition information branches                                                                                                                    
-doWTARecluster = False        # Add jet phi and eta for WTA axis                                                                                                                                   
-doBtagging  =  False         # Note that setting to True increases computing time a lot                                                                                                             
+# Choose which additional information is added to jet trees
+doHIJetID = True             # Fill jet ID and composition information branches
+doWTARecluster = False        # Add jet phi and eta for WTA axis
+doBtagging  =  False         # Note that setting to True increases computing time a lot
 
-# 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8                                                                                                                           
-jetLabel = "0"
+# 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
+# Add all the values you want to process to the list
+jetLabels = ["0"]
 
-# add candidate tagging, copy/paste to add other jet radii                                                                                                                                         
-                                                                         
+# add candidate tagging for all selected jet radii
 from HeavyIonsAnalysis.JetAnalysis.setupJets_ppRef_cff import candidateBtaggingMiniAOD
-candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
-# setup jet analyzer                                                   
-                                                                      
-setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
-if doBtagging:
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
-process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")
+
+for jetLabel in jetLabels:
+    candidateBtaggingMiniAOD(process, isMC = False, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
+
+    # setup jet analyzer
+    setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doBtagging = doBtagging
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=='0' else float(jetLabel)*0.1
+    if doBtagging:
+        getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
+        getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
+    process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
@@ -132,39 +132,41 @@ process.forest = cms.Path(
 )
 
 #####################################################################################
-# Select the types of jets filled                                                                                                                                                           
-                                                                            
-matchJets = True             # Enables q/g and heavy flavor jet identification in MC                                                                        
+# Select the types of jets filled 
+matchJets = True             # Enables q/g and heavy flavor jet identification in MC
 jetPtMin = 15
 jetAbsEtaMax = 2.5
 
-# Choose which additional information is added to jet trees                                                                                                                                        
-doHIJetID = True             # Fill jet ID and composition information branches                                                                                                                    
-doWTARecluster = False        # Add jet phi and eta for WTA axis                                                                                                                                   
-doBtagging  =  False         # Note that setting to True increases computing time a lot                                                                                                             
+# Choose which additional information is added to jet trees
+doHIJetID = True             # Fill jet ID and composition information branches
+doWTARecluster = False        # Add jet phi and eta for WTA axis
+doBtagging  =  False         # Note that setting to True increases computing time a lot
 
-# 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8                                                                                                                           
-jetLabel = "0"
+# 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
+# Add all the values you want to process to the list
+jetLabels = ["0"]
 
-# add candidate tagging, copy/paste to add other jet radii                                                                                                                                         
-                                                                         
+# add candidate tagging for all selected jet radii
 from HeavyIonsAnalysis.JetAnalysis.setupJets_ppRef_cff import candidateBtaggingMiniAOD
-candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
-# setup jet analyzer                                                   
-                                                                      
-setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = int(jetLabel)*0.1
-getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFFlavourInfos"
-if jetLabel!="0": getattr(process,"ak"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
-if doBtagging:
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
-    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
-process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")
+
+for jetLabel in jetLabels:
+    candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = jetPtMin, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = doBtagging, labelR = jetLabel)
+
+    # setup jet analyzer
+    setattr(process,"ak"+jetLabel+"PFJetAnalyzer",process.ak4PFJetAnalyzer.clone())
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetTag = "selectedUpdatedPatJetsAK"+jetLabel+"PFCHSBtag"
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetName = 'ak'+jetLabel+'PF'
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchJets = matchJets
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").matchTag = 'patJetsAK'+jetLabel+'PFUnsubJets'
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doBtagging = doBtagging
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doHiJetID = doHIJetID
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").doWTARecluster = doWTARecluster
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetPtMin = jetPtMin
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=="0" else float(jetLabel)*0.1
+    getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFFlavourInfos"
+    if jetLabel!="0": getattr(process,"ak"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
+    if doBtagging:
+        getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
+        getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")
+    process.forest += getattr(process,"ak"+jetLabel+"PFJetAnalyzer")

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = False, labelR = "0"):
     # DeepNtuple settings
-    jetR = 0.1*int(labelR)
+    jetR = 0.1*float(labelR)
     if labelR == "0": jetR = 0.4
 
     jetCorrectionsAK4 = ('AK4PFchs' if labelR == "0" else 'AK'+labelR+'PFchs', jetCorrLevels, 'None')
@@ -72,7 +72,11 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
                     src = 'packedGenParticlesForJetsNoNu'
                 )
         )
-        process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, getattr(process,"ak"+labelR+"GenJetsWithNu"), process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsRecluster"))
+         # We need to be careful not to override the previous genTask in case several different jet radii are defined in the forest configuration file
+        if hasattr(process, "genTask"):
+            process.genTask.add(getattr(process,"ak"+labelR+"GenJetsWithNu"),  getattr(process,"ak"+labelR+"GenJetsRecluster"))
+        else:
+            process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, getattr(process,"ak"+labelR+"GenJetsWithNu"), process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsRecluster"))
 
 
     # Create unsubtracted reco jets


### PR DESCRIPTION
#### PR description:

Following updates are done in this PR:

- Flow subtracted CS jets have been added to use the recently added candidateBtaggingMiniAOD method
- For both PbPb and pp configuration, add jet-R loop in forest configurations to easily define several different R values in single configuration
- Remove unsubtracted jets from the PbPb configuration

#### PR validation:

I have tested locally the configurations

forest_miniAOD_run3_DATA.py
forest_miniAOD_run3_MC.py
forest_miniAOD_run3_ppref_DATA.py
forest_miniAOD_run3_ppref_MC.py

and they seem to run without issues.
