### PR TITLE
Added dEdx to Track ntuple in HiForest

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
@@ -3,14 +3,14 @@
 # Type: data
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_2024_UPC_cff import Run3_2024_UPC
-process = cms.Process('HiForest', Run3_2024_UPC)
+from Configuration.Eras.Era_Run3_2025_OXY_cff import Run3_2025_OXY
+process = cms.Process('HiForest', Run3_2025_OXY)
 
 ###############################################################################
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 141X, data")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 150X, data")
 
 # import subprocess, os
 # version = subprocess.check_output(
@@ -25,7 +25,7 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 141X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://xrootd-cms.infn.it//store/hidata/HIRun2023A/HIPhysicsRawPrime25/MINIAOD/PromptReco-v2/000/375/259/00000/842ae3e0-1bfa-46d9-92d6-a3e8566638d8.root'
+        'root://xrootd-cms.infn.it//store/hidata/HIRun2024A/HIForward0/MINIAOD/PromptReco-v1/000/387/878/00000/b7894635-d50c-454f-a11b-f072514f8dfc.root'
     ), 
 )
 
@@ -45,7 +45,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 
 from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, '141X_dataRun3_Prompt_v3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '150X_dataRun3_Prompt_v1', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 
 ## --> only use this starting from 388000
@@ -62,15 +62,6 @@ process.es_ascii = cms.ESSource('HcalTextCalibrations',
       ),
    )
 )
-## <--
-###############################################################################
-
-# No centrality binning for UPC
-## Define centrality binning
-#process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
-#process.centralityBin.Centrality = cms.InputTag("hiCentrality")
-#process.centralityBin.centralityVariable = cms.string("HFtowers")
-
 ###############################################################################
 
 # root output
@@ -104,6 +95,7 @@ process.hiEvtAnalyzer.doHFfilters = cms.bool(False)
 # FIXME: Do we have an updated trigger list?
 #from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_data_2023_skimmed
 #process.hltobject.triggerNames = trigger_list_data_2023_skimmed
+process.hltobject.triggerNames = cms.vstring()
 
 process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
 ################################
@@ -113,19 +105,15 @@ process.ggHiNtuplizer.doMuons = cms.bool(False)
 process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
 ################################
 # jet reco sequence
