### PR TITLE
Optimized parameter set for flow-subtracted jets

### DIFF
--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_DATA.py
@@ -161,6 +161,17 @@ doHIJetID = True             # Fill jet ID and composition information branches
 doWTARecluster = True        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
+# Configuration for jet flow subtraction
+iterativeFlow = True         # Iterative jetty region exclusion. Default = True
+pfCandidateEtaCut = 2        # Eta range for PF candidates used in flow fit. Default = 2
+minPfCandidatesPerEvent = 60 # Minimum number of PF candidates to make the flow fit. Default = 60
+minPfCandidatePt = 0.3       # Minimum pT for PF candidates in flow fit. Default = 0.3
+maxPfCandidatePt = 3         # Maximum pT for PF candidates in flow fit. Default = 3
+minFitQuality = 0            # Minimum flow fit quality score. Default = 0
+maxFitQuality = 1            # Maximum flow fit quality score. Default = 1
+firstFittedVn = 2            # First fitted vn component. Default = 2
+lastFittedVn = 3             # Last fitted vn component. Default = 3
+
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
 # Add all the values you want to process to the list
 # These will create collections of CS subtracted jets (only eta dependent background)
@@ -196,6 +207,25 @@ for jetLabel in allJetLabels:
         getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
     process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
+# Configuration for the flow fit
+for jetLabel in [flowR + "Flow" for flowR in jetLabelsFlowCS]:
+
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateEtaCut = pfCandidateEtaCut
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").minPfCandidatesPerEvent = minPfCandidatesPerEvent
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").firstFittedVn = firstFittedVn
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").lastFittedVn = lastFittedVn
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateMinPtCut = minPfCandidatePt
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateMaxPtCut = maxPfCandidatePt
+    getattr(process, "akCs"+jetLabel+"PFJets").minFlowChi2Prob = minFitQuality
+    getattr(process, "akCs"+jetLabel+"PFJets").maxFlowChi2Prob = maxFitQuality
+
+    if iterativeFlow:
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateEtaCut = pfCandidateEtaCut
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").minPfCandidatesPerEvent = minPfCandidatesPerEvent
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").firstFittedVn = firstFittedVn
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").lastFittedVn = lastFittedVn
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateMinPtCut = minPfCandidatePt
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateMaxPtCut = maxPfCandidatePt
 
 #########################
 # Event Selection -> add the needed filters here

--- a/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
+++ b/HeavyIonsAnalysis/Configuration/test/forest_miniAOD_run3_MC.py
@@ -10,7 +10,7 @@ process = cms.Process('HiForest', Run3_pp_on_PbPb_2024)
 
 # HiForest info
 process.load("HeavyIonsAnalysis.EventAnalysis.HiForestInfo_cfi")
-process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 140X, mc")
+process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 141X, mc")
 
 ###############################################################################
 
@@ -18,7 +18,7 @@ process.HiForestInfo.info = cms.vstring("HiForest, miniAOD, 140X, mc")
 process.source = cms.Source("PoolSource",
     duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
     fileNames = cms.untracked.vstring(
-        'root://eoscms.cern.ch//store/group/phys_heavyions/jviinika/PythiaHydjetRun3_5p36TeV_dijet_ptHat15_100kEvents_miniAOD_2023_08_30/PythiaHydjetDijetRun3/PythiaHydjetRun3_dijet_ptHat15_5p36TeV_miniAOD/230830_165931/0000/pythiaHydjet_miniAOD_11.root'
+        'root://cmsxrootd.fnal.gov//store/mc/HINPbPbWinter24MiniAOD/Dijet_pThat-15to1200_TuneCP5_5p36TeV_pythia8/MINIAODSIM/141X_mcRun3_2024_realistic_HI_v14-v2/2520003/fb3d1c69-59df-4e79-bf33-91cb43316e94.root'
     ),
 )
 
