### PR TITLE
Add forest config and hardcoded ZDC option for Feb2025 Rereco of 2023 PbPb in 14_1_X 

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_23rereco_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_23rereco_DATA.py
@@ -1,0 +1,227 @@
+### HiForest Configuration
+# Input: miniAOD
+# Type: data
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.Eras.Era_Run3_2023_UPC_cff import Run3_2023_UPC
+process = cms.Process('HiForest', Run3_2023_UPC)
+
+###############################################################################
+
+# HiForest info
+process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 141X, data")
+
+# import subprocess, os
+# version = subprocess.check_output(
+#     ['git', '-C', os.path.expandvars('$CMSSW_BASE/src'), 'describe', '--tags'])
+# if version == '':
+#     version = 'no git info'
+# process.HiForestInfo.HiForestVersion = cms.string(version)
+
+###############################################################################
+
+# input files
+process.source = cms.Source("PoolSource",
+    duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
+    fileNames = cms.untracked.vstring(
+        '/store/hidata/HIRun2023A/HIForward0/MINIAOD/14Feb2025-v1/2530000/bc64b56f-9175-43e4-94b0-7a075787bf65.root'
+    ), 
+)
+
+# number of events to process, set to -1 to process all events
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(20)
+    )
+
+###############################################################################
+
+# load Global Tag, geometry, etc.
+process.load('Configuration.Geometry.GeometryDB_cff')
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, '141X_dataRun3_v6', '')
+process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
+
+###############################################################################
+
+# No centrality binning for UPC
+## Define centrality binning
+#process.load("RecoHI.HiCentralityAlgos.CentralityBin_cfi")
+#process.centralityBin.Centrality = cms.InputTag("hiCentrality")
+#process.centralityBin.centralityVariable = cms.string("HFtowers")
+
+###############################################################################
+
+# root output
+process.TFileService = cms.Service("TFileService",
+    fileName = cms.string("HiForestMiniAOD.root"))
+
+# # edm output for debugging purposes
+# process.output = cms.OutputModule(
+#     "PoolOutputModule",
+#     fileName = cms.untracked.string('HiForestEDM.root'),
+#     outputCommands = cms.untracked.vstring(
+#         'keep *',
+#         )
+#     )
+
+# process.output_path = cms.EndPath(process.output)
+
+###############################################################################
+
+# event analysis
+process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.skimanalysis_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.hltobject_cfi')
+process.load('HeavyIonsAnalysis.EventAnalysis.l1object_cfi')
+
+# No centrality binning for UPC
+process.hiEvtAnalyzer.doCentrality = cms.bool(False)
+process.hiEvtAnalyzer.doHFfilters = cms.bool(False)
+
+# FIXME: Do we have an updated trigger list?
+#from HeavyIonsAnalysis.EventAnalysis.hltobject_cfi import trigger_list_data_2023_skimmed
+#process.hltobject.triggerNames = trigger_list_data_2023_skimmed
+
+process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
+################################
+# electrons, photons, muons
+process.load('HeavyIonsAnalysis.EGMAnalysis.ggHiNtuplizer_cfi')
+process.ggHiNtuplizer.doMuons = cms.bool(False)
+process.load("TrackingTools.TransientTrack.TransientTrackBuilder_cfi")
+################################
+# jet reco sequence
+process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
+# process.load('HeavyIonsAnalysis.JetAnalysis.ak4CaloJetSequence_pp_data_cff')
+################################
+# tracks
+process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
+# muons (FTW)
+process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
+process.load("HeavyIonsAnalysis.MuonAnalysis.muonAnalyzer_cfi")
+###############################################################################
+
+#########################
+# ZDC RecHit Producer && Analyzer
+#########################
+# to prevent crash related to HcalSeverityLevelComputerRcd record
+process.load("RecoLocalCalo.HcalRecAlgos.hcalRecAlgoESProd_cfi")
+process.load('HeavyIonsAnalysis.ZDCAnalysis.ZDCAnalyzersPbPb_cff')
+# 2023 only had hard coded calibration
+process.zdcanalyzer.doHardcodedChargeSum = cms.bool(True)
+
+###############################################################################
+# main forest sequence
+process.forest = cms.Path(
+    process.HiForestInfo +
+    process.hiEvtAnalyzer +
+    process.hltanalysis +
+    # process.hltobject + # Not working
+    process.l1object +
+    process.trackSequencePP +
+    # process.ak4CaloJetAnalyzer + # Not working
+    process.particleFlowAnalyser +
+    # process.ggHiNtuplizer + # Segmentation fault
+    process.zdcSequencePbPb #+
+    # process.unpackedMuons + # Not working
+    # process.muonAnalyzer # Not working
+    )
+
+#customisation
+
+# Select the types of jets filled
+addR4Jets = False # Not working
+addUnsubtractedR4Jets = False # Not working
+
+# Choose which additional information is added to jet trees
+doHIJetID = True             # Fill jet ID and composition information branches
+doWTARecluster = True        # Add jet phi and eta for WTA axis
+
+# this is only for non-reclustered jets
+addCandidateTagging = False
+
+
+if addR4Jets or addUnsubtractedR4Jets :
+    process.load("HeavyIonsAnalysis.JetAnalysis.extraJets_cff")
+    from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupHeavyIonJets
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+
+    if addR4Jets :
+        # Recluster using an alias "0" in order not to get mixed up with the default AK4 collections
+        process.jetsR4 = cms.Sequence()
+        setupHeavyIonJets('akCs0PF', process.jetsR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF', doFlow = False)
+        process.akCs0PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.akCs4PFJetAnalyzer.jetTag = 'akCs0PFpatJets'
+        process.akCs4PFJetAnalyzer.jetName = 'akCs0PF'
+        process.akCs4PFJetAnalyzer.doHiJetID = doHIJetID
+        process.akCs4PFJetAnalyzer.doWTARecluster = doWTARecluster
+        process.forest += process.extraJetsData * process.jetsR4 * process.akCs4PFJetAnalyzer
+
+    if addUnsubtractedR4Jets:
+        process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
+        from HeavyIonsAnalysis.JetAnalysis.clusterJetsFromMiniAOD_cff import setupPprefJets
+        process.unsubtractedJetR4 = cms.Sequence()
+        setupPprefJets('ak04PF', process.unsubtractedJetR4, process, isMC = 0, radius = 0.40, JECTag = 'AK4PF')
+        process.ak04PFpatJetCorrFactors.levels = ['L2Relative', 'L2L3Residual']
+        process.ak4PFJetAnalyzer.jetTag = "ak04PFpatJets"
+        process.ak4PFJetAnalyzer.jetName = "ak04PF"
+        process.forest += process.unsubtractedJetR4 * process.ak4PFJetAnalyzer
+
+
+if addCandidateTagging:
+    process.load("HeavyIonsAnalysis.JetAnalysis.candidateBtaggingMiniAOD_cff")
+
+    from PhysicsTools.PatAlgos.tools.jetTools import updateJetCollection
+    updateJetCollection(
+        process,
+        jetSource = cms.InputTag('slimmedJets'),
+        jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+        btagDiscriminators = ['pfCombinedSecondaryVertexV2BJetTags', 'pfDeepCSVDiscriminatorsJetTags:BvsAll', 'pfDeepCSVDiscriminatorsJetTags:CvsB', 'pfDeepCSVDiscriminatorsJetTags:CvsL'], ## to add discriminators,
+        btagPrefix = 'TEST',
+    )
+
+    process.updatedPatJets.addJetCorrFactors = False
+    process.updatedPatJets.discriminatorSources = cms.VInputTag(
+        cms.InputTag('pfDeepCSVJetTags:probb'),
+        cms.InputTag('pfDeepCSVJetTags:probc'),
+        cms.InputTag('pfDeepCSVJetTags:probudsg'),
+        cms.InputTag('pfDeepCSVJetTags:probbb'),
+    )
+
+    process.akCs4PFJetAnalyzer.jetTag = "updatedPatJets"
+
+    process.forest.insert(1,process.candidateBtagging*process.updatedPatJets)
+
+#########################
+# Event Selection -> add the needed filters here
+#########################
+
+process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
+process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
+process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
+process.load('HeavyIonsAnalysis.EventAnalysis.hffilterPF_cfi')
+process.pAna = cms.EndPath(process.skimanalysis)
+
+#from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+#process.hltfilter = hltHighLevel.clone(
+#    HLTPaths = [
+#        #"HLT_HIZeroBias_v4",                                                     
+#        "HLT_HIMinimumBias_v2",
+#    ]
+#)
+#process.filterSequence = cms.Sequence(
+#    process.hltfilter
+#)
+#
+#process.superFilterPath = cms.Path(process.filterSequence)
+#process.skimanalysis.superFilters = cms.vstring("superFilterPath")
+#
+#for path in process.paths:
+#    getattr(process, path)._seq = process.filterSequence * getattr(process,path)._seq
+

--- a/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzerHC_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/ZDCRecHitAnalyzerHC_cfi.py
@@ -10,6 +10,7 @@ zdcanalyzer = cms.EDAnalyzer(
    doAuxZdcRecHits = cms.bool(False),
    skipRpdRecHits = cms.bool(True), # True: only have ZDC 18 channels in rechit tree
    skipRpdDigis = cms.bool(False), # False: save ZDC 18 channels + RPD 32 channels in digi tree
+    doHardcodedChargeSum = cms.bool(False), # charge and energy reco was hardcoded for 2023 PbPb
    doHardcodedRPD = cms.bool(True) # Geometry updated for the RPD are not part of 14_1_X and the GT used for 2024. Always do hard coded RPD for 2024.
 )
 

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/ZDCRecHitAnalyzerHC.cc
@@ -78,6 +78,7 @@ private:
   bool doAuxZdcRecHits_;
   bool skipRpdRecHits_;
   bool skipRpdDigis_;
+  bool doHardcodedChargeSum_;
   bool doHardcodedRPD_;
   edm::Service<TFileService> fs;
   TTree *t1, *t2;   
@@ -111,6 +112,7 @@ ZDCRecHitAnalyzerHC::ZDCRecHitAnalyzerHC(const edm::ParameterSet& iConfig) :
   doAuxZdcRecHits_(iConfig.getParameter<bool>("doAuxZdcRecHits")),
   skipRpdRecHits_(iConfig.getParameter<bool>("skipRpdRecHits")),
   skipRpdDigis_(iConfig.getParameter<bool>("skipRpdDigis")),
+  doHardcodedChargeSum_(iConfig.getParameter<bool>("doHardcodedChargeSum")),
   doHardcodedRPD_(iConfig.getParameter<bool>("doHardcodedRPD"))
 {
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
@@ -254,7 +256,10 @@ void ZDCRecHitAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetu
 
   } // if (doAuxZdcRecHits_) {
 
-  if (t1) t1->Fill();
+  if (doHardcodedChargeSum_) {
+    zdcRechit.sumMinus = 0;
+    zdcRechit.sumPlus = 0;
+  }
   
   if (doZdcDigis_) {
     zdcDigi.n = 0;
@@ -268,7 +273,7 @@ void ZDCRecHitAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetu
         zdcDigi.tdc[ts][i] = -99;
       }
     }
