### PR TITLE
Add ZDC energy filters

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_UPC_DATA.py
@@ -3,14 +3,14 @@
 # Type: data
 
 import FWCore.ParameterSet.Config as cms
-from Configuration.Eras.Era_Run3_2025_OXY_cff import Run3_2025_OXY
-process = cms.Process('HiForest', Run3_2025_OXY)
+from Configuration.Eras.Era_Run3_2025_UPC_cff import Run3_2025_UPC
+process = cms.Process('HiForest', Run3_2025_UPC)
 
 ###############################################################################
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 150X, data")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 151X, data")
 
 # import subprocess, os
 # version = subprocess.check_output(
@@ -25,7 +25,7 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 150X, data")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://xrootd-cms.infn.it//store/hidata/HIRun2024A/HIForward0/MINIAOD/PromptReco-v1/000/387/878/00000/b7894635-d50c-454f-a11b-f072514f8dfc.root'
+        '/store/hidata/HIRun2025A/HIForward9/MINIAOD/PromptReco-v1/000/400/401/00000/17810c72-10b7-434a-a587-b23cf3df10eb.root'
     ), 
 )
 
@@ -46,7 +46,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 
 from Configuration.AlCa.GlobalTag import GlobalTag
 
-process.GlobalTag = GlobalTag(process.GlobalTag, '150X_dataRun3_Prompt_v3', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, '151X_dataRun3_Prompt_v1', '')
 process.HiForestInfo.GlobalTagLabel = process.GlobalTag.globaltag
 
 ###############################################################################
@@ -98,7 +98,7 @@ process.load('HeavyIonsAnalysis.JetAnalysis.ak4PFJetSequence_ppref_data_cff')
 ################################
 # tracks
 process.load("HeavyIonsAnalysis.TrackAnalysis.TrackAnalyzers_cff")
-process.ppTracks.dedxEstimators = cms.VInputTag(["dedxEstimator:dedxAllLikelihood", "dedxEstimator:dedxHarmonic2"])
+process.ppTracks.dedxEstimators = cms.VInputTag(["dedxEstimator:dedxAllLikelihood"])
 process.ppTracks.trackEtaMax = cms.untracked.double(3.0)
 # muons (FTW)
 process.load("HeavyIonsAnalysis.MuonAnalysis.unpackedMuons_cfi")
@@ -182,22 +182,24 @@ process.load('HeavyIonsAnalysis.EventAnalysis.collisionEventSelection_cff')
 process.pclusterCompatibilityFilter = cms.Path(process.clusterCompatibilityFilter)
 process.pprimaryVertexFilter = cms.Path(process.primaryVertexFilter)
 process.load('HeavyIonsAnalysis.EventAnalysis.hffilterPF_cfi')
+process.load('HeavyIonsAnalysis.ZDCAnalysis.HiZDCfilter_cfi')
 process.pAna = cms.EndPath(process.skimanalysis)
 
-#from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
-#process.hltfilter = hltHighLevel.clone(
+# from HLTrigger.HLTfilters.hltHighLevel_cfi import hltHighLevel
+# process.hltfilter = hltHighLevel.clone(
 #    HLTPaths = [
-#        #"HLT_HIZeroBias_v4",                                                     
 #        "HLT_HIMinimumBias_v2",
 #    ]
-#)
-#process.filterSequence = cms.Sequence(
-#    process.hltfilter
-#)
-#
-#process.superFilterPath = cms.Path(process.filterSequence)
-#process.skimanalysis.superFilters = cms.vstring("superFilterPath")
-#
-#for path in process.paths:
+# )
+# process.filterSequence = cms.Sequence(
+#     process.hltfilter *
+#     process.primaryVertexFilter *
+#     (process.zdcrecoRun3 + process.zdcEnergyFilter0nOr)
+# )
+
+# process.superFilterPath = cms.Path(process.filterSequence)
+# process.skimanalysis.superFilters = cms.vstring("superFilterPath")
+
+# for path in process.paths:
 #    getattr(process, path)._seq = process.filterSequence * getattr(process,path)._seq
 

--- a/HeavyIonsAnalysis/ZDCAnalysis/python/HiZDCfilter_cfi.py
+++ b/HeavyIonsAnalysis/ZDCAnalysis/python/HiZDCfilter_cfi.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# module
+zdcEnergyFilter1nOr = cms.EDFilter(
+    'HiZDCFilter',
+    ZDCRecHitSource = cms.InputTag('zdcrecoRun3'),
+    threshold4ltPlus = cms.double(1500), # threshold for less than for ZDC+
+    threshold4gtPlus = cms.double(900), # threshold for greater than for ZDC+
+    threshold4ltMinus = cms.double(1500), # threshold for less than for ZDC-
+    threshold4gtMinus = cms.double(900), # threshold for greater than for ZDC-
+    algorithm = cms.string('gt OR') # [lt/gt][AND/OR], XOR (not case-sensitive)
+)
+zdcEnergyFilter0nOr = zdcEnergyFilter1nOr.clone( algorithm = 'lt OR' )
+zdcEnergyFilterXOr = zdcEnergyFilter1nOr.clone( algorithm = 'XOR' )
+
+# path
+pzdcEnergyFilter1nOr = cms.Path(zdcEnergyFilter1nOr)
+pzdcEnergyFilter0nOr = cms.Path(zdcEnergyFilter0nOr)
+pzdcEnergyFilterXOr = cms.Path(zdcEnergyFilterXOr)

