### PR TITLE
add options to select tracks while foresting

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
@@ -99,6 +99,7 @@ process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
 process.ppTracks.dedxEstimators = cms.VInputTag(["dedxEstimator:dedxAllLikelihood", "dedxEstimator:dedxHarmonic2"])
+process.ppTracks.trackEtaMax = cms.untracked.double(3.0)
 # muons (FTW)
 process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
 process.unpackedMuons.muonSelectors = cms.vstring()

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_ppref_DATA.py
@@ -106,7 +106,8 @@ process.load('HeavyIonsAnalysis.EventAnalysis.particleFlowAnalyser_cfi')
 # Track Analyzer
 #########################
 process.load('HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff')
-
+process.ppTracks.trackEtaMax = cms.untracked.double(3.0)
+process.ppTracks.trackPtMin = cms.untracked.double(0.3)
 #####################################################################################
 
 #####################

--- a/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
+++ b/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
@@ -37,6 +37,8 @@ private:
   // ----------member data ---------------------------
   const bool doTrack_;
   const double trackPtMin_;
+  const double trackEtaMax_;
+  const bool applyTrackSelections_;
 
   const edm::EDGetTokenT<reco::VertexCollection> vertexSrc_;
   const edm::EDGetTokenT<reco::TrackCollection> trackSrc_;

--- a/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
@@ -3,6 +3,8 @@ import FWCore.ParameterSet.Config as cms
 trackAnalyzer = cms.EDAnalyzer('TrackAnalyzer',
     doTrack = cms.untracked.bool(True),
     trackPtMin = cms.untracked.double(0.01),
+    trackEtaMax = cms.untracked.double(4.0),
+    applyTrackSelections = cms.untracked.bool(False),
     vertexSrc = cms.InputTag("unpackedTracksAndVertices"),
     trackSrc = cms.InputTag("unpackedTracksAndVertices"),
     beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot'),

--- a/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
@@ -3,6 +3,8 @@
 TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) :
   doTrack_(iConfig.getUntrackedParameter<bool>("doTrack", true)),
   trackPtMin_(iConfig.getUntrackedParameter<double>("trackPtMin", 0.01)),
+  trackEtaMax_(iConfig.getUntrackedParameter<double>("trackEtaMax", 4.0)),
+  applyTrackSelections_(iConfig.getUntrackedParameter<bool>("applyTrackSelections", false)),
   vertexSrc_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexSrc"))),
   trackSrc_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("trackSrc"))),
   track2pcSrc_(consumes<std::vector<edm::Ptr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("trackSrc"))),
@@ -86,6 +88,16 @@ void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& 
 
     if (t.pt() < trackPtMin_)
       continue;
+
+    if (fabs(t.eta()) > trackEtaMax_)
+	    continue;
+
+    if (applyTrackSelections_){
+      if (t.quality(reco::TrackBase::qualityByName("highPurity")) == false) // only high-purity tracks
+	      continue;
+      if (t.ptError() / t.pt() > 0.1) // only tracks with pT resolution better than 10%
+	      continue;
+    }
 
     trkPt.push_back(t.pt());
     trkPtError.push_back(t.ptError());


### PR DESCRIPTION
as the track analyzer tree is the heaviest by far, selecting the tracks of interest while producing the forest reduces the output size significantly