@@ -76,6 +76,8 @@ process.TFileService = cms.Service("TFileService",
 # Gen Analyzer
 #############################
 process.load('HeavyIonsAnalysis.EventAnalysis.HiGenAnalyzer_cfi')
+#process.HiGenParticleAna.ptMin = cms.untracked.double(0.7) # default is 5
+#process.HiGenParticleAna.etaMax = cms.untracked.double(2.6) # default is 2.5
 
 # event analysis
 process.load('HeavyIonsAnalysis.EventAnalysis.hltanalysis_cfi')
@@ -144,6 +146,17 @@ doHIJetID = True             # Fill jet ID and composition information branches
 doWTARecluster = False        # Add jet phi and eta for WTA axis
 doBtagging  =  False         # Note that setting to True increases computing time a lot
 
+# Configuration for jet flow subtraction
+iterativeFlow = True         # Iterative jetty region exclusion. Default = True
+pfCandidateEtaCut = 2        # Eta range for PF candidates used in flow fit. Default = 2
+minPfCandidatesPerEvent = 60 # Minimum number of PF candidates to make the flow fit. Default = 60
+minPfCandidatePt = 0.3       # Minimum pT for PF candidates in flow fit. Default = 0.3
+maxPfCandidatePt = 3         # Maximum pT for PF candidates in flow fit. Default = 3
+minFitQuality = 0            # Minimum flow fit quality score. Default = 0
+maxFitQuality = 1            # Maximum flow fit quality score. Default = 1
+firstFittedVn = 2            # First fitted vn component. Default = 2
+lastFittedVn = 3             # Last fitted vn component. Default = 3
+
 # 0 means use original mini-AOD jets, otherwise use R value, e.g., 3,4,8
 # Generator level jets in original miniAOD jets contain neutrinos
 # You will need to do reclustering with R-value to get generator level jets without neutrinos
@@ -183,6 +196,25 @@ for jetLabel in allJetLabels:
         getattr(process,"akCs"+jetLabel+"PFJetAnalyzer").pfUnifiedParticleTransformerAK4JetTags = cms.untracked.string("pfUnifiedParticleTransformerAK4JetTagsAK"+jetLabel+"PFBtag")
     process.forest += getattr(process,"akCs"+jetLabel+"PFJetAnalyzer")
 
+# Configuration for the flow fit
+for jetLabel in [flowR + "Flow" for flowR in jetLabelsFlowCS]:
+
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateEtaCut = pfCandidateEtaCut
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").minPfCandidatesPerEvent = minPfCandidatesPerEvent
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").firstFittedVn = firstFittedVn
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").lastFittedVn = lastFittedVn
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateMinPtCut = minPfCandidatePt
+    getattr(process, "rhoModulationAkCs"+jetLabel+"PFJets").pfCandidateMaxPtCut = maxPfCandidatePt
+    getattr(process, "akCs"+jetLabel+"PFJets").minFlowChi2Prob = minFitQuality
+    getattr(process, "akCs"+jetLabel+"PFJets").maxFlowChi2Prob = maxFitQuality
+
+    if iterativeFlow:
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateEtaCut = pfCandidateEtaCut
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").minPfCandidatesPerEvent = minPfCandidatesPerEvent
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").firstFittedVn = firstFittedVn
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").lastFittedVn = lastFittedVn
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateMinPtCut = minPfCandidatePt
+        getattr(process, "rhoModulationIterAkCs"+jetLabel+"PFJets").pfCandidateMaxPtCut = maxPfCandidatePt
 
 #########################
 # Event Selection -> add the needed filters here

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
@@ -72,7 +72,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
 
         setattr(process,"ak"+labelR+"GenJetsReclusterNoNu",
                 ak4GenJets.clone(
-                    src = 'packedGenParticlesForJetsNoNu'
+                    src = 'packedGenParticlesForJetsNoNu',
+                    rParam = jetR
                 )
         )
  

--- a/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/setupJets_PbPb_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = False, labelR = "0"):
+def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels = ['L2Relative', 'L3Absolute'], doBtagging = False, labelR = "0", iterativeFlow = True):
 
     # First, check if the label contains the string "Flow" to mark the use of flow subtraction
     doFlow = "Flow" in labelR
