### PR TITLE
Add 3 leading HF tower energy in HiEvtAnalyzer 

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -2,7 +2,7 @@
 // system include files
 #include <memory>
 #include <vector>
-
+#include <algorithm>
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
@@ -37,6 +37,7 @@
 //
 // class declaration
 //
+#define NHFLEAD 3
 
 class HiEvtAnalyzer : public edm::one::EDAnalyzer<> {
 public:
@@ -95,9 +96,10 @@ private:
   float hiEB, hiET, hiEE, hiEEplus, hiEEminus;
   float hiZDC, hiZDCplus, hiZDCminus;
 
-  float hiHF_pf, hiHFE_pf, hiHF_pfle, hiHF_pfha, hiHF_pfem;
-  float hiHFPlus_pf, hiHFEPlus_pf, hiHFPlus_pfle, hiHFPlus_pfha, hiHFPlus_pfem;
-  float hiHFMinus_pf, hiHFEMinus_pf, hiHFMinus_pfle, hiHFMinus_pfha, hiHFMinus_pfem;
+  float hiHF_pf, hiHFE_pf, hiHF_pfha, hiHF_pfem;
+  float hiHFPlus_pf, hiHFEPlus_pf, hiHFPlus_pfha, hiHFPlus_pfem;
+  float hiHFMinus_pf, hiHFEMinus_pf, hiHFMinus_pfha, hiHFMinus_pfem;
+  float hiHF_pfle[NHFLEAD], hiHFPlus_pfle[NHFLEAD], hiHFMinus_pfle[NHFLEAD];
   int nCountsHF_pf, nCountsHFPlus_pf, nCountsHFMinus_pf;
 
   float fNpart;
@@ -138,6 +140,16 @@ private:
   unsigned long long event;
   unsigned int run;
   unsigned int lumi;
+
+  void inspfle(float hfe, float pfle[NHFLEAD]) {
+    if (hfe <= pfle[NHFLEAD-1]) { return; }
+    auto* end = pfle + NHFLEAD;
+    auto* insert_pos = std::lower_bound(pfle, end, hfe, std::greater<float>{});
+    if (insert_pos != end) {
+        std::move_backward(insert_pos, end - 1, end);
+        *insert_pos = hfe;
+    }
+  }
 };
 
 //
@@ -317,45 +329,48 @@ void HiEvtAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     edm::Handle<pat::PackedCandidateCollection> pfCandidates;
     iEvent.getByToken(pfCandidateTag_, pfCandidates);
 
