### PR TITLE
Add configurable minHFEnergy cut to HF PF candidates

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -81,6 +81,11 @@ private:
 
   int evtPlaneLevel_;
 
+  float minHFEnergy_;
+  float minAbsEtaHF_;
+  float maxAbsEtaHF_;
+
+
   edm::Service<TFileService> fs_;
 
   TTree* thi_;
@@ -183,7 +188,10 @@ HiEvtAnalyzer::HiEvtAnalyzer(const edm::ParameterSet& iConfig)
       doHFfilters_(iConfig.getParameter<bool>("doHFfilters")),
       useHepMC_(iConfig.getParameter<bool>("useHepMC")),
       doVertex_(iConfig.getParameter<bool>("doVertex")),
-      evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")) {}
+      evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")),
+	minHFEnergy_(iConfig.getUntrackedParameter<double>("minHFEnergy", 4.0)),
+	minAbsEtaHF_(iConfig.getUntrackedParameter<double>("minAbsEtaHF", 3.0)),
+	maxAbsEtaHF_(iConfig.getUntrackedParameter<double>("maxAbsEtaHF", 5.2)) {}
 
 HiEvtAnalyzer::~HiEvtAnalyzer() {
   // do anything here that needs to be done at desctruction time
@@ -338,11 +346,17 @@ void HiEvtAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
     for (const auto& pfcand : *pfCandidates) {
       if (pfcand.pdgId() != 1 && pfcand.pdgId() != 2) continue;
-      if (pfcand.et() < 0.0) continue;
-      const bool eta_plus = (pfcand.eta() > 3.0) && (pfcand.eta() < 6.0);
-      const bool eta_minus = (pfcand.eta() < -3.0) && (pfcand.eta() > -6.0);
-      if (!eta_plus && !eta_minus) continue;
-      const auto hfe = pfcand.energy();
+
+      const float eta = pfcand.eta();
+      const float absEta = std::abs(eta);
+      if (absEta < minAbsEtaHF_ || absEta > maxAbsEtaHF_) continue;
+
+      const float hfe  = pfcand.energy();
+      if (hfe < minHFEnergy_) continue;
+
+      const bool eta_plus = (eta > 0.f);
+      const bool eta_minus = !eta_plus;
+
       const auto hfet = pfcand.et();
       const auto hfid = pfcand.pdgId();
 
@@ -586,6 +600,11 @@ void HiEvtAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& description
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
+
+  desc.addUntracked<double>("minHFEnergy", 4.0);
+  desc.addUntracked<double>("minAbsEtaHF", 3.0);
+  desc.addUntracked<double>("maxAbsEtaHF", 5.2);
+
   descriptions.addDefault(desc);
 }
 

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -189,9 +189,9 @@ HiEvtAnalyzer::HiEvtAnalyzer(const edm::ParameterSet& iConfig)
       useHepMC_(iConfig.getParameter<bool>("useHepMC")),
       doVertex_(iConfig.getParameter<bool>("doVertex")),
       evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")),
-	minHFEnergy_(iConfig.getUntrackedParameter<double>("minHFEnergy", 4.0)),
-	minAbsEtaHF_(iConfig.getUntrackedParameter<double>("minAbsEtaHF", 3.0)),
-	maxAbsEtaHF_(iConfig.getUntrackedParameter<double>("maxAbsEtaHF", 5.2)) {}
+      minHFEnergy_(iConfig.getParameter<double>("minHFEnergy")),
+      minAbsEtaHF_(iConfig.getParameter<double>("minAbsEtaHF")),
+      maxAbsEtaHF_(iConfig.getParameter<double>("maxAbsEtaHF")) {}
 
 HiEvtAnalyzer::~HiEvtAnalyzer() {
   // do anything here that needs to be done at desctruction time

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -600,11 +600,6 @@ void HiEvtAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& description
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
-
-  desc.addUntracked<double>("minHFEnergy", 4.0);
-  desc.addUntracked<double>("minAbsEtaHF", 3.0);
-  desc.addUntracked<double>("maxAbsEtaHF", 5.2);
-
   descriptions.addDefault(desc);
 }
 

--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -81,9 +81,9 @@ private:
 
   int evtPlaneLevel_;
 
-  float minHFEnergy_;
-  float minAbsEtaHF_;
-  float maxAbsEtaHF_;
+  float minHFEnergy_pf_;
+  float minAbsEtaHF_pf_;
+  float maxAbsEtaHF_pf_;
 
 
   edm::Service<TFileService> fs_;
@@ -189,9 +189,9 @@ HiEvtAnalyzer::HiEvtAnalyzer(const edm::ParameterSet& iConfig)
       useHepMC_(iConfig.getParameter<bool>("useHepMC")),
       doVertex_(iConfig.getParameter<bool>("doVertex")),
       evtPlaneLevel_(iConfig.getParameter<int>("evtPlaneLevel")),
-      minHFEnergy_(iConfig.getParameter<double>("minHFEnergy")),
-      minAbsEtaHF_(iConfig.getParameter<double>("minAbsEtaHF")),
-      maxAbsEtaHF_(iConfig.getParameter<double>("maxAbsEtaHF")) {}
+      minHFEnergy_pf_(iConfig.getParameter<double>("minHFEnergy_pf")),
+      minAbsEtaHF_pf_(iConfig.getParameter<double>("minAbsEtaHF_pf")),
+      maxAbsEtaHF_pf_(iConfig.getParameter<double>("maxAbsEtaHF_pf")) {}
 
 HiEvtAnalyzer::~HiEvtAnalyzer() {
   // do anything here that needs to be done at desctruction time
@@ -349,10 +349,10 @@ void HiEvtAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
       const float eta = pfcand.eta();
       const float absEta = std::abs(eta);
-      if (absEta < minAbsEtaHF_ || absEta > maxAbsEtaHF_) continue;
+      if (absEta < minAbsEtaHF_pf_ || absEta > maxAbsEtaHF_pf_) continue;
 
       const float hfe  = pfcand.energy();
-      if (hfe < minHFEnergy_) continue;
+      if (hfe < minHFEnergy_pf_) continue;
 
       const bool eta_plus = (eta > 0.f);
       const bool eta_minus = !eta_plus;

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
@@ -19,7 +19,7 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0),
 
-   minHFEnergy     = cms.untracked.double(4.0),
-   minAbsEtaHF     = cms.untracked.double(3.0),
-   maxAbsEtaHF     = cms.untracked.double(5.2),
+   minHFEnergy     = cms.double(0.0),
+   minAbsEtaHF     = cms.double(3.0),
+   maxAbsEtaHF     = cms.double(6.0),
 )

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
@@ -17,5 +17,9 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHiMC           = cms.bool(False),
    useHepMC         = cms.bool(False),
    doHFfilters      = cms.bool(True),
