### PR TITLE
Remove neutrinos from reclustered jet collections in 14_1_X

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -145,6 +145,8 @@ doWTARecluster = False        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
+# Generator level jets in original miniAOD jets contain neutrinos
+# You will need to do reclustering with R-value to get generator level jets without neutrinos
 # Add all the values you want to process to the list
 # These will create collections of CS subtracted jets (only eta dependent background)
 jetLabelsCS = ["4"]
@@ -175,7 +177,7 @@ for jetLabel in allJetLabels:
     getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
     getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=="0" else  float(jetLabel.replace("Flow",""))*0.1
     getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFUnsubJetFlavourInfos"
-    if jetLabel!="0": getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
+    if jetLabel != "0": getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsReclusterNoNu"
     if doBtagging:
         getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFBtag") 
         getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_MC.py
@@ -143,8 +143,10 @@ doWTARecluster = False        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
+# Generator level jets in original miniAOD jets contain neutrinos
+# You will need to do reclustering with R-value to get generator level jets without neutrinos
 # Add all the values you want to process to the list
-jetLabels = ["0"]
+jetLabels = ["4"]
 
 # add candidate tagging for all selected jet radii
 from HeavyIonsAnalysis.JetAnalysis.setupJets_ppRef_cff import candidateBtaggingMiniAOD
@@ -165,7 +167,7 @@ for jetLabel in jetLabels:
     getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetAbsEtaMax = cms.untracked.double(jetAbsEtaMax)
     getattr(process,"ak"+jetLabel+"PFJetAnalyzer").rParam = 0.4 if jetLabel=="0" else float(jetLabel)*0.1
     getattr(process,"ak"+jetLabel+"PFJetAnalyzer").jetFlavourInfos = "ak"+jetLabel+"PFFlavourInfos"