--- a/HeavyIonsAnalysis/ZDCAnalysis/src/HiZDCFilter.cc
+++ b/HeavyIonsAnalysis/ZDCAnalysis/src/HiZDCFilter.cc
@@ -1,0 +1,90 @@
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h" // Required by making plug-in
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+// #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+// #include "HeavyIonsAnalysis/ZDCAnalysis/interface/Zdcesum.h"
+
+class HiZDCFilter : public edm::one::EDFilter<> {
+public:
+  explicit HiZDCFilter(const edm::ParameterSet&);
+  ~HiZDCFilter() override;
+
+private:
+  bool filter(edm::Event&, const edm::EventSetup&) override;
+
+  const edm::EDGetTokenT<edm::SortedCollection<ZDCRecHit>> ZDCRecHitToken_;
+  const double ltPlus_, gtPlus_;
+  const double ltMinus_, gtMinus_;
+  std::string algo_;
+  // StringCutObjectSelector<Zdcesum, false> energyCut_;
+
+  // Zdcesum zdc;
+  float sumPlus, sumMinus;
+  bool has_algo(std::string key) { return (algo_.find(key) != std::string::npos); }
+};
+
+HiZDCFilter::HiZDCFilter(const edm::ParameterSet& iConfig) :
+  ZDCRecHitToken_(consumes<edm::SortedCollection<ZDCRecHit>>(iConfig.getParameter<edm::InputTag>("ZDCRecHitSource"))),
+  ltPlus_(iConfig.getParameter<double>("threshold4ltPlus")),
+  gtPlus_(iConfig.getParameter<double>("threshold4gtPlus")),
+  ltMinus_(iConfig.getParameter<double>("threshold4ltMinus")),
+  gtMinus_(iConfig.getParameter<double>("threshold4gtMinus")),
+  // energyCut_(iConfig.getParameter<std::string>("algorithm")) {
+  algo_(iConfig.getParameter<std::string>("algorithm")) {
+  std::transform(algo_.begin(), algo_.end(), algo_.begin(),
+                 [](unsigned char c){ return std::tolower(c); });
+}
+
+HiZDCFilter::~HiZDCFilter() {}
+
+bool HiZDCFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  bool accepted = false;
+  sumPlus = 0;
+  sumMinus = 0;
+
+  const auto& zdcrechits = iEvent.get(ZDCRecHitToken_);
+
+  for (auto const& rh : zdcrechits) { // does not have RPD if it was skipped in reco
+    HcalZDCDetId zdcid = rh.id();
+    int zside = zdcid.zside();
+    int section = zdcid.section();
+    float energy = rh.energy();
+    if (zside < 0 && (section == 1 || section == 2))
+      sumMinus += energy;
+    if (zside > 0 && (section == 1 || section == 2))
+      sumPlus += energy;
+  }
+
+  // accepted = energyCut_(zdc);
+  
+  if (has_algo("lt") && has_algo("or")) {
+    accepted = (sumPlus <= ltPlus_ || sumMinus <= ltMinus_);
+  } else if (has_algo("lt") && has_algo("and")) {
+    accepted = (sumPlus <= ltPlus_ && sumMinus <= ltMinus_);
+  } else if (has_algo("gt") && has_algo("or")) {
+    accepted = (sumPlus >= gtPlus_ || sumMinus >= gtMinus_);
+  } else if (has_algo("gt") && has_algo("and")) {
+    accepted = (sumPlus >= gtPlus_ && sumMinus >= gtMinus_);
+  } else if (has_algo("xor")) {
+    accepted = (sumPlus >= gtPlus_ && sumMinus <= ltMinus_)
+      || (sumPlus <= ltPlus_ && sumMinus >= gtMinus_);
+  } else {
+    std::cout<<"error: bad algorithm "<<algo_<<std::endl;
+  }
+
+  return accepted;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HiZDCFilter);


### PR DESCRIPTION
#### PR description:
This PR introduces:
- A new module, HiZDCFilter, which filters events based on the ZDC energy sum.
    - It requires configurable thresholds for “greater than” and “less than” cuts, applied separately to ZDCplus and ZDCminus.
    - For now, the module supports AND (greater or less), OR (greater or less), and XOR logic.
- A python cfi `HiZDCfilter_cfi.py` providomg three predefined paths corresponding to 1nOR, 0nOR and XOR
    - The threshold values (900 for “greater than” and 1500 for “less than”) are intentionally conservative compared to offline analysis selections, but are flexible at the module level.
- Updated `forest_miniAOD_run3_UPC_DATA.py` to add these ZDC energy filters in skim tree and provide a template to filter them while foresting. 
- Other standard changes (Era, GT, etc) are also implemented in `forest_miniAOD_run3_UPC_DATA.py` to apply for 2025 PbPb data. Especially `dedxEstimator:dedxHarmonic2` is removed in 2025 data. 

#### Backport
This will be backported to all run3 data branches: 15_0_X, 14_1_X, 13_2_X 