### PR TITLE
Update FSC analyzer

### DIFF
--- a/HeavyIonsAnalysis/ZDCAnalysis/python/FSCAnalyzerHC_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/FSCAnalyzerHC_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 fscanalyzer = cms.EDAnalyzer(
    "FSCAnalyzerHC",
    ZDCDigiSource    = cms.InputTag('hcalDigis', 'ZDC'),
+   do50nsRecoFSC = cms.bool(True), # reconstruction used for 50ns bunch spacing
    doHardcodedFSC = cms.bool(True) # FSC only loaded into EMAP
 )
 

--- a/HeavyIonsAnalysis/ZDCAnalysis/python/FSCAnalyzerHC_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/FSCAnalyzerHC_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 fscanalyzer = cms.EDAnalyzer(
    "FSCAnalyzerHC",
    ZDCDigiSource    = cms.InputTag('hcalDigis', 'ZDC'),
+   doFullFitFSC = cms.bool(False), # reconstruction used for >100ns bunch spacing (no out-of-time pileup)
    do50nsRecoFSC = cms.bool(True), # reconstruction used for 50ns bunch spacing
    doHardcodedFSC = cms.bool(True) # FSC only loaded into EMAP
 )

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -380,13 +380,13 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	if(fscDigi.adc[0][nhits]==255) saturation +=10; // TS0 saturated
 	
 	// new calibrated charge
-	charge = Q2 * (1.0f + f3v*f3v + f4v*f4v + f5v*f5v);
+	charge = Q2 * (1.0f + f3v + f4v + f5v);
 	
 	fscDigi.Fitted_QTS0[nhits] = Q0 + ped;
 	fscDigi.Fitted_QTS2[nhits] = Q2 + ped;
 	fscDigi.saturation[nhits] = saturation;
 	fscDigi.charge[nhits] = charge;	
-	fscDigi.charge_bare[nhits] = (fscDigi.chargefC[2][nhits] - ped) * (1.0f + f3v*f3v + f4v*f4v + f5v*f5v);
+	fscDigi.charge_bare[nhits] = (fscDigi.chargefC[2][nhits] - ped) * (1.0f + f3v + f4v + f5v);
 	
     nhits++;
 	

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -72,6 +72,7 @@ private:
   // ----------member data ---------------------------
   const edm::EDGetTokenT<QIE10DigiCollection> ZDCDigiToken_;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
+  bool doFullFitFSC_;
   bool do50nsRecoFSC_;
   bool doHardcodedFSC_;
   edm::Service<TFileService> fs;
@@ -122,13 +123,27 @@ namespace {
 FSCAnalyzerHC::FSCAnalyzerHC(const edm::ParameterSet& iConfig)
     : ZDCDigiToken_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("ZDCDigiSource"))),
       hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>()),
+      doFullFitFSC_(iConfig.getParameter<bool>("doFullFitFSC")),
       do50nsRecoFSC_(iConfig.getParameter<bool>("do50nsRecoFSC")),
       doHardcodedFSC_(iConfig.getParameter<bool>("doHardcodedFSC")) {
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
   setupDataToken_ = esConsumes<SetupData, SetupRecord>();
 #endif
-  //now do what ever initialization is needed
+    // ---- PROTECTION: user must choose exactly one method ----
+    int nSelected = (doFullFitFSC_ ? 1 : 0) + (do50nsRecoFSC_ ? 1 : 0);
+
+    if (nSelected != 1) {
+        throw cms::Exception("Configuration")
+            << "Invalid FSC charge reconstruction configuration:\n"
+            << "  doFullFitFSC = " << doFullFitFSC_ << "\n"
+            << "  do50nsRecoFSC = " << do50nsRecoFSC_ << "\n"
+            << "Exactly ONE of these must be set to True.\n"
+            << "Please fix the configuration and rerun.\n";
+    }
+
+    // now continue with other initialization…
 }
