### PR TITLE
Fix for muon null track eta error

### DIFF
--- a/HeavyIonsAnalysis/MuonAnalysis/src/HLTMuTree.cc
+++ b/HeavyIonsAnalysis/MuonAnalysis/src/HLTMuTree.cc
@@ -337,7 +337,7 @@ void HLTMuTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       edm::RefToBase<reco::Muon> muCand(muons, i);
       if (muCand.isNull())
         continue;
-      if (fabs(muCand->combinedMuon()->eta()) > 2.4)
+      if (muCand->combinedMuon().isNull() || fabs(muCand->combinedMuon()->eta()) > 2.4)
 	continue;
       if (muCand->globalTrack().isNonnull() && muCand->innerTrack().isNonnull()) {
         if (muCand->isGlobalMuon() && muCand->isTrackerMuon()) {
@@ -346,7 +346,7 @@ void HLTMuTree::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
             edm::RefToBase<reco::Muon> muCand2(muons, j);
             if (muCand2.isNull())
               continue;
-	    if (fabs(muCand2->combinedMuon()->eta()) > 2.4)
+	    if (muCand2->combinedMuon().isNull() || fabs(muCand2->combinedMuon()->eta()) > 2.4)
 	      continue;
             if (muCand2->globalTrack().isNonnull() && muCand2->innerTrack().isNonnull()) {
               if (muCand2->isGlobalMuon() && muCand2->isTrackerMuon()) {


### PR DESCRIPTION
#### PR description:

Foresting with HltMuTree throws errors when a null track eta is encountered. This is resolved by changing the code in lines 340 and 349 to also catch null track eta in addition to out-of-range track eta.

#### PR validation:

Successfully forested multiple PDs with CMSSW_14_0_9 without error and confirmed that HltMuTree fills correctly.