-    hiHF_pf=0; hiHFE_pf=0; hiHF_pfle =0; hiHF_pfha=0; hiHF_pfem=0;
-    hiHFPlus_pf=0; hiHFEPlus_pf=0; hiHFPlus_pfle =0; hiHFPlus_pfha=0; hiHFPlus_pfem=0;
-    hiHFMinus_pf=0; hiHFEMinus_pf=0; hiHFMinus_pfle =0; hiHFMinus_pfha=0; hiHFMinus_pfem=0;
+    hiHF_pf = 0; hiHFE_pf = 0; hiHF_pfha = 0; hiHF_pfem = 0;
+    for (auto& le : hiHF_pfle) le = 0;
+    hiHFPlus_pf = 0; hiHFEPlus_pf = 0; hiHFPlus_pfha = 0; hiHFPlus_pfem = 0;
+    for (auto& le : hiHFPlus_pfle) le = 0;
+    hiHFMinus_pf = 0; hiHFEMinus_pf = 0; hiHFMinus_pfha = 0; hiHFMinus_pfem = 0;
+    for (auto& le : hiHFMinus_pfle) le = 0;
     nCountsHF_pf = 0; nCountsHFPlus_pf = 0; nCountsHFMinus_pf = 0;
 
     for (const auto& pfcand : *pfCandidates) {
-      if (pfcand.pdgId() == 1 || pfcand.pdgId() == 2){
-        const bool eta_plus = (pfcand.eta() > 3.0) && (pfcand.eta() < 6.0);
-        const bool eta_minus = (pfcand.eta() < -3.0) && (pfcand.eta() > -6.0);
-        if (pfcand.et() < 0.0) continue;
-        if (eta_plus || eta_minus)
-        {   
-          hiHF_pf += pfcand.et();
-          hiHFE_pf += pfcand.energy();
-          if(pfcand.energy() >= hiHF_pfle) hiHF_pfle = pfcand.energy();
-          if(pfcand.pdgId() == 1) hiHF_pfha += pfcand.et();
-          if(pfcand.pdgId() == 2) hiHF_pfem += pfcand.et();
-          nCountsHF_pf++;
+      if (pfcand.pdgId() != 1 && pfcand.pdgId() != 2) continue;
+      if (pfcand.et() < 0.0) continue;
+      const bool eta_plus = (pfcand.eta() > 3.0) && (pfcand.eta() < 6.0);
+      const bool eta_minus = (pfcand.eta() < -3.0) && (pfcand.eta() > -6.0);
+      if (!eta_plus && !eta_minus) continue;
+      const auto hfe = pfcand.energy();
+      const auto hfet = pfcand.et();
+      const auto hfid = pfcand.pdgId();
 
-          if(eta_plus){
-            hiHFPlus_pf += pfcand.et();
-            hiHFEPlus_pf += pfcand.energy();
-            if(pfcand.energy() >= hiHFPlus_pfle) hiHFPlus_pfle = pfcand.energy();
-            if(pfcand.pdgId() == 1) hiHFPlus_pfha += pfcand.et();
-            if(pfcand.pdgId() == 2) hiHFPlus_pfem += pfcand.et();
-            nCountsHFPlus_pf++;
-          }
-          else if(eta_minus){
-            hiHFMinus_pf += pfcand.et();
-            hiHFEMinus_pf += pfcand.energy();
-            if(pfcand.energy() >= hiHFMinus_pfle) hiHFMinus_pfle = pfcand.energy();
-            if(pfcand.pdgId() == 1) hiHFMinus_pfha += pfcand.et();
-            if(pfcand.pdgId() == 2) hiHFMinus_pfem += pfcand.et();
-            nCountsHFMinus_pf++;
-          }
-        }
-      }
-    }
+      hiHF_pf += hfet;
+      hiHFE_pf += hfe;
+      if(hfid == 1) hiHF_pfha += hfet;
+      if(hfid == 2) hiHF_pfem += hfet;
+      nCountsHF_pf++;
+      inspfle(hfe, hiHF_pfle);
 
+      if (eta_plus) {
+        hiHFPlus_pf += hfet;
+        hiHFEPlus_pf += hfe;
+        if(hfid == 1) hiHFPlus_pfha += hfet;
+        if(hfid == 2) hiHFPlus_pfem += hfet;
+        nCountsHFPlus_pf++;
+        inspfle(hfe, hiHFPlus_pfle);
+      } // if (eta_plus) {
+      if (eta_minus) {
+        hiHFMinus_pf += hfet;
+        hiHFEMinus_pf += hfe;
+        if(hfid == 1) hiHFMinus_pfha += hfet;
+        if(hfid == 2) hiHFMinus_pfem += hfet;
+        nCountsHFMinus_pf++;
+        inspfle(hfe, hiHFMinus_pfle);
+      } // if(eta_minus) {
+    } // for (const auto& pfcand : *pfCandidates) {
   }
 
   nEvtPlanes = 0;