+
 
 FSCAnalyzerHC::~FSCAnalyzerHC() {
   // do anything here that needs to be done at desctruction time
@@ -227,6 +242,7 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
 	float Q0 = fscDigi.chargefC[0][nhits] - ped, Q1 = fscDigi.chargefC[1][nhits] - ped;
 	float Q2 = fscDigi.chargefC[2][nhits] - ped, Q3 = fscDigi.chargefC[3][nhits] - ped;
+	float Q4 = fscDigi.chargefC[4][nhits] - ped, Q5 = fscDigi.chargefC[5][nhits] - ped;
 	float charge = 0;
 	
 	// Reconstruct the charge in Q2
@@ -294,21 +310,68 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         Q0 = static_cast<float>(bestB);	
 	}
 	else{ Q0 = 0; }
-	
-	// saturated signals goes here
-	if(fscDigi.adc[2][nhits]==255) { // TS2 saturated
-		if(fscDigi.adc[3][nhits]==255) { // TS3 saturated
-			Q2 = Q3 / f3v + ped;
-			saturation = 2;
+		
+	if (doFullFitFSC_) {
+
+		// ===== Full fit: TS2–TS5 optimal combination =====
+
+		if (fscDigi.adc[2][nhits] == 255) {          // TS2 saturated
+			if (fscDigi.adc[3][nhits] == 255) {      // TS3 saturated
+				if (fscDigi.adc[4][nhits] == 255) {  // TS4 saturated
+					// TS2–TS4 saturated → only TS5 available
+					Q2 = Q5 / f5v;
+
+					if (fscDigi.adc[5][nhits] == 255) { // TS5 saturated
+						saturation = 5;                 // TS2–TS5 saturated
+					} else {
+						saturation = 4;                 // TS2–TS4 saturated
+					}
+				}
+				else {
+					// TS2–TS3 saturated, TS4 OK → use TS4 & TS5
+					Q2 = (f4v * Q4 + f5v * Q5) / (f4v*f4v + f5v*f5v);
+					saturation = 3;
+				}
+			}
+			else {
+				// TS2 saturated, TS3 OK → use TS3–TS5
+				Q2 = (f3v * Q3 + f4v * Q4 + f5v * Q5) /
+					 (f3v*f3v + f4v*f4v + f5v*f5v);
+				saturation = 1;
+			}
 		}
-		else{
-			Q2 = (Q3 - Q0 * f5v) / f3v + ped;
-			saturation = 1;
+		else {
+			// TS2 not saturated → full optimal combination
+			Q2 = (Q2 + f3v * Q3 + f4v * Q4 + f5v * Q5) /
+				 (1.0f + f3v*f3v + f4v*f4v + f5v*f5v);
+			saturation = 0;
+		}
+
+	} else {
+
+		// subtract signal leackage from out-of-time pileup signal
+		Q2 -= Q0 * f4v;
+		Q3 -= Q0 * f5v;
+		
+		// ===== Reduced fit: ONLY TS2 and TS3  =====
+
+		if (fscDigi.adc[2][nhits] == 255) {   // TS2 saturated
+			Q2 = Q3 / f3v;
+
+			if (fscDigi.adc[3][nhits] == 255) { // TS3 saturated
+				saturation = 2;
+			}
+			else {
+				saturation = 1;
+			}
+		}
+		else {
+			Q2 = (Q2 + f3v * Q3) / (1.0f + f3v*f3v);
+			saturation = 0;
 		}
 	}
-	else{
-		Q2 = (Q2 + f3v * Q3) / (1.0f + f3v*f3v);
-	}
+
+
 	if(fscDigi.adc[0][nhits]==255) saturation +=10; // TS0 saturated
 	
 	// new calibrated charge

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -324,12 +324,12 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	// add sums:
 	if(zside < 0){
 		fscDigi.sumMinus += charge;
-		if(section < 9) fscDigi.sumMinus_FSC2only += charge;
+		if(channel < 9) fscDigi.sumMinus_FSC2only += charge;
 		else fscDigi.sumMinus_FSC3only += charge;
 	}
 	else{
 		fscDigi.sumPlus += charge;
-		if(section < 9) fscDigi.sumPlus_FSC2only += charge;
+		if(channel < 9) fscDigi.sumPlus_FSC2only += charge;
 		else fscDigi.sumPlus_FSC3only += charge;
 	}
 	

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -88,28 +88,29 @@ private:
 // constants, enums and typedefs
 //
 // This information is temrorarly stored here, once the sequence is validated it will be ported to the database
-// These numbers extracted on November 13, 2025. Any time timing calibration is applied, the F3, F4, F5 need to be updated
+// These numbers extracted on November 16, 2025 (run=399551). Any time timing calibration is applied, the F3, F4, F5 need to be updated
 namespace {
   // 2 sides (−, +) × NFSC channels
   constexpr float Pedestal[2][NFSC] = {
-    {1256.1f, 1287.21f, 1129.36f, 1216.32f, 1285.49f, 1169.89f}, // side minus
-    {1256.1f, 1287.21f, 1129.36f, 1216.32f, 1285.49f, 1169.89f}  // side plus
+    {1248.54f, 1287.14f, 1129.79f, 1216.63f, 1285.63f, 1170.79f}, // side minus
+    {1202.87f, 1199.81f, 1187.31f, 1218.55f, 1147.67f, 1231.52f}, // side plus
   };
 
   constexpr float f3[2][NFSC] = {
-    {0.530911f, 0.41923f, 0.568465f, 0.564356f, 0.663121f, 0.437691f},
-    {0.404952f, 0.367785f, 0.289732f, 0.28137f,  0.295755f, 0.288639f}
+    {0.485614f, 0.37147f, 0.431836f, 0.357515f, 0.432989f, 0.314054f}, // side minus
+    {0.40573f, 0.368565f, 0.239196f, 0.281138f, 0.295968f, 0.290039f}, // side plus
   };
 
   constexpr float f4[2][NFSC] = {
-    {0.203833f, 0.173217f, 0.172461f, 0.178248f, 0.204802f, 0.143328f},
-    {0.146871f, 0.136037f, 0.102299f, 0.102644f, 0.102658f, 0.105907f}
+    {0.191546f, 0.159452f, 0.142411f, 0.131297f, 0.154015f, 0.11559f}, // side minus
+    {0.145969f, 0.134359f, 0.0892946f, 0.101017f, 0.101158f, 0.1043f}, // side plus
   };
 
   constexpr float f5[2][NFSC] = {
-    {0.125581f, 0.106735f, 0.0923971f, 0.0920702f, 0.116749f, 0.0762132f},
-    {0.0850411f, 0.0786189f, 0.0595604f, 0.0607462f, 0.058937f, 0.0614747f}
+    {0.119143f, 0.0990354f, 0.080384f, 0.0701533f, 0.0912764f, 0.0629495f}, // side minus
+    {0.083688f, 0.0764629f, 0.0522635f, 0.0588876f, 0.0572844f, 0.0595602f}, // side plus
   };
+
 }  // namespace
 //
 // static data member definitions

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -112,6 +112,11 @@ namespace {
     {0.083688f, 0.0764629f, 0.0522635f, 0.0588876f, 0.0572844f, 0.0595602f}, // side plus
   };
 
+  // pO pulse shape constants, uncomment in case if running on oxygen data (extracted from run=393953)
+  //constexpr float Pedestal[2][NFSC] = {{1240.81f, 1244.26f, 1129.9f, 1217.23f, 1279.97f, 1169.07f},{}};
+  //constexpr float f3[2][NFSC] = {{0.432071f, 0.37209f, 0.66697f, 0.679988f, 0.80187f, 0.483295f},{}};
+  //constexpr float f4[2][NFSC] = {{0.175788f, 0.159102f, 0.1914f, 0.199924f, 0.233085f, 0.150607f}, {}};
+  //constexpr float f5[2][NFSC] = {{0.110565f, 0.0990709f, 0.0991153f, 0.102377f, 0.129583f, 0.079309f},{}};
 }  // namespace
 //
 // static data member definitions

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCAnalyzerHC.cc
@@ -43,7 +43,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
-#include "ZDCstruct.h"
+#include "FSCstruct.h"
 #include "ZDCHardCodeHelper.h"
 
 //
@@ -72,11 +72,12 @@ private:
   // ----------member data ---------------------------
   const edm::EDGetTokenT<QIE10DigiCollection> ZDCDigiToken_;
   edm::ESGetToken<HcalDbService, HcalDbRecord> hcalDatabaseToken_;
+  bool do50nsRecoFSC_;
   bool doHardcodedFSC_;
   edm::Service<TFileService> fs;
   TTree* t1;
 
-  MyZDCDigi zdcDigi;
+  MyFSCDigi fscDigi;
 
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
   edm::ESGetToken<SetupData, SetupRecord> setupToken_;
@@ -86,7 +87,30 @@ private:
 //
 // constants, enums and typedefs
 //
+// This information is temrorarly stored here, once the sequence is validated it will be ported to the database
+// These numbers extracted on November 13, 2025. Any time timing calibration is applied, the F3, F4, F5 need to be updated
+namespace {
+  // 2 sides (−, +) × NFSC channels
+  constexpr float Pedestal[2][NFSC] = {
+    {1256.1f, 1287.21f, 1129.36f, 1216.32f, 1285.49f, 1169.89f}, // side minus
+    {1256.1f, 1287.21f, 1129.36f, 1216.32f, 1285.49f, 1169.89f}  // side plus
+  };
 
+  constexpr float f3[2][NFSC] = {
+    {0.530911f, 0.41923f, 0.568465f, 0.564356f, 0.663121f, 0.437691f},
+    {0.404952f, 0.367785f, 0.289732f, 0.28137f,  0.295755f, 0.288639f}
+  };
+
+  constexpr float f4[2][NFSC] = {
+    {0.203833f, 0.173217f, 0.172461f, 0.178248f, 0.204802f, 0.143328f},
+    {0.146871f, 0.136037f, 0.102299f, 0.102644f, 0.102658f, 0.105907f}
+  };
+
+  constexpr float f5[2][NFSC] = {
+    {0.125581f, 0.106735f, 0.0923971f, 0.0920702f, 0.116749f, 0.0762132f},
+    {0.0850411f, 0.0786189f, 0.0595604f, 0.0607462f, 0.058937f, 0.0614747f}
+  };
+}  // namespace
 //
 // static data member definitions
 //
@@ -97,6 +121,7 @@ private:
 FSCAnalyzerHC::FSCAnalyzerHC(const edm::ParameterSet& iConfig)
     : ZDCDigiToken_(consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("ZDCDigiSource"))),
       hcalDatabaseToken_(esConsumes<HcalDbService, HcalDbRecord>()),
+      do50nsRecoFSC_(iConfig.getParameter<bool>("do50nsRecoFSC")),
       doHardcodedFSC_(iConfig.getParameter<bool>("doHardcodedFSC")) {
 #ifdef THIS_IS_AN_EVENTSETUP_EXAMPLE
   setupDataToken_ = esConsumes<SetupData, SetupRecord>();
@@ -126,16 +151,28 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
   edm::ESHandle<HcalDbService> conditions = iSetup.getHandle(hcalDatabaseToken_);
 
-  zdcDigi.n = 0;
+  fscDigi.sumPlus = 0;
+  fscDigi.sumMinus = 0;
+  fscDigi.sumPlus_FSC2only = 0;
+  fscDigi.sumPlus_FSC3only = 0;
+  fscDigi.sumMinus_FSC2only = 0;
+  fscDigi.sumMinus_FSC3only = 0;
+  
+  fscDigi.n = 0;
   for (unsigned int i = 0; i < NMOD; i++) {
-    zdcDigi.zside[i] = -99;
-    zdcDigi.section[i] = -99;
-    zdcDigi.channel[i] = -99;
+    fscDigi.zside[i] = -99;
+    fscDigi.section[i] = -99;
+    fscDigi.channel[i] = -99;
     for (int ts = 0; ts < NTS; ts++) {
-      zdcDigi.chargefC[ts][i] = -99;
-      zdcDigi.adc[ts][i] = -99;
-      zdcDigi.tdc[ts][i] = -99;
+      fscDigi.chargefC[ts][i] = -99;
+      fscDigi.adc[ts][i] = -99;
+      fscDigi.tdc[ts][i] = -99;
     }
+    fscDigi.charge[i] = -99;
+    fscDigi.charge_bare[i] = -99;
+    fscDigi.Fitted_QTS0[i] = -99;
+    fscDigi.Fitted_QTS2[i] = -99;
+    fscDigi.saturation[i] = -99;
   }
 
   int nhits = 0;
@@ -149,7 +186,7 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
     if (nhits >= NMOD)
       break;
-    if (!(section == 1 && channel > 5))
+    if (!(section == 1 && channel > 6))
       continue;  // Only consider FSC channel located in dummy ECAL
 
     CaloSamples caldigi;
@@ -164,24 +201,141 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       coder.adc2fC(digi, caldigi);
     }
 
-    zdcDigi.zside[nhits] = zside;
-    zdcDigi.section[nhits] = section;
-    zdcDigi.channel[nhits] = channel;
+    fscDigi.zside[nhits] = zside;
+    fscDigi.section[nhits] = section;
+    fscDigi.channel[nhits] = channel;
 
     for (int ts = 0; ts < digi.samples(); ts++) {
-      zdcDigi.adc[ts][nhits] = digi[ts].adc();
-      zdcDigi.tdc[ts][nhits] = digi[ts].le_tdc();
+      fscDigi.adc[ts][nhits] = digi[ts].adc();
+      fscDigi.tdc[ts][nhits] = digi[ts].le_tdc();
       if (doHardcodedFSC_) {
-        zdcDigi.chargefC[ts][nhits] = HardCodeZDC.charge(digi[ts].adc(), digi[ts].capid());
+        fscDigi.chargefC[ts][nhits] = HardCodeZDC.charge(digi[ts].adc(), digi[ts].capid());
       } else {
-        zdcDigi.chargefC[ts][nhits] = caldigi[ts];
+        fscDigi.chargefC[ts][nhits] = caldigi[ts];
       }
     }
+	
+	// CHARGE RECONSTRUCTION
+	int side = (zside<0) ? 0 : 1;
+	int ch = channel - 7;
+	float ped = Pedestal[side][ch];
+	float f3v=f3[side][ch];
+	float f4v=f4[side][ch];
+	float f5v=f5[side][ch];
+	int saturation = 0;
 
+	float Q0 = fscDigi.chargefC[0][nhits] - ped, Q1 = fscDigi.chargefC[1][nhits] - ped;
+	float Q2 = fscDigi.chargefC[2][nhits] - ped, Q3 = fscDigi.chargefC[3][nhits] - ped;
+	float charge = 0;
+	
+	// Reconstruct the charge in Q2
+	if (do50nsRecoFSC_){ // apply correction from the first time slice
+
+        auto chi2 = [&](double A, double B) {
+            double r0 = B + A * f4v - Q0;
+            double r1 = B * f3v + A * Q1;
+            return r0 * r0 + r1 * r1;
+        };
+
+        double bestB    = 0.0;
+        double bestChi2 = std::numeric_limits<double>::infinity();
+
+        // --- 0) Unconstrained interior solution ---
+        double denom = f3v * f4v - f5v;
+        if (std::fabs(denom) > 1e-12) {
+            double A_star = (Q0 * f3v - Q1) / denom;
+            double B_star = (Q1 * f4v - Q0 * f5v) / denom;
+            if (A_star >= 0.0 && B_star >= 0.0) {
+                double c = chi2(A_star, B_star);
+                bestChi2 = c;
+                bestB    = B_star;
+            }
+        }		
+
+        // --- 1) Boundary case A = 0 ---
+        {
+            double denomA = 1.0 + f3v * f3v;
+            if (denomA > 1e-12) {
+                double B_A = (Q0 + f3v * Q1) / denomA;
+                if (B_A >= 0.0) {
+                    double c = chi2(0.0, B_A);
+                    if (c < bestChi2) {
+                        bestChi2 = c;
+                        bestB    = B_A;
+                    }
+                }
+            }
+        }
+        // --- 2) Boundary case B = 0 ---
+        {
+            double denomB = f4v * f4v + f5v * f5v;
+            if (denomB > 1e-12) {
+                double A_B = (Q0 * f4v + Q1 * f5v) / denomB;
+                if (A_B >= 0.0) {
+                    double c = chi2(A_B, 0.0);
+                    if (c < bestChi2) {
+                        bestChi2 = c;
+                        bestB    = 0.0;
+                    }
+                }
+            }
+        }
+        // --- 3) Corner A = 0, B = 0 ---
+        {
+            double c = chi2(0.0, 0.0);
+            if (c < bestChi2) {
+                bestChi2 = c;
+                bestB    = 0.0;
+            }
+        }	
+
+        // Best-fit previous-bunch charge
+        Q0 = static_cast<float>(bestB);	
+	}
+	else{ Q0 = 0; }
+	
+	// saturated signals goes here
+	if(fscDigi.adc[2][nhits]==255) { // TS2 saturated
+		if(fscDigi.adc[3][nhits]==255) { // TS3 saturated
+			Q2 = Q3 / f3v + ped;
+			saturation = 2;
+		}
+		else{
+			Q2 = (Q3 - Q0 * f5v) / f3v + ped;
+			saturation = 1;
+		}
+	}
+	else{
+		Q2 = (Q2 + f3v * Q3) / (1.0f + f3v*f3v);
+	}
+	if(fscDigi.adc[0][nhits]==255) saturation +=10; // TS0 saturated
+	
+	// new calibrated charge
+	charge = Q2 * (1.0f + f3v*f3v + f4v*f4v + f5v*f5v);
+	
+	fscDigi.Fitted_QTS0[nhits] = Q0 + ped;
+	fscDigi.Fitted_QTS2[nhits] = Q2 + ped;
+	fscDigi.saturation[nhits] = saturation;
+	fscDigi.charge[nhits] = charge;	
+	fscDigi.charge_bare[nhits] = (fscDigi.chargefC[2][nhits] - ped) * (1.0f + f3v*f3v + f4v*f4v + f5v*f5v);
+	
     nhits++;
+	
+	// add sums:
+	if(zside < 0){
+		fscDigi.sumMinus += charge;
+		if(section < 9) fscDigi.sumMinus_FSC2only += charge;
+		else fscDigi.sumMinus_FSC3only += charge;
+	}
+	else{
+		fscDigi.sumPlus += charge;
+		if(section < 9) fscDigi.sumPlus_FSC2only += charge;
+		else fscDigi.sumPlus_FSC3only += charge;
+	}
+	
   }  // end loop zdc digis
 
