### PR TITLE
[Forest 14_1_X]: Switch gen jet collection to be those with no neutrinos.

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
@@ -4,7 +4,7 @@ from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
 
 ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     jetTag = cms.InputTag("slimmedJets"),
-    genjetTag = 'slimmedGenJets',
+    genjetTag = 'ak4GenJetsNoNu',
     rParam = 0.4,
     fillGenJets = True,
     isMC = True,


### PR DESCRIPTION
This PR is the 14_1_X equivalent of a similar PR for the forest 13_2_X (https://github.com/CmsHI/cmssw/pull/423). 

This will again be corrected in central CMSSW by a PR by @mandrenguyen here: https://github.com/cms-sw/cmssw/pull/47210

Tagging also @jusaviin . 