-   evtPlaneLevel    = cms.int32(0)
+   evtPlaneLevel    = cms.int32(0),
+
+   minHFEnergy     = cms.untracked.double(4.0),
+   minAbsEtaHF     = cms.untracked.double(3.0),
+   maxAbsEtaHF     = cms.untracked.double(5.2),
 )

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_data_cfi.py
@@ -19,7 +19,7 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0),
 
-   minHFEnergy     = cms.double(0.0),
-   minAbsEtaHF     = cms.double(3.0),
-   maxAbsEtaHF     = cms.double(6.0),
+   minHFEnergy_pf   = cms.double(0.0),
+   minAbsEtaHF_pf   = cms.double(3.0),
+   maxAbsEtaHF_pf   = cms.double(6.0),
 )

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
@@ -19,9 +19,9 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0),
 
-   minHFEnergy     = cms.untracked.double(4.0),
-   minAbsEtaHF     = cms.untracked.double(3.0),
-   maxAbsEtaHF     = cms.untracked.double(5.2),
+   minHFEnergy     = cms.double(0.0),
+   minAbsEtaHF     = cms.double(3.0),
+   maxAbsEtaHF     = cms.double(6.0),
 )
 
 #from HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi import *

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
@@ -17,7 +17,11 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHiMC           = cms.bool(True),
    useHepMC         = cms.bool(False),
    doHFfilters      = cms.bool(True),
-   evtPlaneLevel    = cms.int32(0)
+   evtPlaneLevel    = cms.int32(0),
+
+   minHFEnergy     = cms.untracked.double(4.0),
+   minAbsEtaHF     = cms.untracked.double(3.0),
+   maxAbsEtaHF     = cms.untracked.double(5.2),
 )
 
 #from HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi import *

--- a/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
+++ b/HeavyIonsAnalysis/EventAnalysis/python/hievtanalyzer_mc_cfi.py
@@ -19,9 +19,9 @@ hiEvtAnalyzer = cms.EDAnalyzer('HiEvtAnalyzer',
    doHFfilters      = cms.bool(True),
    evtPlaneLevel    = cms.int32(0),
 
-   minHFEnergy     = cms.double(0.0),
-   minAbsEtaHF     = cms.double(3.0),
-   maxAbsEtaHF     = cms.double(6.0),
+   minHFEnergy_pf   = cms.double(0.0),
+   minAbsEtaHF_pf   = cms.double(3.0),
+   maxAbsEtaHF_pf   = cms.double(6.0),
 )
 
 #from HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_data_cfi import *


### PR DESCRIPTION
#### PR description:

This PR introduces a configurable minimum energy threshold for HF PF candidates in `HiEvtAnalyzer`.

Added new parameters which can be set as follows:
```python
process.load('HeavyIonsAnalysis.EventAnalysis.hievtanalyzer_[mc,data]_cfi')
process.hiEvtAnalyzer.minHFEnergy_pf = cms.double(4.0)
process.hiEvtAnalyzer.minAbsEtaHF_pf = cms.double(3.0)
process.hiEvtAnalyzer.maxAbsEtaHF_pf = cms.double(5.2)
```

This allows to modify the HF PF selection to be consistent with standard forward activity thresholds (e.g. ≥4 GeV used in soft QCD / diffractive analyses), and avoids integrating very low-energy noise contributions.

#### PR validation:
 compiled with `CMSSW_15_0_11`

#### If this PR is a backport please specify the original PR and why you need to backport that PR. If this PR will be backported please specify to which release cycle the backport is meant for:

Not a backport.

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)

<!-- Please delete the text above after you verified all points of the checklist  -->