-    if jetLabel!="0": getattr(process,"ak"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsWithNu"
+    if jetLabel != "0": getattr(process,"ak"+jetLabel+"PFJetAnalyzer").genjetTag = "ak"+jetLabel+"GenJetsReclusterNoNu"
     if doBtagging:
         getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfJetProbabilityBJetTag = cms.untracked.string("pfJetProbabilityBJetTagsAK"+jetLabel+"PFCHSBtag")
         getattr(process,"ak"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFCHSBtag")

--- a/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/ak4PFJetSequence_ppref_mc_cff.py
@@ -4,7 +4,7 @@ from HeavyIonsAnalysis.JetAnalysis.inclusiveJetAnalyzer_cff import *
 
 ak4PFJetAnalyzer = inclusiveJetAnalyzer.clone(
     jetTag = cms.InputTag("slimmedJets"),
-    genjetTag = 'ak4GenJetsNoNu',
+    genjetTag = 'slimmedGenJets',
     rParam = 0.4,
     fillGenJets = True,
     isMC = True,

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
@@ -128,8 +128,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
 
     matchedGenJets = ""
     if isMC:
-        # Use reclustered jets without neutrinos for matching. slimmedGenJets can be used after the fix in miniAOD step is propagated here for labelR = 0.
-        matchedGenJets  = "ak"+labelR+"GenJetsReclusterNoNu"
+        if labelR == "0": matchedGenJets = "slimmedGenJets"
+        else: matchedGenJets  = "ak"+labelR+"GenJetsReclusterNoNu"
 
 
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
@@ -62,18 +62,15 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
         process.allPartons = allPartons.clone(
             src = 'hiSignalGenParticles'
         )
+
+        # Reclusted generator level jets without neutrinos
         from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-        setattr(process,"ak"+labelR+"GenJetsWithNu",
-                ak4GenJets.clone(
-                    src = 'packedGenParticlesSignal',
-                    rParam = jetR
-                )
-        )
         process.packedGenParticlesForJetsNoNu = cms.EDFilter("CandPtrSelector",
             src = cms.InputTag("packedGenParticlesSignal"),
             cut = cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
         )
-        setattr(process,"ak"+labelR+"GenJetsRecluster",
+
+        setattr(process,"ak"+labelR+"GenJetsReclusterNoNu",
                 ak4GenJets.clone(
                     src = 'packedGenParticlesForJetsNoNu'
                 )
@@ -81,9 +78,9 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
  
         # We need to be careful not to override the previous genTask in case several different jet radii are defined in the forest configuration file
         if hasattr(process, "genTask"):
-            process.genTask.add(getattr(process,"ak"+labelR+"GenJetsWithNu"),  getattr(process,"ak"+labelR+"GenJetsRecluster")) 
+            process.genTask.add(getattr(process,"ak"+labelR+"GenJetsReclusterNoNu")) 
         else:
-            process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, getattr(process,"ak"+labelR+"GenJetsWithNu"), process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsRecluster"))
+            process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsReclusterNoNu"))
 
     # Remake secondary vertices
     from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import inclusiveCandidateVertexFinder, candidateVertexMerger, candidateVertexArbitrator, inclusiveCandidateSecondaryVertices
@@ -131,8 +128,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
 
     matchedGenJets = ""
     if isMC:
-        if labelR == "0": matchedGenJets = "slimmedGenJets"
-        else: matchedGenJets  = "ak"+labelR+"GenJetsWithNu"
+        # Use reclustered jets without neutrinos for matching. slimmedGenJets can be used after the fix in miniAOD step is propagated here for labelR = 0.
+        matchedGenJets  = "ak"+labelR+"GenJetsReclusterNoNu"
 
 
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
@@ -107,8 +107,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
 
     matchedGenJets = ""
     if isMC:
-        # Use reclustered jets without neutrinos for matching. slimmedGenJets can be used after the fix in miniAOD step is propagated here for labelR = 0.ZZ
-        matchedGenJets = "ak"+labelR+"GenJetsReclusterNoNu"
+        if labelR == "0": matchedGenJets = "slimmedGenJets"
+        else: matchedGenJets = "ak"+labelR+"GenJetsReclusterNoNu"
 
 
     svSource = cms.InputTag("slimmedSecondaryVertices")

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_ppRef_cff.py
@@ -56,27 +56,26 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
         process.allPartons = allPartons.clone(
             src = 'hiSignalGenParticles'
         )
+
+        # Define generator level jets without neutrinos
         from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-        setattr(process,"ak"+labelR+"GenJetsWithNu",
-                ak4GenJets.clone(
-                    src = 'packedGenParticles',
-                    rParam = jetR
-                )
-        )
+
         process.packedGenParticlesForJetsNoNu = cms.EDFilter("CandPtrSelector",
             src = cms.InputTag("packedGenParticles"),
             cut = cms.string("abs(pdgId) != 12 && abs(pdgId) != 14 && abs(pdgId) != 16")
         )
-        setattr(process,"ak"+labelR+"GenJetsRecluster",
+
+        setattr(process,"ak"+labelR+"GenJetsReclusterNoNu",
                 ak4GenJets.clone(
-                    src = 'packedGenParticlesForJetsNoNu'
+                    src = 'packedGenParticlesForJetsNoNu',
+                    rParam = jetR
                 )
         )
          # We need to be careful not to override the previous genTask in case several different jet radii are defined in the forest configuration file
         if hasattr(process, "genTask"):
-            process.genTask.add(getattr(process,"ak"+labelR+"GenJetsWithNu"),  getattr(process,"ak"+labelR+"GenJetsRecluster"))
+            process.genTask.add( getattr(process,"ak"+labelR+"GenJetsReclusterNoNu"))
         else:
-            process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, getattr(process,"ak"+labelR+"GenJetsWithNu"), process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsRecluster"))
+            process.genTask = cms.Task(process.hiSignalGenParticles, process.allPartons, process.packedGenParticlesForJetsNoNu, getattr(process,"ak"+labelR+"GenJetsReclusterNoNu"))
 
 
     # Create unsubtracted reco jets
@@ -108,8 +107,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
 
     matchedGenJets = ""
     if isMC:
-        if labelR == "0": matchedGenJets = "slimmedGenJets"
-        else: matchedGenJets  = "ak"+labelR+"GenJetsWithNu"
+        # Use reclustered jets without neutrinos for matching. slimmedGenJets can be used after the fix in miniAOD step is propagated here for labelR = 0.ZZ
+        matchedGenJets = "ak"+labelR+"GenJetsReclusterNoNu"
 
 
     svSource = cms.InputTag("slimmedSecondaryVertices")


### PR DESCRIPTION
#### PR description:

The recent pull request #423 by @hjbossi removed neutrinos from generator level jets in forest 13_2_X, which still uses legacy miniAOD jet clustering using the methods in clusterJetsFromMiniAOD_cff.py script. The jet clustering has been updated for 14_1_X, so the same fix as in 13_2_X does not work anymore in 14_1_X. Thus, the pull request #424 does not actually remove neutrinos from jets. This is now fixed in this pull request. The neutrinos are removed from all the reclustered jets, and the generator level jet collections with neutrinos included have been removed from the clustering sequence. It is also explicitly commented in the forest configuration files that without reclustering, the jets directly read from miniAOD:s currently contain neutrinos in their generator level jets.

@mandrenguyen @stahlleiton 

#### PR validation:

Tested locally the following configurations and confirm that refpt and genpt quantities match:

forest_miniAOD_run3_MC.py
forest_miniAOD_run3_ppref_MC.py