-    
+
     int nhits = 0;
     for (auto it = zdcdigis->begin(); it != zdcdigis->end(); it++) {      
       const QIE10DataFrame digi = static_cast<const QIE10DataFrame>(*it);
@@ -301,10 +306,22 @@ void ZDCRecHitAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetu
       for (int ts = 0; ts < digi.samples(); ts++) {
         zdcDigi.adc[ts][nhits] = digi[ts].adc();
         zdcDigi.tdc[ts][nhits] = digi[ts].le_tdc();
-        if (doHardcodedRPD_ && section == 4) {
+        if ((doHardcodedRPD_ && section == 4) || doHardcodedChargeSum_) {
           zdcDigi.chargefC[ts][nhits] = HardCodeZDC.charge(digi[ts].adc(),digi[ts].capid());
         } else {
           zdcDigi.chargefC[ts][nhits] = caldigi[ts];
+        }
+      }
+
+      if (doHardcodedChargeSum_ && (section == 1 || section == 2)) {
+        float te = zdcDigi.chargefC[2][nhits] - zdcDigi.chargefC[1][nhits];
+        if (section == 1) { te *= 0.1; } // EM
+        if (zside < 0) {
+          te *= 0.5031;
+          zdcRechit.sumMinus += te;
+        } else {
+          te *= 0.9397;
+          zdcRechit.sumPlus += te;
         }
       }
       
@@ -315,7 +332,9 @@ void ZDCRecHitAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetu
 
     t2->Fill();
   } // if(doZdcDigis_)
-  
+
+  if (t1) t1->Fill();
+   
 
   // #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
   // // if the SetupData is always needed


### PR DESCRIPTION
#### PR description:

- Allow ZDC analyzer to use hard coded calibration for 2023 PbPb data
- Add a forest config to run on Feb2025 rereco of 2023 PbPb HIForward `forest_miniAOD_run3_UPC_23rereco_DATA.py`. Compared to `forest_miniAOD_run3_UPC_DATA.py` for 2024 PbPb
    - Use hardcoded ZDC calibration
    - Comment out the sequences that don't work
    - Change to corresponding Era and GT 