@@ -196,6 +196,8 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
     processAdditives = ["PackedPFTowers", "hiPuRho"]
 
     # If we do flow subtraction, we need to setup the producers for flow modulation
+    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import akCs4PFJets
+    iterativeTag = ""
     if doFlow:
         from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import ak4PFJetsForFlow, hiFJRhoFlowModulation
         setattr(process, "ak4PFJetsFor"+labelR,
@@ -214,14 +216,40 @@ def candidateBtaggingMiniAOD(process, isMC = True, jetPtMin = 15, jetCorrLevels 
         processAdditives.append("ak4PFJetsFor"+labelR)
         processAdditives.append("rhoModulationAkCs"+labelR+"PFJets")
 
-    from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cff import akCs4PFJets
+        # For iterative flow, we need to use the previously determined flow components to create a jet collection that will be used in jetty region subtraction
+        if iterativeFlow:
+            setattr(process, "akCs4PFJetsFor"+labelR,
+                    akCs4PFJets.clone(
+                        src = 'packedPFCandidates',
+                        rParam = jetR,
+                        jetPtMin = 40,
+                        useModulatedRho = cms.bool(True),
+                        rhoFlowFitParams = cms.InputTag("rhoModulationAkCs"+labelR+"PFJets", "rhoFlowFitParams")
+                    )
+            )
+
+            setattr(process, "rhoModulationIterAkCs"+labelR+"PFJets",
+                    hiFJRhoFlowModulation.clone(
+                        jetTag = "akCs4PFJetsFor"+labelR,
+                        doJettyExclusion = cms.bool(True)
+                    )
+            )
+            
+            # Both of these processes are needed for flow subtracted jets
+            processAdditives.append("akCs4PFJetsFor"+labelR)
+            processAdditives.append("rhoModulationIterAkCs"+labelR+"PFJets")
+
+            # Add iterative tag to the jet collection
+            iterativeTag = "Iter"
+
+
     setattr(process,"akCs"+labelR+"PFJets",
             akCs4PFJets.clone(
                 src = 'packedPFCandidates',
                 jetPtMin = jetPtMin,
                 rParam = jetR,
                 useModulatedRho = doFlow,
-                rhoFlowFitParams = cms.InputTag("rhoModulationAkCs"+labelR+"PFJets","rhoFlowFitParams")
+                rhoFlowFitParams = cms.InputTag("rhoModulation"+iterativeTag+"AkCs"+labelR+"PFJets","rhoFlowFitParams")
             )
     )
 

--- a/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
+++ b/RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py
@@ -89,6 +89,8 @@ akCs4PFJets = cms.EDProducer(
     csAlpha   = cms.double(2.),
     writeJetsWithConst = cms.bool(True),
     useModulatedRho = cms.bool(False),
+    minFlowChi2Prob = cms.double(0),
+    maxFlowChi2Prob = cms.double(1),
     rhoFlowFitParams = cms.InputTag('hiFJRhoFlowModulation', 'rhoFlowFitParams'),
     jetCollInstanceName = cms.string("pfParticlesCs"),
 )


### PR DESCRIPTION
#### PR description:

This PR changes the default parametrization for flow subtracted jets in HiForest. Based on the studies presented in Jet MiniPOG meetings on 2025-12-02 for run2 and 2026-01-21 for run3, the flow subtraction method in the HiForest can be improved from the current forest default. This PR implements the updated parametrization.

#### PR validation:

Tested locally by me.

#### Notes:

Similar update needs to be done for other HiForest versions that are used for new analyses to optimize jet performance.

@mandrenguyen The PR is not fully contained in the HeavyIonsAnalysis area, but an update in the python configuration is also needed in the file RecoHI/HiJetAlgos/python/HiRecoPFJets_cff.py. Usually we want to keep the Reco folders in sync with the main CMSSW versions. Should we prepare a patch for CMSSW to update the Python configuration centrally?
