### PR TITLE
Switch gen jet collection to be those with no neutrinos.

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
@@ -4,7 +4,7 @@ from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
 
 ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     jetTag = cms.InputTag("slimmedJets"),
-    genjetTag = 'slimmedGenJets',
+    genjetTag = 'ak4GenJetsNoNu',
     rParam = 0.4,
 #    trackTag = cms.InputTag("generalTracks"),
     fillGenJets = True,


### PR DESCRIPTION
#### PR description:
This PR switches the gen jet collection to be that which does not include neutrinos. This is to correct a mismatch between ref and gen jets, leading to incorrect determination of `genmatchindex`. This will be corrected centrally by https://github.com/cms-sw/cmssw/pull/47210, but this serves as a temporary fix for the forest. 

#### PR validation:

This PR was validated by performing a small test, which removes the observed precision issues as seen in the screenshot below. 
![Screenshot 2025-01-30 at 10 55 28](https://github.com/user-attachments/assets/eff6fcb9-4e7e-4c8a-80d1-ad532e05b79c)


#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

This PR does not need a backport. 