@@ -529,22 +544,24 @@ void HiEvtAnalyzer::beginJob() {
   
   thi_->Branch("hiHF_pf", &hiHF_pf, "hiHF_pf/F");
   thi_->Branch("hiHFE_pf", &hiHFE_pf, "hiHFE_pf/F");
-  thi_->Branch("hiHF_pfle", &hiHF_pfle, "hiHF_pfle/F");
+
   thi_->Branch("hiHF_pfha", &hiHF_pfha, "hiHF_pfha/F");
   thi_->Branch("hiHF_pfem", &hiHF_pfem, "hiHF_pfem/F");
-  
   thi_->Branch("hiHFPlus_pf", &hiHFPlus_pf, "hiHFPlus_pf/F");
   thi_->Branch("hiHFEPlus_pf", &hiHFEPlus_pf, "hiHFEPlus_pf/F");
-  thi_->Branch("hiHFPlus_pfle", &hiHFPlus_pfle, "hiHFPlus_pfle/F");
   thi_->Branch("hiHFPlus_pfha", &hiHFPlus_pfha, "hiHFPlus_pfha/F");
   thi_->Branch("hiHFPlus_pfem", &hiHFPlus_pfem, "hiHFPlus_pfem/F");
 
   thi_->Branch("hiHFMinus_pf", &hiHFMinus_pf, "hiHFMinus_pf/F");
   thi_->Branch("hiHFEMinus_pf", &hiHFEMinus_pf, "hiHFEMinus_pf/F");
-  thi_->Branch("hiHFMinus_pfle", &hiHFMinus_pfle, "hiHFMinus_pfle/F");
   thi_->Branch("hiHFMinus_pfha", &hiHFMinus_pfha, "hiHFMinus_pfha/F");
   thi_->Branch("hiHFMinus_pfem", &hiHFMinus_pfem, "hiHFMinus_pfem/F");
 
+  for (int i=0; i<NHFLEAD; i++) {
+    thi_->Branch(Form("hiHF_pfle%d", i+1), &(hiHF_pfle[i]), Form("hiHF_pfle%d/F", i+1));
+    thi_->Branch(Form("hiHFPlus_pfle%d", i+1), &(hiHFPlus_pfle[i]), Form("hiHFPlus_pfle%d/F", i+1));
+    thi_->Branch(Form("hiHFMinus_pfle%d", i+1), &(hiHFMinus_pfle[i]), Form("hiHFMinus_pfle%d/F", i+1));
+  }
   thi_->Branch("nCountsHF_pf", &nCountsHF_pf, "nCountsHF_pf/I");
   thi_->Branch("nCountsHFPlus_pf", &nCountsHFPlus_pf, "nCountsHFPlus_pf/I");
   thi_->Branch("nCountsHFMinus_pf", &nCountsHFMinus_pf, "nCountsHFMinus_pf/I");

--- a/HeavyIonsAnalysis/ZDCAnalysis/readme.md
+++ b/HeavyIonsAnalysis/ZDCAnalysis/readme.md
@@ -1,3 +1,41 @@
+# Map (Small system run, July 2025)
+ZDC and FSC channel map and by default if they are saved in the 3 trees in the forest.
+
+| idet | zside | section | channel | Detector | ZDCrechit | ZDCdigi | FSCdigi |
+| -----: | -----: | -----: | -----: | :----- | :-----: | :-----: | :-----: |
+|  0 | -1 |  1 |  1 | ZDCm EM 1 | :heavy_check_mark: | :heavy_check_mark: | |
+|  1 | -1 |  1 |  2 | ZDCm EM 2 | :heavy_check_mark: | :heavy_check_mark: | |
+|  2 | -1 |  1 |  3 | ZDCm EM 3 | :heavy_check_mark: | :heavy_check_mark: | |
+|  3 | -1 |  1 |  4 | ZDCm EM 4 | :heavy_check_mark: | :heavy_check_mark: | |
+|  4 | -1 |  1 |  5 | ZDCm EM 5 | :heavy_check_mark: | :heavy_check_mark: | |
+|  5 | -1 |  1 |  6 | Dummy | | | :heavy_check_mark: |
+|  6 | -1 |  1 |  7 | FSC2 Up | | | :heavy_check_mark: |
+|  7 | -1 |  1 |  8 | FSC2 Down | | | :heavy_check_mark: |
+|  8 | -1 |  1 |  9 | FSC3 BottLeft | | | :heavy_check_mark: |
+|  9 | -1 |  1 | 10 | FSC3 BottRight | | | :heavy_check_mark: |
+| 10 | -1 |  1 | 11 | FSC3 Topleft | | | :heavy_check_mark: |
+| 11 | -1 |  1 | 12 | FSC3 TopRight | | | :heavy_check_mark: |
+| 12 | -1 |  2 |  1 | ZDCm HAD 1 | :heavy_check_mark: | :heavy_check_mark: | |
+| 13 | -1 |  2 |  2 | ZDCm HAD 2 | :heavy_check_mark: | :heavy_check_mark: | |
+| 14 | -1 |  2 |  3 | ZDCm HAD 3 | :heavy_check_mark: | :heavy_check_mark: | |
+| 15 | -1 |  2 |  4 | ZDCm HAD 4 | :heavy_check_mark: | :heavy_check_mark: | |
+| 16 |  1 |  1 |  1 | ZDCp EM 1 | :heavy_check_mark: | :heavy_check_mark: | |
+| 17 |  1 |  1 |  2 | ZDCp EM 2 | :heavy_check_mark: | :heavy_check_mark: | |
+| 18 |  1 |  1 |  3 | ZDCp EM 3 | :heavy_check_mark: | :heavy_check_mark: | |
+| 19 |  1 |  1 |  4 | ZDCp EM 4 | :heavy_check_mark: | :heavy_check_mark: | |
+| 20 |  1 |  1 |  5 | ZDCp EM 5 | :heavy_check_mark: | :heavy_check_mark: | |
+| 21 |  1 |  1 |  6 | Dummy | | | :heavy_check_mark: |
+| 22 |  1 |  1 |  7 | Dummy | | | :heavy_check_mark: |
+| 23 |  1 |  1 |  8 | Dummy | | | :heavy_check_mark: |
+| 24 |  1 |  2 |  1 | ZDCp HAD 1 | :heavy_check_mark: | :heavy_check_mark: | |
+| 25 |  1 |  2 |  2 | ZDCp HAD 2 | :heavy_check_mark: | :heavy_check_mark: | |
+| 26 |  1 |  2 |  3 | ZDCp HAD 3 | :heavy_check_mark: | :heavy_check_mark: | |
+| 27 |  1 |  2 |  4 | ZDCp HAD 4 | :heavy_check_mark: | :heavy_check_mark: | |
+| 28-43 | -1 |  4 |  1-16 | ZDCm RPD 1-16 | | :heavy_check_mark: | |
+| 44-59 |  1 |  4 |  1-16 | ZDCp RPD 1-16 | | :heavy_check_mark: | |
+
+---
+
 # ZDC analyzer
 ## Minimum usage
 Energy sum is `(float) sumPlus` and `(float) sumMinus` in `zdcanalyzer/zdcrechit`.
@@ -5,97 +43,7 @@ Energy sum is `(float) sumPlus` and `(float) sumMinus` in `zdcanalyzer/zdcrechit
    (HiForestMiniAOD.root)
    ./
     └── (TDirectoryFile) => zdcanalyzer
-        ├── (TTree) => zdcrechit (1)
-        └── (TTree) => zdcdigi (1)
-```
-## Branches
-```
-   (HiForestMiniAOD.root)
-   ./
-    └── (TDirectoryFile) => zdcanalyzer
-        ├── (TTree) => zdcrechit (1)
-******************************************************************************
-*Tree    :zdcrechit : zdcrechit                                              *
-******************************************************************************
-*Br    0 :sumPlus   : sumPlus/F                                              *
-*............................................................................*
-*Br    1 :sumMinus  : sumMinus/F                                             *
-*............................................................................*
-*Br    2 :n         : n/I                                                    *
-*............................................................................*
-*Br    3 :zside     : zside[n]/I                                             *
-*............................................................................*
-*Br    4 :section   : section[n]/I                                           *
-*............................................................................*
-*Br    5 :channel   : channel[n]/I                                           *
-*............................................................................*
-*Br    6 :energy    : energy[n]/F                                            *
-*............................................................................*
-*Br    7 :time      : time[n]/F                                              *
-*............................................................................*
-*Br    8 :TDCtime   : TDCtime[n]/F                                           *
-*............................................................................*
-*Br    9 :chargeWeightedTime : chargeWeightedTime[n]/F                       *
-*............................................................................*
-*Br   10 :energySOIp1 : energySOIp1[n]/F                                     *
-*............................................................................*
-*Br   11 :ratioSOIp1 : ratioSOIp1[n]/F                                       *
-*............................................................................*
-*Br   12 :saturation : saturation[n]/I                                       *
-*............................................................................*
-*Br   13 :sumPlus_Aux : sumPlus_Aux/F                                        *
-*............................................................................*
-*Br   14 :sumMinus_Aux : sumMinus_Aux/F                                      *
-*............................................................................*
-
-        └── (TTree) => zdcdigi (1)
-******************************************************************************
-*Tree    :zdcdigi   : zdcdigi                                                *
-******************************************************************************
-*Br    0 :n         : n/I                                                    *
-*............................................................................*
-*Br    1 :zside     : zside[n]/I                                             *
-*............................................................................*
-*Br    2 :section   : section[n]/I                                           *
-*............................................................................*
-*Br    3 :channel   : channel[n]/I                                           *
-*............................................................................*
-*Br    4 :adcTs0    : adcTs0[n]/I                                            *
-*............................................................................*
-*Br    5 :chargefCTs0 : chargefCTs0[n]/F                                     *
-*............................................................................*
-*Br    6 :tdcTs0    : tdcTs0[n]/I                                            *
-*............................................................................*
-*Br    7 :adcTs1    : adcTs1[n]/I                                            *
-*............................................................................*
-*Br    8 :chargefCTs1 : chargefCTs1[n]/F                                     *
-*............................................................................*
-*Br    9 :tdcTs1    : tdcTs1[n]/I                                            *
-*............................................................................*
-*Br   10 :adcTs2    : adcTs2[n]/I                                            *
-*............................................................................*
-*Br   11 :chargefCTs2 : chargefCTs2[n]/F                                     *
-*............................................................................*
-*Br   12 :tdcTs2    : tdcTs2[n]/I                                            *
-*............................................................................*
-*Br   13 :adcTs3    : adcTs3[n]/I                                            *
-*............................................................................*
-*Br   14 :chargefCTs3 : chargefCTs3[n]/F                                     *
-*............................................................................*
-*Br   15 :tdcTs3    : tdcTs3[n]/I                                            *
-*............................................................................*
-*Br   16 :adcTs4    : adcTs4[n]/I                                            *
-*............................................................................*
-*Br   17 :chargefCTs4 : chargefCTs4[n]/F                                     *
-*............................................................................*
-*Br   18 :tdcTs4    : tdcTs4[n]/I                                            *
-*............................................................................*
-*Br   19 :adcTs5    : adcTs5[n]/I                                            *
-*............................................................................*
-*Br   20 :chargefCTs5 : chargefCTs5[n]/F                                     *
-*............................................................................*
-*Br   21 :tdcTs5    : tdcTs5[n]/I                                            *
-*............................................................................*
+        └── (TTree) => zdcrechit (1)
 ```
 
 ## Indices and dimensions
@@ -184,9 +132,9 @@ Energy sum is `(float) sumPlus` and `(float) sumMinus` in `zdcanalyzer/zdcrechit
 *        0 *       49 *        50 *         1 *         4 *        16 *
 ***********************************************************************
 ```
-- The safe length of the arrays is 56 = (9 ZDC + 16 RPD + 3 dump) &times; 2 sides, no matter if RPD is skipped, e.g.
+- The safest length of the arrays is 60 = (9 ZDC + 16 RPD) &times; 2 sides + 4 dump (3 at plus + 1 at minus) + 6 FSC, no matter if RPD is skipped, e.g.
 ```
-#define MAXMOD 56 
+#define MAXMOD 60 
 int zside[MAXMOD];
 ```
 


### PR DESCRIPTION
#### PR description:
 - Update ZDCAnalyzer `readme.md` to include the changes by adding FSC in 2025
 - Update `HiEvtAnalyzer.cc` to save 3 leading HF PF candidates (towers) on both sides rather than 1. Branches: 
   - `hiHF_pfle` &rarr; `hiHF_pfle1`, `hiHF_pfle2`, `hiHF_pfle3`
   - `hiHFPlus_pfle` &rarr; `hiHFPlus_pfle1`, `hiHFPlus_pfle2`, `hiHFPlus_pfle3`
   - `hiHFMinus_pfle` &rarr; `hiHFMinus_pfle1`, `hiHFMinus_pfle2`, `hiHFMinus_pfle3`
