### PR TITLE
add proc_id in case of LHE files from a gridpack

### DIFF
--- a/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
+++ b/HeavyIonsAnalysis/EventAnalysis/plugins/HiEvtAnalyzer.cc
@@ -263,15 +263,22 @@ void HiEvtAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         }
       }
 
-      //alternative weights for systematics
+	  // LHE: use it for weights and (critically) IDPRUP when present
       edm::Handle<LHEEventProduct> evet;
       iEvent.getByToken(generatorlheToken_, evet);
-      if (evet.isValid() && genInfo.isValid()) {
-        const auto& asdd = evet->originalXWGTUP();
-        const auto& norm = (asdd!=0. ? genInfo->weight()/asdd : 1.);
-        for (const auto& asdde : evet->weights())
-          ttbar_w.emplace_back(norm * asdde.wgt);
-      }
+	  
+	  if (evet.isValid()){
+		// Prefer LHE process id when available
+		proc_id = evet->hepeup().IDPRUP;
+		
+		//alternative weights for systematics
+		if (genInfo.isValid()) {
+			const auto& asdd = evet->originalXWGTUP();
+			const auto& norm = (asdd!=0. ? genInfo->weight()/asdd : 1.);
+			for (const auto& asdde : evet->weights())
+			  ttbar_w.emplace_back(norm * asdde.wgt);
+		}
+	  }		
     }
 
     // MC PILEUP INFORMATION


### PR DESCRIPTION
#### PR description:

EPOS LHC-R samples encode the event “process type” in the LHE header (`IDPRUP`). In these samples, `GenEventInfoProduct::signalProcessID()` is typically `0`, so the process ID is lost unless we read it from `LHEEventProduct`.

This PR updates `HiEvtAnalyzer` to set `ProcessID` with the following precedence:

```cpp
if (useHepMC_) {
  proc_id = hepmcevt->GetEvent()->signal_process_id();
} else {
  if (iEvent.getByToken(genInfoToken_, genInfo))
    proc_id = genInfo->signalProcessID();

  // If an LHE record is present (e.g. EPOS), override with IDPRUP
  if (iEvent.getByToken(generatorlheToken_, evet) && evet.isValid())
    proc_id = evet->hepeup().IDPRUP;
}
```

Previously we only did:
```cpp
if (useHepMC_) proc_id = hepmcevt->GetEvent()->signal_process_id();
else if (iEvent.getByToken(genInfoToken_, genInfo)) proc_id = genInfo->signalProcessID();
```

So the net effect is: keep existing behaviour for `HepMC` and standard `GenEventInfo`, but use `LHEEventProduct::hepeup().IDPRUP` when available, which is required for EPOS.

#### PR validation:

Tested with `CMSSW_15_0_11` with both Pythia and EPOS simulation files:
```
cmsRun forest_miniAOD_run3_MC.py \
  inputFiles=file:/eos/cms/store/group/phys_heavyions/mpitt/Run3_2025_OXY/pO_UPC_miniAOD/MinBias_Angantyr_Py8315_ffTune_pythia_Op_150X_mcRun3_2025_forpO_realistic_v9/miniAOD_0000.root \
  outputFile=HiForest_Pythia.root

cmsRun forest_miniAOD_run3_MC.py \
inputFiles=file:/eos/cms/store/group/phys_heavyions/mpitt/Run3_2025_OXY/pO_UPC_miniAOD/MinBias_crmcv2_2_1_eposlhcr_Op_150X_mcRun3_2025_forpO_realistic_v9/miniAOD_0000.root \
  outputFile=HiForest_EPOS.root

```

Observed:

* Pythia: proc_id remains consistent with `signalProcessID()` behavior.
* EPOS: proc_id is correctly populated from `LHEEventProduct (IDPRUP)`.

NOTE: I used `/eos/cms/store/group/phys_heavyions/mpitt/Run3_2025_OXY/scripts/forest_miniAOD_run3_MC.py` and removed `process.hiEvtAnalyzer.minHFEnergy = cms.double(4.0); process.hiEvtAnalyzer.maxAbsEtaHF = cms.double(5.2)` to run the config