-process.load(
-    'HeavyIonsAnalysis.JetAnalysis.ak2PFJetSequence_ppref_data_cff')
-process.load(
-    'HeavyIonsAnalysis.JetAnalysis.ak3PFJetSequence_ppref_data_cff')
-process.load(
-    'HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
-process.load('HeavyIonsAnalysis.JetAnalysis.ak4CaloJetSequence_pp_data_cff')
+process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
+process.ppTracks.dedxEstimators = cms.VInputTag(["dedxEstimator:dedxAllLikelihood", "dedxEstimator:dedxHarmonic2"])
 # muons (FTW)
 process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
 process.load("HeavyIonsAnalysis.MuonAnalysis.muonAnalyzer_cfi")
+process.unpackedMuons.muonSelectors = cms.vstring()
 ###############################################################################
 
 #########################
@@ -145,13 +133,11 @@ process.forest = cms.Path(
     process.hltobject +
     process.l1object +
     process.trackSequencePP +
-    process.ak4CaloJetAnalyzer +
     process.particleFlowAnalyser +
     process.ggHiNtuplizer +
     process.zdcSequencePbPb +
     process.unpackedMuons +
-    process.muonAnalyzer +
-    #process.akPu4CaloJetAnalyzer
+    process.muonAnalyzer
     )
 
 #customisation
@@ -159,9 +145,9 @@ process.forest = cms.Path(
 # Select the types of jets filled
 addR3Jets = False
 addR3FlowJets = False
-addR4Jets = True
-addR4FlowJets = True
-addUnsubtractedR4Jets = True
+addR4Jets = False
+addR4FlowJets = False
+addUnsubtractedR4Jets = False
 
 # Choose which additional information is added to jet trees
 doHIJetID = True             # Fill jet ID and composition information branches
@@ -253,7 +239,6 @@ if addCandidateTagging:
 process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
 process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
-process.load('HeavyIonsAnalysis.EventAnalysis.hffilter_cfi')
 process.load('HeavyIonsAnalysis.EventAnalysis.hffilterPF_cfi')
 process.pAna = cms.EndPath(process.skimanalysis)
 

--- a/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
+++ b/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/TrackReco/interface/DeDxData.h"
 
 // Root include files
 #include "TTree.h"
@@ -41,6 +42,7 @@ private:
   const edm::EDGetTokenT<reco::TrackCollection> trackSrc_;
   const edm::EDGetTokenT<std::vector<edm::Ptr<pat::PackedCandidate> > > track2pcSrc_;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotProducer_;
+  std::map<std::string, edm::EDGetTokenT<edm::ValueMap<reco::DeDxData>>> dedxEstimatorsSrc_;
 
   edm::Service<TFileService> fs;
 
@@ -97,6 +99,7 @@ private:
   std::vector<float> trkDzErrFirstVtx;
   std::vector<float> trkDxyFirstVtx;
   std::vector<float> trkDxyErrFirstVtx;
+  std::map<std::string, std::vector<float>> trkDeDx;
 };
 
 inline void TrackAnalyzer::clearVectors() {
@@ -142,6 +145,8 @@ inline void TrackAnalyzer::clearVectors() {
   trkDzErrFirstVtx.clear();
   trkDxyFirstVtx.clear();
   trkDxyErrFirstVtx.clear();
+  for (auto& d : trkDeDx)
+    d.second.clear();
 }
 
 #endif

--- a/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
@@ -5,5 +5,6 @@ trackAnalyzer = cms.EDAnalyzer('TrackAnalyzer',
     trackPtMin = cms.untracked.double(0.01),
     vertexSrc = cms.InputTag("unpackedTracksAndVertices"),
     trackSrc = cms.InputTag("unpackedTracksAndVertices"),
-    beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot')
+    beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot'),
+    dedxEstimators = cms.VInputTag(),
 )

--- a/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
@@ -8,6 +8,8 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) :
   track2pcSrc_(consumes<std::vector<edm::Ptr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("trackSrc"))),
   beamSpotProducer_(consumes<reco::BeamSpot>(
       iConfig.getUntrackedParameter<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot")))) {
+  for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("dedxEstimators"))
+    dedxEstimatorsSrc_.emplace(tag.instance(), consumes<edm::ValueMap<reco::DeDxData> >(tag));
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -70,6 +72,9 @@ void TrackAnalyzer::fillVertices(const edm::Event& iEvent) {
 void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const auto& tracks = iEvent.get(trackSrc_);
   const auto& track2pc = iEvent.getHandle(track2pcSrc_);
+  std::map<std::string, edm::ValueMap<reco::DeDxData> > dedxMaps;
+  for (const auto& d : dedxEstimatorsSrc_)
+    dedxMaps.emplace(d.first, iEvent.get(d.second));
 
   //loop over tracks
   for (unsigned it = 0; it < tracks.size(); ++it) {
@@ -129,6 +134,8 @@ void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& 
       trkDxyFirstVtx.push_back(-999999);
       trkDxyErrFirstVtx.push_back(-999999);
     }
+    for (auto& d : trkDeDx)
+      d.second.push_back(dedxMaps.at(d.first)[track2pc->at(it)].dEdx());
 
     nTrk++;
   }
@@ -186,6 +193,8 @@ void TrackAnalyzer::beginJob() {
   trackTree_->Branch("trkDzErrFirstVtx", &trkDzErrFirstVtx);
   trackTree_->Branch("trkDxyFirstVtx", &trkDxyFirstVtx);
   trackTree_->Branch("trkDxyErrFirstVtx", &trkDxyErrFirstVtx);
+  for (const auto& d : dedxEstimatorsSrc_)
+    trackTree_->Branch(d.first.c_str(), &(trkDeDx[d.first]));
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
@@ -8,8 +8,10 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) :
   track2pcSrc_(consumes<std::vector<edm::Ptr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("trackSrc"))),
   beamSpotProducer_(consumes<reco::BeamSpot>(
       iConfig.getUntrackedParameter<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot")))) {
-  for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("dedxEstimators"))
-    dedxEstimatorsSrc_.emplace(tag.instance(), consumes<edm::ValueMap<reco::DeDxData> >(tag));
+  for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("dedxEstimators")) {
+    const auto label = tag.instance()!="" ? tag.instance() : tag.label();
+    dedxEstimatorsSrc_.emplace(label, consumes<edm::ValueMap<reco::DeDxData> >(tag));
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -70,16 +72,17 @@ void TrackAnalyzer::fillVertices(const edm::Event& iEvent) {
 
 //--------------------------------------------------------------------------------------------------
 void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const auto& tracks = iEvent.get(trackSrc_);
+  const auto& tracks = iEvent.getHandle(trackSrc_);
   const auto& track2pc = iEvent.getHandle(track2pcSrc_);
   std::map<std::string, edm::ValueMap<reco::DeDxData> > dedxMaps;
   for (const auto& d : dedxEstimatorsSrc_)
     dedxMaps.emplace(d.first, iEvent.get(d.second));
 
   //loop over tracks
-  for (unsigned it = 0; it < tracks.size(); ++it) {
-    const auto& t = tracks[it];
-    const auto& c = track2pc.isValid() ? *track2pc->at(it) : pat::PackedCandidate();
+  for (unsigned it = 0; it < tracks->size(); ++it) {
+    const auto& t = tracks->at(it);
+    const auto& k = track2pc.isValid() ? track2pc->at(it) : edm::Ptr<pat::PackedCandidate>();
+    const auto& c = k.isNonnull() ? *k : pat::PackedCandidate();
 
     if (t.pt() < trackPtMin_)
       continue;
@@ -134,8 +137,14 @@ void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& 
       trkDxyFirstVtx.push_back(-999999);
       trkDxyErrFirstVtx.push_back(-999999);
     }
-    for (auto& d : trkDeDx)
-      d.second.push_back(dedxMaps.at(d.first)[track2pc->at(it)].dEdx());
+    for (auto& d : trkDeDx) {
+      double dEdx(-99.9);
+      if (track2pc.isValid() && dedxMaps.at(d.first).contains(k.id()))
+        dEdx = dedxMaps.at(d.first)[k].dEdx();
+      else if (dedxMaps.at(d.first).contains(tracks.id()))
+        dEdx = dedxMaps.at(d.first)[reco::TrackRef(tracks, it)].dEdx();
+      d.second.push_back(dEdx);
+    }
 
     nTrk++;
   }


### PR DESCRIPTION
#### PR description:

Add the option to store the energy loss dEdx in the track ntuple of the HiForest.

#### PR validation:

Tested locally that the dEdx branches are created and contain values when reading from MiniAOD files that contain the dEdx value maps (e.g. UPC related eras)