### PR TITLE
Inclusion of dEdx info in trackTree

### DIFF
--- a/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
+++ b/HeavyIonsAnalysis/TrackAnalysis/interface/TrackAnalyzer.h
@@ -15,6 +15,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/TrackReco/interface/DeDxData.h"
 
 // Root include files
 #include "TTree.h"
@@ -41,6 +42,7 @@ private:
   const edm::EDGetTokenT<reco::TrackCollection> trackSrc_;
   const edm::EDGetTokenT<std::vector<edm::Ptr<pat::PackedCandidate> > > track2pcSrc_;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotProducer_;
+  std::map<std::string, edm::EDGetTokenT<edm::ValueMap<reco::DeDxData>>> dedxEstimatorsSrc_;
 
   edm::Service<TFileService> fs;
 
@@ -97,6 +99,7 @@ private:
   std::vector<float> trkDzErrFirstVtx;
   std::vector<float> trkDxyFirstVtx;
   std::vector<float> trkDxyErrFirstVtx;
+  std::map<std::string, std::vector<float>> trkDeDx;
 };
 
 inline void TrackAnalyzer::clearVectors() {
@@ -142,6 +145,8 @@ inline void TrackAnalyzer::clearVectors() {
   trkDzErrFirstVtx.clear();
   trkDxyFirstVtx.clear();
   trkDxyErrFirstVtx.clear();
+  for (auto& d : trkDeDx)
+    d.second.clear();
 }
 
 #endif

--- a/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
+++ b/HeavyIonsAnalysis/TrackAnalysis/python/TrackAnalyzer_cfi.py
@@ -5,5 +5,6 @@ trackAnalyzer = cms.EDAnalyzer('TrackAnalyzer',
     trackPtMin = cms.untracked.double(0.01),
     vertexSrc = cms.InputTag("unpackedTracksAndVertices"),
     trackSrc = cms.InputTag("unpackedTracksAndVertices"),
-    beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot')
+    beamSpotSrc = cms.untracked.InputTag('offlineBeamSpot'),
+    dedxEstimators = cms.VInputTag(),
 )

--- a/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
+++ b/HeavyIonsAnalysis/TrackAnalysis/src/TrackAnalyzer.cc
@@ -8,6 +8,10 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig) :
   track2pcSrc_(consumes<std::vector<edm::Ptr<pat::PackedCandidate> > >(iConfig.getParameter<edm::InputTag>("trackSrc"))),
   beamSpotProducer_(consumes<reco::BeamSpot>(
       iConfig.getUntrackedParameter<edm::InputTag>("beamSpotSrc", edm::InputTag("offlineBeamSpot")))) {
+  for (const auto& tag : iConfig.getParameter<std::vector<edm::InputTag>>("dedxEstimators")) {
+    const auto label = tag.instance()!="" ? tag.instance() : tag.label();
+    dedxEstimatorsSrc_.emplace(label, consumes<edm::ValueMap<reco::DeDxData> >(tag));
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -68,13 +72,17 @@ void TrackAnalyzer::fillVertices(const edm::Event& iEvent) {
 
 //--------------------------------------------------------------------------------------------------
 void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  const auto& tracks = iEvent.get(trackSrc_);
+  const auto& tracks = iEvent.getHandle(trackSrc_);
   const auto& track2pc = iEvent.getHandle(track2pcSrc_);
+  std::map<std::string, edm::ValueMap<reco::DeDxData> > dedxMaps;
+  for (const auto& d : dedxEstimatorsSrc_)
+    dedxMaps.emplace(d.first, iEvent.get(d.second));
 
   //loop over tracks
-  for (unsigned it = 0; it < tracks.size(); ++it) {
-    const auto& t = tracks[it];
-    const auto& c = track2pc.isValid() ? *track2pc->at(it) : pat::PackedCandidate();
+  for (unsigned it = 0; it < tracks->size(); ++it) {
+    const auto& t = tracks->at(it);
+    const auto& k = track2pc.isValid() ? track2pc->at(it) : edm::Ptr<pat::PackedCandidate>();
+    const auto& c = k.isNonnull() ? *k : pat::PackedCandidate();
 
     if (t.pt() < trackPtMin_)
       continue;
@@ -128,6 +136,14 @@ void TrackAnalyzer::fillTracks(const edm::Event& iEvent, const edm::EventSetup& 
       trkDzErrFirstVtx.push_back(-999999);
       trkDxyFirstVtx.push_back(-999999);
       trkDxyErrFirstVtx.push_back(-999999);
+    }
+    for (auto& d : trkDeDx) {
+      double dEdx(-99.9);
+      if (track2pc.isValid() && dedxMaps.at(d.first).contains(k.id()))
+        dEdx = dedxMaps.at(d.first)[k].dEdx();
+      else if (dedxMaps.at(d.first).contains(tracks.id()))
+        dEdx = dedxMaps.at(d.first)[reco::TrackRef(tracks, it)].dEdx();
+      d.second.push_back(dEdx);
     }
 
     nTrk++;
@@ -186,6 +202,8 @@ void TrackAnalyzer::beginJob() {
   trackTree_->Branch("trkDzErrFirstVtx", &trkDzErrFirstVtx);
   trackTree_->Branch("trkDxyFirstVtx", &trkDxyFirstVtx);
   trackTree_->Branch("trkDxyErrFirstVtx", &trkDxyErrFirstVtx);
+  for (const auto& d : dedxEstimatorsSrc_)
+    trackTree_->Branch(d.first.c_str(), &(trkDeDx[d.first]));
 }
 
 // ------------ method called once each job just after ending the event loop  ------------


### PR DESCRIPTION
#### PR description:

Update to TrackAnalysis scripts to add dEdx branches to the trackTree. This copies dEdx-specific changes made in forest_CMSSW_15_0_X to the forest_CMSSW_14_1_X branch.

#### PR validation:

Tested with cmsRun on 2023 PbPb data from the Feb 2025 ReReco with `dedxAllLikelihood`, `dedxPixelLikelihood`, and `dedxStripLikelihood`. It adds these branches to the end of `ppTracks/trackTree`. These branches show similar values to the same branches from a forest on light ion data produced with forest_CMSSW_15_0_X.