-  zdcDigi.n = nhits;
+  fscDigi.n = nhits;
 
   t1->Fill();
 
@@ -197,10 +351,10 @@ void FSCAnalyzerHC::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 void FSCAnalyzerHC::beginJob() {
   t1 = fs->make<TTree>("fscdigi", "fscdigi");
 
-  t1->Branch("n", &zdcDigi.n, "n/I");
-  t1->Branch("zside", zdcDigi.zside, "zside[n]/I");
-  t1->Branch("section", zdcDigi.section, "section[n]/I");
-  t1->Branch("channel", zdcDigi.channel, "channel[n]/I");
+  t1->Branch("n", &fscDigi.n, "n/I");
+  t1->Branch("zside", fscDigi.zside, "zside[n]/I");
+  t1->Branch("section", fscDigi.section, "section[n]/I");
+  t1->Branch("channel", fscDigi.channel, "channel[n]/I");
 
   for (int i = 0; i < NTS; i++) {
     TString adcTsSt("adcTs"), chargefCTsSt("chargefCTs"), tdcTsSt("tdcTs");
@@ -208,10 +362,22 @@ void FSCAnalyzerHC::beginJob() {
     chargefCTsSt += i;
     tdcTsSt += i;
 
-    t1->Branch(adcTsSt, zdcDigi.adc[i], adcTsSt + "[n]/I");
-    t1->Branch(chargefCTsSt, zdcDigi.chargefC[i], chargefCTsSt + "[n]/F");
-    t1->Branch(tdcTsSt, zdcDigi.tdc[i], tdcTsSt + "[n]/I");
+    t1->Branch(adcTsSt, fscDigi.adc[i], adcTsSt + "[n]/I");
+    t1->Branch(chargefCTsSt, fscDigi.chargefC[i], chargefCTsSt + "[n]/F");
+    t1->Branch(tdcTsSt, fscDigi.tdc[i], tdcTsSt + "[n]/I");
   }
+
+  t1->Branch("Fitted_QTS0", fscDigi.Fitted_QTS0, "Fitted_QTS0[n]/F");
+  t1->Branch("Fitted_QTS2", fscDigi.Fitted_QTS2, "Fitted_QTS2[n]/F");
+  t1->Branch("saturation", fscDigi.saturation, "saturation[n]/I");
+  t1->Branch("charge", fscDigi.charge, "charge[n]/F");
+  t1->Branch("charge_bare", fscDigi.charge_bare, "charge_bare[n]/F");
+  t1->Branch("sumMinus", &fscDigi.sumMinus);
+  t1->Branch("sumMinus_FSC2only", &fscDigi.sumMinus_FSC2only);
+  t1->Branch("sumMinus_FSC3only", &fscDigi.sumMinus_FSC3only);
+  t1->Branch("sumPlus", &fscDigi.sumPlus);
+  t1->Branch("sumPlus_FSC2only", &fscDigi.sumPlus_FSC2only);
+  t1->Branch("sumPlus_FSC3only", &fscDigi.sumPlus_FSC3only);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/FSCstruct.h
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/FSCstruct.h
@@ -1,0 +1,30 @@
+#define MAXMOD 56 // 50 real channels + 6 dump channels
+#define NMOD 50 // 50 real channels: (9 ZDC + 16 RPD + 6 FSC) x 2 sides
+#define MAXTS 10 // 10 time slices before 2024
+#define NTS 6 // 6 time slices since 2024
+#define NFSC 6 // 6 FSC detectors on each side 
+
+
+struct MyFSCDigi {
+  int n;
+  float chargefC[MAXTS][MAXMOD];
+  int adc[MAXTS][MAXMOD];
+  int tdc[MAXTS][MAXMOD];
+  int zside[MAXMOD];
+  int section[MAXMOD];
+  int channel[MAXMOD];
+
+  float charge[MAXMOD];
+  float charge_bare[MAXMOD];
+  float Fitted_QTS0[MAXMOD];
+  float Fitted_QTS2[MAXMOD];
+  int saturation[MAXMOD]; // 0 is normal, 1 ADCTS2 saturated, 2 ADCTS3 saturated, +10 ADCTS0 saturated
+
+  float sumPlus;
+  float sumMinus;
+  float sumPlus_FSC2only;
+  float sumPlus_FSC3only;
+  float sumMinus_FSC2only;
+  float sumMinus_FSC3only;
+};
+


### PR DESCRIPTION
#### PR description:

PR Description

This update introduces several improvements to the FSC digitization and reconstruction workflow:

1. Dedicated FSC Data Structure
A new header (`FSCstruct.h`) defines a dedicated struct where additional FSC-related variables can be stored.

2. Charge Calibration Using Calibration Constants
The total measured charge is now computed using calibration parameters (currently hard-coded for validation; once verified, they will be moved to the conditions database).

3. Support for 50 ns Bunch-Spacing Reconstruction
The reconstruction now handles 50 ns bunch spacing, properly accounting for signals from neighbouring bunches.

4. Extended `fscdigi` Output
The fscdigi tree now includes:
- The calibrated charge per counter
- The total charge measured in each detector
- The global charge sum across all FSC detectors in one arm

**Bunch-Spacing Configuration**
The default settings of the module are optimized for PbPb data, which use 50 ns bunch spacing.
For datasets with >100 ns spacing (e.g., O-O, p-O, Ne-Ne, or any other HI run with long bunch spacing), you should switch to the full time-interval charge reconstruction.

To do this, update your configuration as follows:
```python
process.load('HeavyIonsAnalysis.ZDCAnalysis.FSCAnalyzerHC_cfi')
# Use full time interval for charge reconstruction (for bs>100 ns)
process.fscanalyzer.doFullFitFSC  = cms.bool(True)
process.fscanalyzer.do50nsRecoFSC = cms.bool(False)
```


#### PR validation:
Tested with `CMSSW_15_1_0_patch3` and recent HI data (run=399540)

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:
